### PR TITLE
Add Rust file buffer and memory search wrappers

### DIFF
--- a/src/linematch.c
+++ b/src/linematch.c
@@ -8,6 +8,7 @@
  */
 
 #include "vim.h"
+#include "rust_mem.h"
 
 #define LN_MAX_BUFS 8
 #define LN_DECISION_MAX 255  // pow(2, LN_MAX_BUFS(8)) - 1 = 255
@@ -36,7 +37,7 @@ line_len(const mmfile_t *m)
     char	*s = m->ptr;
     char	*end;
 
-    end = memchr(s, '\n', (size_t)m->size);
+    end = rs_memchr(s, '\n', (size_t)m->size);
     return end ? (size_t)(end - s) : (size_t)m->size;
 }
 

--- a/src/rust/mem/Cargo.toml
+++ b/src/rust/mem/Cargo.toml
@@ -9,3 +9,5 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 libc = "0.2"
+memmap2 = "0.5"
+memchr = "2"

--- a/src/rust/mem/src/lib.rs
+++ b/src/rust/mem/src/lib.rs
@@ -1,4 +1,10 @@
 use libc::{c_char, c_int, size_t};
+use std::ffi::{CStr};
+use std::fs::File;
+use memmap2::Mmap;
+use std::ptr;
+use memchr::memchr;
+use memchr::memmem;
 
 /// Simplified representation of Vim's memfile_T.
 /// This structure keeps all lines in memory without swap management.
@@ -52,11 +58,130 @@ pub extern "C" fn ml_line_count(mf: *const MemFile) -> size_t {
     mf.lines.len() as size_t
 }
 
+/// File-backed buffer using a memory mapped file with line offsets.
+pub struct FileBuffer {
+    map: Mmap,
+    line_offsets: Vec<usize>,
+}
+
+impl FileBuffer {
+    fn open(path: &CStr) -> std::io::Result<Self> {
+        let f = File::open(path.to_string_lossy().as_ref())?;
+        let map = unsafe { Mmap::map(&f)? };
+        let mut offsets = vec![0];
+        for (i, b) in map.iter().enumerate() {
+            if *b == b'\n' {
+                offsets.push(i + 1);
+            }
+        }
+        Ok(Self { map, line_offsets: offsets })
+    }
+
+    fn line(&self, idx: usize) -> Option<&[u8]> {
+        if idx >= self.line_offsets.len() {
+            return None;
+        }
+        let start = self.line_offsets[idx];
+        let end = if idx + 1 < self.line_offsets.len() {
+            self.line_offsets[idx + 1] - 1
+        } else {
+            self.map.len()
+        };
+        Some(&self.map[start..end])
+    }
+
+    fn search(&self, pat: &[u8]) -> Option<usize> {
+        memmem::find(&self.map, pat)
+    }
+}
+
+/// Open a file-backed buffer.
+#[no_mangle]
+pub extern "C" fn fb_open(path: *const c_char) -> *mut FileBuffer {
+    if path.is_null() {
+        return ptr::null_mut();
+    }
+    let c_path = unsafe { CStr::from_ptr(path) };
+    match FileBuffer::open(c_path) {
+        Ok(fb) => Box::into_raw(Box::new(fb)),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Close a file-backed buffer.
+#[no_mangle]
+pub extern "C" fn fb_close(fb: *mut FileBuffer) {
+    if !fb.is_null() {
+        unsafe { drop(Box::from_raw(fb)); }
+    }
+}
+
+/// Get a line from a file-backed buffer.
+#[no_mangle]
+pub extern "C" fn fb_get_line(
+    fb: *const FileBuffer,
+    idx: size_t,
+    len: *mut size_t,
+) -> *const c_char {
+    if fb.is_null() {
+        return ptr::null();
+    }
+    let fb_ref = unsafe { &*fb };
+    if let Some(line) = fb_ref.line(idx as usize) {
+        if !len.is_null() {
+            unsafe { *len = line.len() as size_t; }
+        }
+        line.as_ptr() as *const c_char
+    } else {
+        if !len.is_null() {
+            unsafe { *len = 0; }
+        }
+        ptr::null()
+    }
+}
+
+/// Search for a pattern in a file-backed buffer. Returns -1 if not found.
+#[no_mangle]
+pub extern "C" fn fb_search(
+    fb: *const FileBuffer,
+    pat: *const c_char,
+    pat_len: size_t,
+) -> isize {
+    if fb.is_null() || pat.is_null() {
+        return -1;
+    }
+    let fb_ref = unsafe { &*fb };
+    let pattern = unsafe { std::slice::from_raw_parts(pat as *const u8, pat_len as usize) };
+    match fb_ref.search(pattern) {
+        Some(pos) => pos as isize,
+        None => -1,
+    }
+}
+
+/// A safe wrapper around memchr exposed for C callers.
+#[no_mangle]
+pub extern "C" fn rs_memchr(
+    s: *const c_char,
+    c: c_int,
+    n: size_t,
+) -> *const c_char {
+    if s.is_null() {
+        return ptr::null();
+    }
+    let slice = unsafe { std::slice::from_raw_parts(s as *const u8, n as usize) };
+    if let Some(pos) = memchr(c as u8, slice) {
+        unsafe { s.add(pos) }
+    } else {
+        ptr::null()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::CString;
     use std::ptr;
+    use std::fs::File;
 
     #[test]
     fn append_and_count() {
@@ -79,5 +204,26 @@ mod tests {
         let count = ml_line_count(mf);
         mf_close(mf);
         assert_eq!(count, 1000);
+    }
+
+    #[test]
+    fn file_buffer_basic() {
+        use std::io::Write;
+        let dir = std::env::temp_dir();
+        let path = dir.join("fb_test.txt");
+        {
+            let mut f = File::create(&path).unwrap();
+            writeln!(f, "hello").unwrap();
+            writeln!(f, "world").unwrap();
+        }
+        let c_path = CString::new(path.to_str().unwrap()).unwrap();
+        let fb = fb_open(c_path.as_ptr());
+        assert!(!fb.is_null());
+        let mut len: size_t = 0;
+        let line = fb_get_line(fb, 0, &mut len as *mut size_t);
+        let slice = unsafe { std::slice::from_raw_parts(line as *const u8, len as usize) };
+        assert_eq!(slice, b"hello");
+        assert_eq!(fb_search(fb, b"world".as_ptr() as *const c_char, 5), 6);
+        fb_close(fb);
     }
 }

--- a/src/rust_mem.h
+++ b/src/rust_mem.h
@@ -1,0 +1,8 @@
+#ifndef RUST_MEM_H
+#define RUST_MEM_H
+
+#include <stddef.h>
+
+char *rs_memchr(const char *s, int c, size_t n);
+
+#endif // RUST_MEM_H


### PR DESCRIPTION
## Summary
- expose Rust `FileBuffer` for file-backed buffer management and pattern search
- add C-callable `rs_memchr` and replace `memchr` usage in linematch
- wire up new memory helpers via header and build dependencies

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b5abd8a54883209a960b37ec0e6437