### PR TITLE
feat: port screen buffer diff to Rust

### DIFF
--- a/rust_screen/src/lib.rs
+++ b/rust_screen/src/lib.rs
@@ -1,5 +1,5 @@
 use libc::{c_char, c_int};
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::ptr;
 
 /// Safe representation of the Vim screen buffers.
@@ -8,6 +8,9 @@ pub struct ScreenBuffer {
     height: usize,
     lines: Vec<char>,
     attrs: Vec<u8>,
+    /// Previous frame used for diffing.
+    prev_lines: Vec<char>,
+    prev_attrs: Vec<u8>,
 }
 
 impl ScreenBuffer {
@@ -17,6 +20,8 @@ impl ScreenBuffer {
             height,
             lines: vec![' '; width * height],
             attrs: vec![0; width * height],
+            prev_lines: vec![' '; width * height],
+            prev_attrs: vec![0; width * height],
         }
     }
 
@@ -50,6 +55,32 @@ impl ScreenBuffer {
             .iter()
             .collect()
     }
+
+    /// Compute the difference with the previous frame.
+    pub fn flush_diff(&mut self) -> Vec<LineDiff> {
+        let mut diffs = Vec::new();
+        for row in 0..self.height {
+            let start = row * self.width;
+            let end = start + self.width;
+            if self.lines[start..end] != self.prev_lines[start..end]
+                || self.attrs[start..end] != self.prev_attrs[start..end]
+            {
+                let text: String = self.lines[start..end].iter().collect();
+                let attrs = self.attrs[start..end].to_vec();
+                self.prev_lines[start..end].copy_from_slice(&self.lines[start..end]);
+                self.prev_attrs[start..end].copy_from_slice(&self.attrs[start..end]);
+                diffs.push(LineDiff { row, text, attrs });
+            }
+        }
+        diffs
+    }
+}
+
+/// A single line update returned by [`ScreenBuffer::flush_diff`].
+pub struct LineDiff {
+    pub row: usize,
+    pub text: String,
+    pub attrs: Vec<u8>,
 }
 
 #[no_mangle]
@@ -94,6 +125,29 @@ pub extern "C" fn rs_screen_clear_line(buf: *mut ScreenBuffer, row: c_int, attr:
     screen.clear_line(row as usize, attr);
 }
 
+/// Callback used by [`rs_screen_flush`].
+pub type FlushCallback = extern "C" fn(row: c_int, text: *const c_char, attr: *const u8, len: c_int);
+
+#[no_mangle]
+pub extern "C" fn rs_screen_flush(buf: *mut ScreenBuffer, cb: Option<FlushCallback>) {
+    if buf.is_null() {
+        return;
+    }
+    if let Some(callback) = cb {
+        let screen = unsafe { &mut *buf };
+        for diff in screen.flush_diff() {
+            let c_text = CString::new(diff.text).unwrap();
+            // Callback is expected to copy the data immediately.
+            callback(
+                diff.row as c_int,
+                c_text.as_ptr(),
+                diff.attrs.as_ptr(),
+                diff.attrs.len() as c_int,
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,5 +173,29 @@ mod tests {
         // Print timing for performance measurement
         eprintln!("draw_text 1000x took {:?}", elapsed);
         assert!(elapsed.as_nanos() > 0);
+    }
+
+    #[test]
+    fn diff_terminal() {
+        let mut sb = ScreenBuffer::new(5, 2);
+        sb.draw_text(0, 0, "abc", 1);
+        let diff = sb.flush_diff();
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff[0].row, 0);
+        assert_eq!(diff[0].text, "abc  ");
+        sb.draw_text(0, 1, "d", 1);
+        let diff = sb.flush_diff();
+        assert_eq!(diff[0].text, "adc  ");
+    }
+
+    #[test]
+    fn diff_gui_attr() {
+        let mut sb = ScreenBuffer::new(5, 1);
+        sb.draw_text(0, 0, "ab", 1);
+        sb.flush_diff(); // consume
+        sb.draw_text(0, 0, "ab", 2); // change attrs only
+        let diff = sb.flush_diff();
+        assert_eq!(diff.len(), 1);
+        assert_eq!(diff[0].attrs[..2], [2, 2]);
     }
 }

--- a/src/screen_rs.h
+++ b/src/screen_rs.h
@@ -13,6 +13,8 @@ ScreenBuffer *rs_screen_new(int width, int height);
 void rs_screen_free(ScreenBuffer *buf);
 void rs_screen_draw_text(ScreenBuffer *buf, int row, int col, const char *text, uint8_t attr);
 void rs_screen_clear_line(ScreenBuffer *buf, int row, uint8_t attr);
+typedef void (*rs_flush_cb)(int row, const char *text, const uint8_t *attr, int len);
+void rs_screen_flush(ScreenBuffer *buf, rs_flush_cb cb);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- manage screen buffers and diffing in rust_screen
- delegate line clear and char draw in C screen code to Rust
- test diff updates for terminal and GUI attrs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6363d767c83209f05af2823e5e12f