### PR TITLE
Integrate richer Rust JSON API with Vim stubs

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -2,16 +2,27 @@
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
-// Declarations for Rust FFI functions.
-extern char_u *json_encode_rs(const char *input);
-extern char_u *json_decode_rs(const char *input);
+// Structures and declarations for Rust FFI functions.
+typedef struct {
+    char_u *ptr;
+    size_t used;
+    int error;
+} JsonDecodeResult;
+
+typedef struct {
+    size_t used;
+    int status;
+} JsonFindEndResult;
+
+extern char_u *json_encode_rs(const char *input, int options);
+extern JsonDecodeResult json_decode_rs(const char *input, int options);
+extern JsonFindEndResult json_find_end_rs(const char *input, int options);
 
 // Basic JSON encode wrapper using Rust implementation.
 char_u *
 json_encode(typval_T *val, int options)
 {
-    // Ignoring options for the simplified Rust implementation.
-    return json_encode_rs((const char *)tv_get_string(val));
+    return json_encode_rs((const char *)tv_get_string(val), options);
 }
 
 // Encode [nr, val] expression; simplified to encode the value only.
@@ -34,19 +45,24 @@ json_encode_lsp_msg(typval_T *val)
 int
 json_decode(js_read_T *reader, typval_T *res, int options)
 {
-    (void)options;
+    JsonDecodeResult r = json_decode_rs((const char *)reader->js_buf, options);
+    reader->js_used = (int)r.used;
     res->v_type = VAR_STRING;
-    res->vval.v_string = json_decode_rs((const char *)reader->js_buf);
-    return OK;
+    res->vval.v_string = r.ptr;
+    if (r.error == 0)
+        return OK;
+    return r.error == 1 ? MAYBE : FAIL;
 }
 
-// Find the end of a JSON message; this stub always succeeds.
+// Find the end of a JSON message using the Rust implementation.
 int
 json_find_end(js_read_T *reader, int options)
 {
-    (void)reader;
-    (void)options;
-    return OK;
+    JsonFindEndResult r = json_find_end_rs((const char *)reader->js_buf, options);
+    reader->js_used = (int)r.used;
+    if (r.status == 1)
+        return OK;
+    return r.status == 2 ? MAYBE : FAIL;
 }
 
 // Vim script interfaces -----------------------------------------------------
@@ -54,22 +70,24 @@ json_find_end(js_read_T *reader, int options)
 void
 f_js_decode(typval_T *argvars, typval_T *rettv)
 {
+    JsonDecodeResult r = json_decode_rs((const char *)tv_get_string(&argvars[0]), 0);
     rettv->v_type = VAR_STRING;
-    rettv->vval.v_string = json_decode_rs((const char *)tv_get_string(&argvars[0]));
+    rettv->vval.v_string = r.ptr;
 }
 
 void
 f_js_encode(typval_T *argvars, typval_T *rettv)
 {
     rettv->v_type = VAR_STRING;
-    rettv->vval.v_string = json_encode_rs((const char *)tv_get_string(&argvars[0]));
+    rettv->vval.v_string = json_encode_rs((const char *)tv_get_string(&argvars[0]), 0);
 }
 
 void
 f_json_decode(typval_T *argvars, typval_T *rettv)
 {
+    JsonDecodeResult r = json_decode_rs((const char *)tv_get_string(&argvars[0]), 0);
     rettv->v_type = VAR_STRING;
-    rettv->vval.v_string = json_decode_rs((const char *)tv_get_string(&argvars[0]));
+    rettv->vval.v_string = r.ptr;
 }
 
 void

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,3 +8,5 @@ path = "eval.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/rust/json.rs
+++ b/src/rust/json.rs
@@ -1,37 +1,138 @@
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_int};
 
-// Encode a UTF-8 string to a JSON string using serde_json.
+use serde_json::error::Category;
+use serde_json::{self, Value};
+
+// Option flags copied from Vim's C code.  Only JSON_NL has an
+// observable effect in this simplified implementation.
+const JSON_JS: c_int = 1;
+const JSON_NO_NONE: c_int = 2;
+const JSON_NL: c_int = 4;
+
+/// Result for decoding a JSON string.
+#[repr(C)]
+pub struct JsonDecodeResult {
+    pub ptr: *mut c_char,
+    pub used: usize,
+    pub error: c_int,
+}
+
+/// Result for finding the end of a JSON message.
+#[repr(C)]
+pub struct JsonFindEndResult {
+    pub used: usize,
+    pub status: c_int,
+}
+
+// Encode a UTF-8 string to a JSON string using serde_json.  The only option
+// currently honored is JSON_NL, which appends a trailing newline to the
+// encoded result when set.
 #[no_mangle]
