### PR TITLE
Integrate Rust regex engine

### DIFF
--- a/rust_regex/include/rust_regex.h
+++ b/rust_regex/include/rust_regex.h
@@ -14,10 +14,10 @@ typedef struct RegMatch {
     const char *endp[10];
 } RegMatch;
 
-RegProg* rust_vim_regcomp(const char *pattern, int flags);
-void rust_vim_regfree(RegProg *prog);
-int rust_vim_regexec(RegProg *prog, const char *text, RegMatch *matchp);
-char* rust_vim_regsub(RegProg *prog, const char *text, const char *sub);
+RegProg* vim_regcomp(const char *pattern, int flags);
+void vim_regfree(RegProg *prog);
+int vim_regexec(RegProg *prog, const char *text, RegMatch *matchp);
+char* vim_regsub(RegProg *prog, const char *text, const char *sub);
 
 #ifdef __cplusplus
 }

--- a/rust_regex/src/lib.rs
+++ b/rust_regex/src/lib.rs
@@ -8,7 +8,7 @@ pub struct RegProg {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_vim_regcomp(pattern: *const c_char, _flags: c_int) -> *mut RegProg {
+pub extern "C" fn vim_regcomp(pattern: *const c_char, _flags: c_int) -> *mut RegProg {
     if pattern.is_null() {
         return std::ptr::null_mut();
     }
@@ -24,7 +24,7 @@ pub extern "C" fn rust_vim_regcomp(pattern: *const c_char, _flags: c_int) -> *mu
 }
 
 #[no_mangle]
-pub extern "C" fn rust_vim_regfree(prog: *mut RegProg) {
+pub extern "C" fn vim_regfree(prog: *mut RegProg) {
     if !prog.is_null() {
         unsafe { drop(Box::from_raw(prog)); }
     }
@@ -37,7 +37,7 @@ pub struct RegMatch {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_vim_regexec(prog: *mut RegProg, text: *const c_char, matchp: *mut RegMatch) -> c_int {
+pub extern "C" fn vim_regexec(prog: *mut RegProg, text: *const c_char, matchp: *mut RegMatch) -> c_int {
     if prog.is_null() || text.is_null() {
         return 0;
     }
@@ -64,7 +64,7 @@ pub extern "C" fn rust_vim_regexec(prog: *mut RegProg, text: *const c_char, matc
 }
 
 #[no_mangle]
-pub extern "C" fn rust_vim_regsub(prog: *mut RegProg, text: *const c_char, sub: *const c_char) -> *mut c_char {
+pub extern "C" fn vim_regsub(prog: *mut RegProg, text: *const c_char, sub: *const c_char) -> *mut c_char {
     if prog.is_null() || text.is_null() || sub.is_null() {
         return std::ptr::null_mut();
     }

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,6 +290,7 @@ VIEWNAME = view
 
 include auto/config.mk
 #.include "auto/config.mk"
+CFLAGS += -DUSE_RUST_REGEX
 CClink = $(CC)
 
 #}}}
@@ -1398,6 +1399,8 @@ DEPEND_CFLAGS = -DPROTO -DDEPEND -DFEAT_GUI $(LINT_CFLAGS)
 # Location of the Rust memory management crate
 RUST_MEM_DIR = rust/mem
 RUST_MEM_LIB = $(RUST_MEM_DIR)/target/release/libvim_mem.a
+RUST_REGEX_DIR = ../rust_regex
+RUST_REGEX_LIB = $(RUST_REGEX_DIR)/target/release/librust_regex.a
 
 # Note: MZSCHEME_LIBS must come before LIBS, because LIBS adds -lm which is
 # needed by racket.
@@ -1414,6 +1417,7 @@ ALL_LIBS = \
            $(LIBS) \
            $(EXTRA_LIBS) \
            $(RUST_MEM_LIB) \
+           $(RUST_REGEX_LIB) \
            $(LUA_LIBS) \
            $(PERL_LIBS) \
            $(PYTHON_LIBS) \
@@ -1439,7 +1443,10 @@ DEST_FTP = $(DESTDIR)$(FTPLUGSUBLOC)
 
 # Build the Rust memory management library
 $(RUST_MEM_LIB):
-	cd $(RUST_MEM_DIR) && cargo build --release
+        cd $(RUST_MEM_DIR) && cargo build --release
+
+$(RUST_REGEX_LIB):
+        cd $(RUST_REGEX_DIR) && cargo build --release
 DEST_LANG = $(DESTDIR)$(LANGSUBLOC)
 DEST_COMP = $(DESTDIR)$(COMPSUBLOC)
 DEST_KMAP = $(DESTDIR)$(KMAPSUBLOC)
@@ -2102,7 +2109,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB)
 	@$(BUILD_DATE_MSG)
 	@LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) $(OBJ) $(ALL_LIBS)" \

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -15,12 +15,13 @@
 // FFI bindings to Rust regex implementation
 extern int rust_regex_match(const char *pat, const char *text, int magic, long timeout_ms);
 
-    int
+int
 vim_rust_regex_match_wrapper(char_u *pat, char_u *text, int magic, long timeout_ms)
 {
     return rust_regex_match((const char *)pat, (const char *)text, magic, timeout_ms);
 }
-#endif
+
+#else
 #ifdef DEBUG
 // show/save debugging data when BT engine is used
 # define BT_REGEXP_DUMP
@@ -3281,3 +3282,4 @@ vim_regexec_multi(
 
     return result <= 0 ? 0 : result;
 }
+#endif // USE_RUST_REGEX

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -39,6 +39,10 @@
 #define	    BACKTRACKING_ENGINE	1
 #define	    NFA_ENGINE		2
 
+#ifdef USE_RUST_REGEX
+# include "../rust_regex/include/rust_regex.h"
+typedef RegProg regprog_T;
+#else
 typedef struct regengine regengine_T;
 
 /*
@@ -122,6 +126,7 @@ typedef struct
     int			nstate;
     nfa_state_T		state[1];	// actually longer..
 } nfa_regprog_T;
+#endif
 
 /*
  * Structure to be used for single-line matching.
@@ -168,6 +173,7 @@ typedef struct
     char_u		*matches[NSUBEXP];
 } reg_extmatch_T;
 
+#ifndef USE_RUST_REGEX
 struct regengine
 {
     // bt_regcomp or nfa_regcomp
@@ -182,6 +188,7 @@ struct regengine
     char_u	*expr;
 #endif
 };
+#endif
 
 #ifdef USE_RUST_REGEX
 int vim_rust_regex_match_wrapper(char_u *pat, char_u *text, int magic, long timeout_ms);


### PR DESCRIPTION
## Summary
- expose vim_regcomp/vim_regexec/vim_regsub from rust_regex crate
- prefer Rust regex backend by guarding C regex implementation
- default build to Rust regex engine with new rules

## Testing
- `cargo test --manifest-path rust_regex/Cargo.toml`
- `cargo test --manifest-path src/rust_regex/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac2cb5888320af9a8594d38733aa