### PR TITLE
Add Rust regex FFI crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ src/cscope.out
 /.cache/clangd/
 /.ccls-cache/
 /compile_commands.json
+
+src/rust/regex/target/

--- a/src/Makefile
+++ b/src/Makefile
@@ -2087,13 +2087,18 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o
+RUST_REGEX_LIB = rust/regex/target/release/libvim_regex.a
+
+$(RUST_REGEX_LIB):
+	cd rust/regex && cargo build --release
+
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_REGEX_LIB)
 	@$(BUILD_DATE_MSG)
 	@LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
-		-o $(VIMTARGET) $(OBJ) $(ALL_LIBS)" \
-		MAKE="$(MAKE)" LINK_AS_NEEDED=$(LINK_AS_NEEDED) \
-		PROG="vim" \
-		sh $(srcdir)/link.sh
+-o $(VIMTARGET) $(OBJ) $(ALL_LIBS) $(RUST_REGEX_LIB)" \
+	MAKE="$(MAKE)" LINK_AS_NEEDED=$(LINK_AS_NEEDED) \
+	PROG="vim" \
+	sh $(srcdir)/link.sh
 
 xxd/xxd$(EXEEXT): xxd/xxd.c
 	cd xxd; CC="$(CC)" CFLAGS="$(CPPFLAGS) $(CFLAGS)" LDFLAGS="$(LDFLAGS)" \

--- a/src/rust/regex/Cargo.toml
+++ b/src/rust/regex/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vim_regex"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "vim_regex"
+crate-type = ["staticlib"]
+
+[dependencies]
+regex = "1"
+libc = "0.2"

--- a/src/rust/regex/src/lib.rs
+++ b/src/rust/regex/src/lib.rs
@@ -1,0 +1,76 @@
+use regex::Regex;
+use libc::{c_char, c_int};
+use std::ffi::CStr;
+use std::ptr;
+
+const NSUBEXP: usize = 10;
+
+#[repr(C)]
+pub struct regprog_T {
+    regex: *mut Regex,
+}
+
+#[repr(C)]
+pub struct regmatch_T {
+    pub regprog: *mut regprog_T,
+    pub startp: [*const c_char; NSUBEXP],
+    pub endp: [*const c_char; NSUBEXP],
+    pub rm_matchcol: u32,
+    pub rm_ic: c_int,
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regcomp_rs(pattern: *const c_char, _flags: c_int) -> *mut regprog_T {
+    if pattern.is_null() {
+        return ptr::null_mut();
+    }
+    let cstr = unsafe { CStr::from_ptr(pattern) };
+    let pat = match cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+    let regex = match Regex::new(pat) {
+        Ok(r) => Box::new(r),
+        Err(_) => return ptr::null_mut(),
+    };
+    let prog = Box::new(regprog_T { regex: Box::into_raw(regex) });
+    Box::into_raw(prog)
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regfree_rs(prog: *mut regprog_T) {
+    if prog.is_null() {
+        return;
+    }
+    unsafe {
+        let prog = Box::from_raw(prog);
+        if !prog.regex.is_null() {
+            let _ = Box::from_raw(prog.regex);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regexec_rs(rmp: *mut regmatch_T, line: *const c_char, col: u32) -> c_int {
+    if rmp.is_null() || line.is_null() {
+        return 0;
+    }
+    unsafe {
+        let prog = (*rmp).regprog;
+        if prog.is_null() || (*prog).regex.is_null() {
+            return 0;
+        }
+        let regex = &*((*prog).regex);
+        let cstr = CStr::from_ptr(line);
+        if let Ok(s) = cstr.to_str() {
+            if let Some(m) = regex.find(&s[col as usize..]) {
+                let start = m.start() + col as usize;
+                let end = m.end() + col as usize;
+                (*rmp).startp[0] = s.as_ptr().add(start) as *const c_char;
+                (*rmp).endp[0] = s.as_ptr().add(end) as *const c_char;
+                return 1;
+            }
+        }
+    }
+    0
+}


### PR DESCRIPTION
## Summary
- create `src/rust/regex` Rust crate using the `regex` crate
- expose basic `vim_regcomp`, `vim_regfree`, and `vim_regexec` FFI replacements
- hook the new library into the build so it is linked with Vim

## Testing
- `make test_regex_char_classes` *(fails: No rule to make target '../vim')*

------
https://chatgpt.com/codex/tasks/task_e_68b5a8c7d89483209ef8ac0551abbaeb