### PR TITLE
Refactor window lifecycle to Rust

### DIFF
--- a/rust_window/src/lib.rs
+++ b/rust_window/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::os::raw::{c_int, c_void};
-use std::sync::Mutex;
+use std::sync::{atomic::{AtomicI32, Ordering}, Mutex};
 use once_cell::sync::Lazy;
 
 #[repr(C)]
@@ -11,27 +11,40 @@ pub struct WinState {
     pub height: c_int,
 }
 
+static NEXT_ID: AtomicI32 = AtomicI32::new(1);
 static WINDOWS: Lazy<Mutex<HashMap<usize, WinState>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[no_mangle]
 pub extern "C" fn rs_win_new(ptr: *mut c_void, width: c_int, height: c_int) {
+    if ptr.is_null() {
+        return;
+    }
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
     let mut windows = WINDOWS.lock().unwrap();
-    let id = (windows.len() as c_int) + 1;
     windows.insert(ptr as usize, WinState { id, width, height });
 }
 
 #[no_mangle]
 pub extern "C" fn rs_win_update(ptr: *mut c_void, width: c_int, height: c_int) {
-    let mut windows = WINDOWS.lock().unwrap();
-    if let Some(state) = windows.get_mut(&(ptr as usize)) {
-        state.width = width;
-        state.height = height;
+    if ptr.is_null() {
+        return;
     }
+    let mut windows = WINDOWS.lock().unwrap();
+    let entry = windows.entry(ptr as usize).or_insert_with(|| WinState {
+        id: NEXT_ID.fetch_add(1, Ordering::SeqCst),
+        width,
+        height,
+    });
+    entry.width = width;
+    entry.height = height;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_win_free(ptr: *mut c_void) {
+    if ptr.is_null() {
+        return;
+    }
     let mut windows = WINDOWS.lock().unwrap();
     windows.remove(&(ptr as usize));
 }
@@ -72,5 +85,40 @@ mod tests {
         assert_eq!(restored, saved);
         rs_win_free(new_ptr);
         unsafe { drop(Box::from_raw(new_ptr as *mut u8)); }
+    }
+
+    #[test]
+    fn complex_operations() {
+        let w1 = Box::into_raw(Box::new(0u8)) as *mut c_void;
+        rs_win_new(w1, 80, 24);
+
+        // simulate scrolling reducing available height and restoring it
+        rs_win_update(w1, 80, 20);
+        assert_eq!(rs_win_save(w1).height, 20);
+        rs_win_update(w1, 80, 24);
+
+        // split the window creating a second one
+        let w2 = Box::into_raw(Box::new(0u8)) as *mut c_void;
+        rs_win_new(w2, 80, 12);
+        rs_win_update(w1, 80, 12);
+        {
+            let windows = WINDOWS.lock().unwrap();
+            assert_eq!(windows.len(), 2);
+        }
+
+        // close the split window and resize the first back
+        rs_win_free(w2);
+        unsafe { drop(Box::from_raw(w2 as *mut u8)); }
+        rs_win_update(w1, 80, 24);
+        {
+            let windows = WINDOWS.lock().unwrap();
+            assert_eq!(windows.len(), 1);
+            let state = windows.get(&(w1 as usize)).unwrap();
+            assert_eq!(state.height, 24);
+        }
+
+        rs_win_free(w1);
+        unsafe { drop(Box::from_raw(w1 as *mut u8)); }
+        assert_eq!(WINDOWS.lock().unwrap().len(), 0);
     }
 }

--- a/src/window.c
+++ b/src/window.c
@@ -9,11 +9,9 @@
 
 #include "vim.h"
 
-#ifdef FEAT_RUST_WINDOW
 extern void rs_win_new(void *wp, int width, int height);
 extern void rs_win_update(void *wp, int width, int height);
 extern void rs_win_free(void *wp);
-#endif
 
 static void cmd_with_count(char *cmd, char_u *bufp, size_t bufsize, long Prenum);
 static void win_init(win_T *newp, win_T *oldp, int flags);
@@ -3498,9 +3496,7 @@ win_free_mem(
     frp = win->w_frame;
     wp = winframe_remove(win, dirp, tp, NULL);
     vim_free(frp);
-#ifdef FEAT_RUST_WINDOW
     rs_win_free(win);
-#endif
     win_free(win, tp);
 
     // When deleting the current window in the tab, select a new current
@@ -5800,9 +5796,7 @@ win_alloc(win_T *after, int hidden)
 
     new_wp->w_id = ++last_win_id;
 
-#ifdef FEAT_RUST_WINDOW
     rs_win_new(new_wp, new_wp->w_width, new_wp->w_height);
-#endif
 
 #ifdef FEAT_EVAL
     // init w: variables
@@ -7225,9 +7219,7 @@ win_new_height(win_T *wp, int height)
         wp->w_skipcol = 0;
         scroll_to_fraction(wp, prev_height);
     }
-#ifdef FEAT_RUST_WINDOW
     rs_win_update(wp, wp->w_width, wp->w_height);
-#endif
 }
 
     void
@@ -7365,9 +7357,7 @@ win_new_width(win_T *wp, int width)
 
     redraw_win_later(wp, UPD_NOT_VALID);
     wp->w_redr_status = TRUE;
-#ifdef FEAT_RUST_WINDOW
     rs_win_update(wp, wp->w_width, wp->w_height);
-#endif
 }
 
     void


### PR DESCRIPTION
## Summary
- manage window creation, resizing, and teardown in Rust with unique IDs
- call Rust window hooks from C for all lifecycle events
- cover split and resize sequences with new tests

## Testing
- `cargo test` in `rust_window`
- `make -j4` *(fails: Makefile:1459: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b6364267708320a1f42719cd3cea83