### PR TITLE
Add Rust memory module with FFI and build hooks

### DIFF
--- a/Filelist
+++ b/Filelist
@@ -110,10 +110,12 @@ SRC_ALL =	\
 		src/match.c \
 		src/mbyte.c \
 		src/memfile.c \
-		src/memfile_test.c \
-		src/memline.c \
-		src/menu.c \
-		src/message.c \
+                src/memfile_test.c \
+                src/memline.c \
+                src/rust/mem/Cargo.toml \
+                src/rust/mem/src/lib.rs \
+                src/menu.c \
+                src/message.c \
 		src/message_test.c \
 		src/misc1.c \
 		src/misc2.c \

--- a/src/Makefile
+++ b/src/Makefile
@@ -1395,6 +1395,10 @@ LINT_EXTRA = -D"__attribute__(x)="
 
 DEPEND_CFLAGS = -DPROTO -DDEPEND -DFEAT_GUI $(LINT_CFLAGS)
 
+# Location of the Rust memory management crate
+RUST_MEM_DIR = rust/mem
+RUST_MEM_LIB = $(RUST_MEM_DIR)/target/release/libvim_mem.a
+
 # Note: MZSCHEME_LIBS must come before LIBS, because LIBS adds -lm which is
 # needed by racket.
 ALL_LIB_DIRS = $(GUI_LIBS_DIR) $(X_LIBS_DIR)
@@ -1406,13 +1410,14 @@ ALL_LIBS = \
 	   $(X_LIBS) \
 	   $(WAYLAND_LIBS) \
 	   $(X_EXTRA_LIBS) \
-	   $(MZSCHEME_LIBS) \
-	   $(LIBS) \
-	   $(EXTRA_LIBS) \
-	   $(LUA_LIBS) \
-	   $(PERL_LIBS) \
-	   $(PYTHON_LIBS) \
-	   $(PYTHON3_LIBS) \
+           $(MZSCHEME_LIBS) \
+           $(LIBS) \
+           $(EXTRA_LIBS) \
+           $(RUST_MEM_LIB) \
+           $(LUA_LIBS) \
+           $(PERL_LIBS) \
+           $(PYTHON_LIBS) \
+           $(PYTHON3_LIBS) \
 	   $(TCL_LIBS) \
 	   $(RUBY_LIBS) \
 	   $(PROFILE_LIBS) \
@@ -1431,6 +1436,10 @@ DEST_AUTO = $(DESTDIR)$(AUTOSUBLOC)
 DEST_IMPORT = $(DESTDIR)$(IMPORTSUBLOC)
 DEST_PLUG = $(DESTDIR)$(PLUGSUBLOC)
 DEST_FTP = $(DESTDIR)$(FTPLUGSUBLOC)
+
+# Build the Rust memory management library
+$(RUST_MEM_LIB):
+	cd $(RUST_MEM_DIR) && cargo build --release
 DEST_LANG = $(DESTDIR)$(LANGSUBLOC)
 DEST_COMP = $(DESTDIR)$(COMPSUBLOC)
 DEST_KMAP = $(DESTDIR)$(KMAPSUBLOC)
@@ -2087,7 +2096,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB)
 	@$(BUILD_DATE_MSG)
 	@LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) $(OBJ) $(ALL_LIBS)" \

--- a/src/rust/mem/Cargo.toml
+++ b/src/rust/mem/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "vim-mem"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "vim_mem"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+libc = "0.2"

--- a/src/rust/mem/src/lib.rs
+++ b/src/rust/mem/src/lib.rs
@@ -1,0 +1,83 @@
+use libc::{c_char, c_int, size_t};
+
+/// Simplified representation of Vim's memfile_T.
+/// This structure keeps all lines in memory without swap management.
+#[repr(C)]
+pub struct MemFile {
+    lines: Vec<Vec<u8>>, // stored as UTF-8 bytes
+}
+
+impl MemFile {
+    fn new() -> Self {
+        Self { lines: Vec::new() }
+    }
+
+    fn append(&mut self, line: &[u8]) {
+        self.lines.push(line.to_vec());
+    }
+}
+
+/// Open a memory file. The parameters are kept for FFI compatibility but
+/// are ignored in this simplified implementation.
+#[no_mangle]
+pub extern "C" fn mf_open(_fname: *const c_char, _flags: c_int) -> *mut MemFile {
+    Box::into_raw(Box::new(MemFile::new()))
+}
+
+/// Append a line to the memory file.
+#[no_mangle]
+pub extern "C" fn ml_append(mf: *mut MemFile, line: *const c_char, len: size_t) -> c_int {
+    if mf.is_null() || line.is_null() {
+        return -1;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(line as *const u8, len as usize) };
+    let mf = unsafe { &mut *mf };
+    mf.append(slice);
+    0
+}
+
+/// Close the memory file and free its resources.
+#[no_mangle]
+pub extern "C" fn mf_close(mf: *mut MemFile) {
+    if !mf.is_null() {
+        unsafe { drop(Box::from_raw(mf)); }
+    }
+}
+
+/// Get the number of lines currently stored. Exposed for testing.
+#[no_mangle]
+pub extern "C" fn ml_line_count(mf: *const MemFile) -> size_t {
+    if mf.is_null() { return 0; }
+    let mf = unsafe { &*mf };
+    mf.lines.len() as size_t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::ptr;
+
+    #[test]
+    fn append_and_count() {
+        let mf = mf_open(ptr::null(), 0);
+        let line = CString::new("hello").unwrap();
+        ml_append(mf, line.as_ptr(), 5);
+        let count = ml_line_count(mf);
+        mf_close(mf);
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn append_many_lines() {
+        let mf = mf_open(ptr::null(), 0);
+        for i in 0..1000 {
+            let s = format!("line{}", i);
+            let c = CString::new(s).unwrap();
+            ml_append(mf, c.as_ptr(), c.as_bytes().len());
+        }
+        let count = ml_line_count(mf);
+        mf_close(mf);
+        assert_eq!(count, 1000);
+    }
+}


### PR DESCRIPTION
## Summary
- prototype Rust crate for memory file/line handling
- expose basic `mf_open`, `ml_append`, and helpers over FFI
- hook Rust library into build system

## Testing
- `cd src/rust/mem && cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a8cbcc888320a164fecd4ae739b0