-pub extern "C" fn json_encode_rs(input: *const c_char) -> *mut c_char {
+pub extern "C" fn json_encode_rs(input: *const c_char, options: c_int) -> *mut c_char {
     unsafe {
         if input.is_null() {
             return CString::new("\"\"").unwrap().into_raw();
         }
         match CStr::from_ptr(input).to_str() {
-            Ok(s) => match serde_json::to_string(s) {
-                Ok(json) => CString::new(json).unwrap().into_raw(),
-                Err(_) => CString::new("\"\"").unwrap().into_raw(),
-            },
+            Ok(s) => {
+                let mut json = match serde_json::to_string(s) {
+                    Ok(json) => json,
+                    Err(_) => "\"\"".to_string(),
+                };
+                if (options & JSON_NL) != 0 {
+                    json.push('\n');
+                }
+                CString::new(json).unwrap().into_raw()
+            }
             Err(_) => CString::new("\"\"").unwrap().into_raw(),
         }
     }
 }
 
-// Decode a JSON string back to a plain UTF-8 string.  Returns an empty
-// string on error.
+// Decode a JSON value back to a string.  When the decoded value is a JSON
+// string the returned text is the plain string, otherwise the JSON
+// representation of the value is returned.  On error an empty string is
+// returned and "error" indicates whether the input was incomplete (1) or
+// invalid (2).  "used" is set to the number of bytes consumed when the
+// decoding succeeds.
 #[no_mangle]
-pub extern "C" fn json_decode_rs(input: *const c_char) -> *mut c_char {
+pub extern "C" fn json_decode_rs(input: *const c_char, _options: c_int) -> JsonDecodeResult {
     unsafe {
         if input.is_null() {
-            return CString::new("" ).unwrap().into_raw();
+            return JsonDecodeResult {
+                ptr: CString::new("").unwrap().into_raw(),
+                used: 0,
+                error: 2,
+            };
         }
-        match CStr::from_ptr(input).to_str() {
-            Ok(s) => match serde_json::from_str::<String>(s) {
-                Ok(val) => CString::new(val).unwrap().into_raw(),
-                Err(_) => CString::new("").unwrap().into_raw(),
-            },
-            Err(_) => CString::new("").unwrap().into_raw(),
+
+        let s = match CStr::from_ptr(input).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                return JsonDecodeResult {
+                    ptr: CString::new("").unwrap().into_raw(),
+                    used: 0,
+                    error: 2,
+                };
+            }
+        };
+
+        let mut de = serde_json::Deserializer::from_str(s);
+        match Value::deserialize(&mut de) {
+            Ok(v) => {
+                let used = de.byte_offset();
+                let out = match v {
+                    Value::String(st) => st,
+                    other => other.to_string(),
+                };
+                JsonDecodeResult {
+                    ptr: CString::new(out).unwrap().into_raw(),
+                    used,
+                    error: 0,
+                }
+            }
+            Err(e) => {
+                let err = match e.classify() {
+                    Category::Eof => 1,
+                    _ => 2,
+                };
+                JsonDecodeResult {
+                    ptr: CString::new("").unwrap().into_raw(),
+                    used: 0,
+                    error: err,
+                }
+            }
+        }
+    }
+}
+
+// Find the end of the first JSON value in "input".  "status" is one of the
+// Vim constants OK (1), FAIL (0) or MAYBE (2).
+#[no_mangle]
+pub extern "C" fn json_find_end_rs(input: *const c_char, _options: c_int) -> JsonFindEndResult {
+    unsafe {
+        if input.is_null() {
+            return JsonFindEndResult { used: 0, status: 0 };
+        }
+        let s = match CStr::from_ptr(input).to_str() {
+            Ok(s) => s,
+            Err(_) => return JsonFindEndResult { used: 0, status: 0 },
+        };
+
+        let mut de = serde_json::Deserializer::from_str(s);
+        match Value::deserialize(&mut de) {
+            Ok(_) => {
+                let used = de.byte_offset();
+                JsonFindEndResult { used, status: 1 }
+            }
+            Err(e) => {
+                let status = match e.classify() {
+                    Category::Eof => 2,
+                    _ => 0,
+                };
+                JsonFindEndResult { used: 0, status }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Expand Rust JSON module with option-aware encode/decode and new FFI structs
- Update C json stubs to call into Rust for encoding, decoding and end detection
- Add serde dependencies for Rust JSON support

## Testing
- `make json_test` *(fails: No rule to make target 'json_test')*
- `cd src/rust && cargo test`  
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac2e49d48320b926639b209e4e0b