### PR TITLE
Rust-based expression evaluation

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -24,7 +24,7 @@
 
 // FFI interface to the Rust expression evaluator.
 // Returns non-zero on success and stores the evaluated result in "result".
-extern int eval_expr_rs(const char *expr, long *result);
+extern int eval_expr_rs(const char *expr, typval_T *result);
 
 
 
@@ -139,7 +139,9 @@ eval_to_bool(
     int         skip,       // only parse, don't execute
     int         use_simple_function)
 {
-    long result = 0;
+    typval_T    result;
+    int         res;
+
     if (!eval_expr_rs((const char *)arg, &result))
     {
         if (error != NULL)
@@ -148,7 +150,9 @@ eval_to_bool(
     }
     if (error != NULL)
         *error = FALSE;
-    return result != 0;
+    res = tv_get_bool(&result) != 0;
+    clear_tv(&result);
+    return res;
 }
 
 /*
@@ -776,14 +780,7 @@ eval_expr_ext(char_u *arg, exarg_T *eap, int use_simple_function)
     tv = ALLOC_ONE(typval_T);
     if (tv == NULL)
         return NULL;
-    long result = 0;
-    if (eval_expr_rs((const char *)arg, &result))
-    {
-        tv->v_type = VAR_NUMBER;
-        tv->v_lock = 0;
-        tv->vval.v_number = result;
-    }
-    else
+    if (!eval_expr_rs((const char *)arg, tv))
     {
         VIM_CLEAR(tv);
     }

--- a/src/rust/eval.rs
+++ b/src/rust/eval.rs
@@ -1,18 +1,68 @@
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum Vartype {
+    VAR_UNKNOWN = 0,
+    VAR_ANY,
+    VAR_VOID,
+    VAR_BOOL,
+    VAR_SPECIAL,
+    VAR_NUMBER,
+    VAR_FLOAT,
+    VAR_STRING,
+}
+
+#[repr(C)]
+pub union ValUnion {
+    pub v_number: i64,
+    pub v_string: *mut c_char,
+}
+
+#[repr(C)]
+pub struct typval_T {
+    pub v_type: Vartype,
+    pub v_lock: c_char,
+    pub vval: ValUnion,
+}
 
 #[derive(Debug, Clone)]
 enum Expr {
     Number(i64),
+    Str(String),
     Add(Box<Expr>, Box<Expr>),
     Sub(Box<Expr>, Box<Expr>),
     Mul(Box<Expr>, Box<Expr>),
     Div(Box<Expr>, Box<Expr>),
+    Concat(Box<Expr>, Box<Expr>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Value {
+    Number(i64),
+    Str(String),
+}
+
+impl Value {
+    fn as_number(&self) -> i64 {
+        match self {
+            Value::Number(n) => *n,
+            Value::Str(s) => s.parse().unwrap_or(0),
+        }
+    }
+
+    fn to_string(self) -> String {
+        match self {
+            Value::Number(n) => n.to_string(),
+            Value::Str(s) => s,
+        }
+    }
 }
 
 fn parse_expr(input: &str) -> Result<Expr, ()> {
     let mut chars = Tokenizer::new(input);
-    let expr = parse_add_sub(&mut chars)?;
+    let expr = parse_concat(&mut chars)?;
     if chars.next_non_ws().is_some() {
         return Err(());
     }
@@ -63,8 +113,23 @@ impl<'a> Tokenizer<'a> {
         if s.is_empty() {
             None
         } else {
-            s.parse().ok()
+                s.parse().ok()
         }
+    }
+
+    fn parse_string(&mut self) -> Option<String> {
+        if self.peek_non_ws() != Some('"') {
+            return None;
+        }
+        self.next_non_ws(); // skip opening quote
+        let mut s = String::new();
+        while let Some(c) = self.iter.next() {
+            if c == '"' {
+                return Some(s);
+            }
+            s.push(c);
+        }
+        None
     }
 }
 
@@ -72,11 +137,18 @@ fn parse_primary(tokens: &mut Tokenizer) -> Result<Expr, ()> {
     if let Some(c) = tokens.peek_non_ws() {
         if c == '(' {
             tokens.next_non_ws();
-            let expr = parse_add_sub(tokens)?;
+            let expr = parse_concat(tokens)?;
             if tokens.next_non_ws() != Some(')') {
                 return Err(());
             }
             return Ok(expr);
+        }
+        if c == '"' {
+            if let Some(s) = tokens.parse_string() {
+                return Ok(Expr::Str(s));
+            } else {
+                return Err(());
+            }
         }
     }
     if let Some(num) = tokens.parse_number() {
@@ -124,18 +196,89 @@ fn parse_add_sub(tokens: &mut Tokenizer) -> Result<Expr, ()> {
     Ok(node)
 }
 
-fn eval(expr: &Expr) -> i64 {
+fn parse_concat(tokens: &mut Tokenizer) -> Result<Expr, ()> {
+    let mut node = parse_add_sub(tokens)?;
+    loop {
+        match tokens.peek_non_ws() {
+            Some('.') => {
+                tokens.next_non_ws();
+                let rhs = parse_add_sub(tokens)?;
+                node = Expr::Concat(Box::new(node), Box::new(rhs));
+            }
+            _ => break,
+        }
+    }
+    Ok(node)
+}
+
+fn eval(expr: &Expr) -> Value {
     match expr {
-        Expr::Number(n) => *n,
-        Expr::Add(a, b) => eval(a) + eval(b),
-        Expr::Sub(a, b) => eval(a) - eval(b),
-        Expr::Mul(a, b) => eval(a) * eval(b),
-        Expr::Div(a, b) => eval(a) / eval(b),
+        Expr::Number(n) => Value::Number(*n),
+        Expr::Str(s) => Value::Str(s.clone()),
+        Expr::Add(a, b) => {
+            let a = eval(a).as_number();
+            let b = eval(b).as_number();
+            Value::Number(a + b)
+        }
+        Expr::Sub(a, b) => {
+            let a = eval(a).as_number();
+            let b = eval(b).as_number();
+            Value::Number(a - b)
+        }
+        Expr::Mul(a, b) => {
+            let a = eval(a).as_number();
+            let b = eval(b).as_number();
+            Value::Number(a * b)
+        }
+        Expr::Div(a, b) => {
+            let a = eval(a).as_number();
+            let b = eval(b).as_number();
+            Value::Number(a / b)
+        }
+        Expr::Concat(a, b) => {
+            let left = eval(a).to_string();
+            let right = eval(b).to_string();
+            Value::Str(left + &right)
+        }
+    }
+}
+
+unsafe fn to_typval(val: Value, out: *mut typval_T) {
+    match val {
+        Value::Number(n) => {
+            (*out).v_type = Vartype::VAR_NUMBER;
+            (*out).v_lock = 0;
+            (*out).vval.v_number = n;
+        }
+        Value::Str(s) => {
+            (*out).v_type = Vartype::VAR_STRING;
+            (*out).v_lock = 0;
+            let cstr = CString::new(s).unwrap();
+            (*out).vval.v_string = cstr.into_raw();
+        }
+    }
+}
+
+unsafe fn from_typval(tv: *const typval_T) -> Option<Value> {
+    if tv.is_null() {
+        return None;
+    }
+    match (*tv).v_type {
+        Vartype::VAR_NUMBER => Some(Value::Number((*tv).vval.v_number)),
+        Vartype::VAR_STRING => {
+            if (*tv).vval.v_string.is_null() {
+                Some(Value::Str(String::new()))
+            } else {
+                let cstr = CStr::from_ptr((*tv).vval.v_string);
+                cstr.to_str().ok().map(|s| Value::Str(s.to_string()))
+            }
+        }
+        _ => None,
     }
 }
 
 #[no_mangle]
-pub extern "C" fn eval_expr_rs(expr: *const c_char, out: *mut i64) -> bool {
+pub extern "C" fn eval_expr_rs(expr: *const c_char, out: *mut typval_T) -> bool {
     if expr.is_null() || out.is_null() {
         return false;
     }
@@ -147,9 +290,7 @@ pub extern "C" fn eval_expr_rs(expr: *const c_char, out: *mut i64) -> bool {
     match parse_expr(expr_str) {
         Ok(ast) => {
             let val = eval(&ast);
-            unsafe {
-                *out = val;
-            }
+            unsafe { to_typval(val, out); }
             true
         }
         Err(_) => false,
@@ -161,8 +302,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_eval() {
+    fn test_eval_number() {
         let ast = parse_expr("1 + 2 * 3").unwrap();
-        assert_eq!(eval(&ast), 7);
+        assert_eq!(eval(&ast), Value::Number(7));
+    }
+
+    #[test]
+    fn test_eval_string_concat() {
+        let ast = parse_expr("\"foo\" . \"bar\"").unwrap();
+        assert_eq!(eval(&ast), Value::Str("foobar".to_string()));
+    }
+
+    #[test]
+    fn test_typval_roundtrip() {
+        let ast = parse_expr("\"a\" . \"b\"").unwrap();
+        let val = eval(&ast);
+        let mut tv = typval_T {
+            v_type: Vartype::VAR_UNKNOWN,
+            v_lock: 0,
+            vval: ValUnion { v_number: 0 },
+        };
+        unsafe {
+            to_typval(val.clone(), &mut tv);
+            let back = from_typval(&tv as *const typval_T).unwrap();
+            if let Vartype::VAR_STRING = tv.v_type {
+                // free allocated string
+                let _ = CString::from_raw(tv.vval.v_string);
+            }
+            assert_eq!(back, val);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- map `typval_T` to Rust structures and support conversions
- move numeric and string expression parsing/evaluation to Rust
- convert C evaluation entry points to rely on Rust results

## Testing
- `rustc --test src/rust/eval.rs -o /tmp/eval_test && /tmp/eval_test`
- `make -j4` *(fails: No rule to make target 'xxd/xxd.c')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ac21e6f8832088475d518de7cb49