### PR TITLE
Enable Rust-backed buffer management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_buffer"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +229,7 @@ name = "vim_channel"
 version = "0.1.0"
 dependencies = [
  "diff",
+ "rust_buffer",
  "spell",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tokio = { version = "1", features = ["net", "time", "macros", "io-util", "rt"] }
 spell = { path = "rust/spell" }
 diff = { path = "rust/diff" }
+rust_buffer = { path = "rust_buffer" }
 
 [lib]
 name = "vim_channel"

--- a/rust_buffer/src/lib.rs
+++ b/rust_buffer/src/lib.rs
@@ -1,13 +1,37 @@
-use std::os::raw::{c_void, c_int};
+use std::collections::HashSet;
+use std::os::raw::{c_int, c_void};
+use std::sync::{Mutex, OnceLock};
+
+// Keep track of allocated buffers so they can be cleaned up when buf_freeall is
+// called from the C side.  The actual freeing of the memory is still performed
+// in Vim's C code (free_buffer()), but tracking allocations here makes the
+// behaviour visible and testable from Rust.
+static BUFFERS: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
 
 #[no_mangle]
 pub extern "C" fn buf_alloc(size: usize) -> *mut c_void {
-    unsafe { libc::calloc(1, size) }
+    let ptr = unsafe { libc::calloc(1, size) };
+    if !ptr.is_null() {
+        BUFFERS
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .unwrap()
+            .insert(ptr as usize);
+    }
+    ptr
 }
 
 #[no_mangle]
-pub extern "C" fn buf_freeall(_buf: *mut c_void, _flags: c_int) {
-    // Actual cleanup is performed on the C side.
+pub extern "C" fn buf_freeall(buf: *mut c_void, _flags: c_int) {
+    if buf.is_null() {
+        return;
+    }
+    if let Some(m) = BUFFERS.get() {
+        let mut buffers = m.lock().unwrap();
+        buffers.remove(&(buf as usize));
+    }
+    // The buffer struct itself is freed in Vim's C code; we only keep track
+    // of allocations here and clear our bookkeeping on free.
 }
 
 #[cfg(test)]
@@ -18,7 +42,12 @@ mod tests {
     fn alloc_and_free() {
         let p = buf_alloc(16);
         assert!(!p.is_null());
+        // Ensure that the allocation is tracked.
+        let set = BUFFERS.get().unwrap();
+        assert!(set.lock().unwrap().contains(&(p as usize)));
         buf_freeall(p, 0);
+        // After freeing the entry should have been removed from the tracker.
+        assert!(!set.lock().unwrap().contains(&(p as usize)));
         unsafe { libc::free(p) };
     }
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -1427,6 +1427,7 @@ ALL_LIBS = \
            $(LIBS) \
            $(EXTRA_LIBS) \
            $(RUST_MEM_LIB) \
+           $(RUST_BUFFER_LIB) \
            $(RUST_CHANNEL_LIB) \
            $(LUA_LIBS) \
            $(PERL_LIBS) \
@@ -2127,7 +2128,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_CHANNEL_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_BUFFER_LIB) $(RUST_CHANNEL_LIB)
 	@$(BUILD_DATE_MSG)
 	@LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) $(OBJ) $(ALL_LIBS)" \

--- a/src/rust_buffer.h
+++ b/src/rust_buffer.h
@@ -4,5 +4,6 @@
 #include <stddef.h>
 
 void *buf_alloc(size_t size);
+void buf_freeall(void *buf, int flags);
 
 #endif // RUST_BUFFER_H


### PR DESCRIPTION
## Summary
- Track buffer allocations in Rust and expose `buf_freeall` wrapper
- Link `rust_buffer` library by default and expose interface in C header
- Enable Rust buffer feature via Makefile and Cargo configuration

## Testing
- `cargo check`
- `cargo test --manifest-path rust_buffer/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b6363c9c8c8320be182573974b5bc7