### PR TITLE
feat: add rust-based allocator

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -13,6 +13,61 @@
 
 #include "vim.h"
 
+#ifdef USE_RUST_ALLOC
+
+// Declarations for the Rust allocation implementation.
+extern void *rust_alloc(size_t size);
+extern void *rust_alloc_clear(size_t size);
+extern void rust_free(void *ptr);
+
+void *alloc(size_t size)
+{
+    return rust_alloc(size);
+}
+
+# if defined(FEAT_QUICKFIX) || defined(PROTO)
+void *alloc_id(size_t size, alloc_id_T id UNUSED)
+{
+    return rust_alloc(size);
+}
+# endif
+
+void *alloc_clear(size_t size)
+{
+    return rust_alloc_clear(size);
+}
+
+void *alloc_clear_id(size_t size, alloc_id_T id UNUSED)
+{
+    return rust_alloc_clear(size);
+}
+
+void *lalloc_clear(size_t size, int message)
+{
+    (void)message;
+    return rust_alloc_clear(size);
+}
+
+void *lalloc(size_t size, int message)
+{
+    (void)message;
+    return rust_alloc(size);
+}
+
+# if defined(FEAT_SIGNS) || defined(PROTO)
+void *lalloc_id(size_t size, int message, alloc_id_T id UNUSED)
+{
+    return lalloc(size, message);
+}
+# endif
+
+void vim_free(void *x)
+{
+    rust_free(x);
+}
+
+#else
+
 /**********************************************************************
  * Various routines dealing with allocation and deallocation of memory.
  */
@@ -611,11 +666,13 @@ vim_free(void *x)
     if (x != NULL && !really_exiting)
     {
 #ifdef MEM_PROFILE
-	mem_pre_free(&x);
+        mem_pre_free(&x);
 #endif
-	free(x);
+        free(x);
     }
 }
+
+#endif // USE_RUST_ALLOC
 
 /************************************************************************
  * Functions for handling growing arrays.

--- a/src/rust/alloc.rs
+++ b/src/rust/alloc.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use std::os::raw::c_void;
+use std::sync::{Mutex, OnceLock};
+
+// Lazily initialized global map of allocations so that memory obtained in
+// Rust can later be released from C code.
+static ALLOCATIONS: OnceLock<Mutex<HashMap<usize, Vec<u8>>>> = OnceLock::new();
+
+fn allocations() -> &'static Mutex<HashMap<usize, Vec<u8>>> {
+    ALLOCATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[no_mangle]
+pub extern "C" fn rust_alloc(size: usize) -> *mut c_void {
+    let mut buf: Vec<u8> = Vec::with_capacity(size);
+    let ptr = buf.as_mut_ptr();
+    // Safety: we reserve `size` bytes and assume caller initializes it.
+    unsafe { buf.set_len(size); }
+    allocations().lock().unwrap().insert(ptr as usize, buf);
+    ptr as *mut c_void
+}
+
+#[no_mangle]
+pub extern "C" fn rust_alloc_clear(size: usize) -> *mut c_void {
+    let mut buf = vec![0u8; size];
+    let ptr = buf.as_mut_ptr();
+    allocations().lock().unwrap().insert(ptr as usize, buf);
+    ptr as *mut c_void
+}
+
+#[no_mangle]
+pub extern "C" fn rust_free(ptr: *mut c_void) {
+    if ptr.is_null() {
+        return;
+    }
+    allocations().lock().unwrap().remove(&(ptr as usize));
+}


### PR DESCRIPTION
## Summary
- implement memory allocation in Rust with safe Vec-based storage
- expose alloc/free APIs to C and optionally replace legacy alloc.c routines

## Testing
- `rustc --crate-type staticlib src/rust/alloc.rs -o /tmp/librust_alloc.a`
- `make test` *(fails: No rule to make target 'auto/config.h', needed by 'objects/alloc.o')*


------
https://chatgpt.com/codex/tasks/task_e_68b5a8d4d59083208b4e07586fe5c5d4