### PR TITLE
feat: migrate search stat to rust

### DIFF
--- a/src/search_rs.h
+++ b/src/search_rs.h
@@ -1,0 +1,22 @@
+#ifndef SEARCH_RS_H
+#define SEARCH_RS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    int cur;
+    int cnt;
+    int exact_match;
+    int incomplete;
+    int last_maxcount;
+} searchstat_T;
+
+int rust_search_update_stat(const char *pat, const char *text, searchstat_T *stat);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SEARCH_RS_H

--- a/src/testdir/Make_all.mak
+++ b/src/testdir/Make_all.mak
@@ -278,8 +278,9 @@ NEW_TESTS = \
 	test_rename \
 	test_restricted \
 	test_retab \
-	test_ruby \
-	test_scriptnames \
+        test_ruby \
+        test_rust_search \
+        test_scriptnames \
 	test_scroll_opt \
 	test_scrollbind \
 	test_search \
@@ -548,8 +549,9 @@ NEW_TESTS_RES = \
 	test_rename.res \
 	test_restricted.res \
 	test_retab.res \
-	test_ruby.res \
-	test_scriptnames.res \
+        test_ruby.res \
+        test_rust_search.res \
+        test_scriptnames.res \
 	test_scroll_opt.res \
 	test_scrollbind.res \
 	test_search.res \

--- a/src/testdir/test_rust_search.vim
+++ b/src/testdir/test_rust_search.vim
@@ -1,0 +1,25 @@
+" Tests for Rust-based search implementation
+
+func Test_rust_incremental_search()
+  if !exists('*rust_regex_match')
+    throw 'rust regex not available'
+  endif
+  new
+  set incsearch
+  call setline(1, ['foo', 'bar', 'foobar'])
+  call feedkeys('/fo', 'nx')
+  call feedkeys("\<CR>", 'nx')
+  call assert_equal('foo', getline('.'))
+  bwipe!
+endfunc
+
+func Test_rust_slash_command()
+  if !exists('*rust_regex_match')
+    throw 'rust regex not available'
+  endif
+  new
+  call setline(1, ['alpha', 'beta', 'gamma'])
+  call feedkeys('/beta\<CR>', 'nx')
+  call assert_equal(2, line('.'))
+  bwipe!
+endfunc


### PR DESCRIPTION
## Summary
- move searchstat handling to new Rust struct and FFI
- integrate rust-based update_search_stat into legacy search.c
- add coverage for incremental search and `/` command

## Testing
- `cargo build --release` (in src/rust_regex)
- `make` *(fails: implicit declarations in eval.c)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ac22faf88320915eb198ff2e94de