### PR TITLE
Port quickfix list handling to Rust

### DIFF
--- a/src/feature.h
+++ b/src/feature.h
@@ -83,9 +83,7 @@
 
 // Enable the Rust implementation of memline by default.
 #define USE_RUST_MEMLINE
-// Enable the Rust implementation of quickfix by default.
-#define USE_RUST_QUICKFIX
-
+// Quickfix list handled in Rust; no C fallback remains.
 // Enable Rust implementations for syntax highlighting helpers.
 #define USE_RUST_SYNTAX
 

--- a/src/quickfix.c
+++ b/src/quickfix.c
@@ -198,13 +198,14 @@ static buf_T	*load_dummy_buffer(char_u *fname, char_u *dirname_start, char_u *re
 static void	wipe_dummy_buffer(buf_T *buf, char_u *dirname_start);
 static void	unload_dummy_buffer(buf_T *buf, char_u *dirname_start);
 static qf_info_T *ll_get_or_alloc_list(win_T *);
-#ifdef USE_RUST_QUICKFIX
+
+// Rust quickfix FFI
+extern void rs_qf_new_list(void);
 extern int rs_qf_add_entry(void *qfl, const char *dir, const char *fname,
         const char *module, int bufnum, const char *mesg, long lnum,
         long end_lnum, int col, int end_col, int vis_col, const char *pattern,
         int nr, int type, typval_T *user_data, int valid);
 extern void rs_qf_list(void *eap);
-#endif
 static int	entry_is_closer_to_target(qfline_T *entry, qfline_T *other_entry, int target_fnum, int target_lnum, int target_col);
 
 // Quickfix window check helper macro
@@ -2009,6 +2010,7 @@ qf_pop_stack(qf_info_T *qi, int adjust)
     static void
 qf_new_list(qf_info_T *qi, char_u *qf_title)
 {
+    rs_qf_new_list();
     qf_list_T	*qfl;
 
     // If the current entry is not the last entry, delete entries beyond
@@ -2230,131 +2232,29 @@ check_quickfix_busy(void)
  * Add an entry to the end of the list of errors.
  * Returns QF_OK on success or QF_FAIL on a memory allocation failure.
  */
-    static int
+static int
 qf_add_entry(
-    qf_list_T	*qfl,		// quickfix list entry
-    char_u	*dir,		// optional directory name
-    char_u	*fname,		// file name or NULL
-    char_u	*module,	// module name or NULL
-    int		bufnum,		// buffer number or zero
-    char_u	*mesg,		// message
-    long	lnum,		// line number
-    long	end_lnum,	// line number for end
-    int		col,		// column
-    int		end_col,	// column for end
-    int		vis_col,	// using visual column
-    char_u	*pattern,	// search pattern
-    int		nr,		// error number
-    int		type,		// type character
-    typval_T	*user_data,     // custom user data or NULL
-    int		valid)		// valid entry
+    qf_list_T   *qfl,
+    char_u      *dir,
+    char_u      *fname,
+    char_u      *module,
+    int         bufnum,
+    char_u      *mesg,
+    long        lnum,
+    long        end_lnum,
+    int         col,
+    int         end_col,
+    int         vis_col,
+    char_u      *pattern,
+    int         nr,
+    int         type,
+    typval_T    *user_data,
+    int         valid)
 {
-#ifdef USE_RUST_QUICKFIX
-    return rs_qf_add_entry((void *)qfl, (char *)dir, (char *)fname,
-            (char *)module, bufnum, (char *)mesg, lnum, end_lnum, col,
-            end_col, vis_col, (char *)pattern, nr, type, user_data, valid);
-#else
-    buf_T	*buf;
-    qfline_T	*qfp;
-    qfline_T	**lastp;	// pointer to qf_last or NULL
-    char_u	*fullname = NULL;
-    char_u	*p = NULL;
-
-    if ((qfp = ALLOC_ONE_ID(qfline_T, aid_qf_qfline)) == NULL)
-	return QF_FAIL;
-    if (bufnum != 0)
-    {
-	buf = buflist_findnr(bufnum);
-
-	qfp->qf_fnum = bufnum;
-	if (buf != NULL)
-	    buf->b_has_qf_entry |=
-		IS_QF_LIST(qfl) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
-    }
-    else
-    {
-	qfp->qf_fnum = qf_get_fnum(qfl, dir, fname);
-	buf = buflist_findnr(qfp->qf_fnum);
-    }
-    if (fname != NULL)
-	fullname = fix_fname(fname);
-    qfp->qf_fname = NULL;
-    if (buf != NULL &&
-	buf->b_ffname != NULL && fullname != NULL)
-    {
-	if (fnamecmp(fullname, buf->b_ffname) != 0)
-	{
-	    p = shorten_fname1(fullname);
-	    if (p != NULL)
-		qfp->qf_fname = vim_strsave(p);
-	}
-    }
-    vim_free(fullname);
-    if ((qfp->qf_text = vim_strsave(mesg)) == NULL)
-    {
-	vim_free(qfp);
-	return QF_FAIL;
-    }
-    qfp->qf_lnum = lnum;
-    qfp->qf_end_lnum = end_lnum;
-    qfp->qf_col = col;
-    qfp->qf_end_col = end_col;
-    qfp->qf_viscol = vis_col;
-    if (user_data == NULL || user_data->v_type == VAR_UNKNOWN)
-	qfp->qf_user_data.v_type = VAR_UNKNOWN;
-    else
-    {
-	copy_tv(user_data, &qfp->qf_user_data);
-	qfl->qf_has_user_data = TRUE;
-    }
-    if (pattern == NULL || *pattern == NUL)
-	qfp->qf_pattern = NULL;
-    else if ((qfp->qf_pattern = vim_strsave(pattern)) == NULL)
-    {
-	vim_free(qfp->qf_text);
-	vim_free(qfp);
-	return QF_FAIL;
-    }
-    if (module == NULL || *module == NUL)
-	qfp->qf_module = NULL;
-    else if ((qfp->qf_module = vim_strsave(module)) == NULL)
-    {
-	vim_free(qfp->qf_text);
-	vim_free(qfp->qf_pattern);
-	vim_free(qfp);
-	return QF_FAIL;
-    }
-    qfp->qf_nr = nr;
-    if (type != 1 && !vim_isprintc(type)) // only printable chars allowed
-	type = 0;
-    qfp->qf_type = type;
-    qfp->qf_valid = valid;
-
-    lastp = &qfl->qf_last;
-    if (qf_list_empty(qfl))		// first element in the list
-    {
-	qfl->qf_start = qfp;
-	qfl->qf_ptr = qfp;
-	qfl->qf_index = 0;
-	qfp->qf_prev = NULL;
-    }
-    else
-    {
-	qfp->qf_prev = *lastp;
-	(*lastp)->qf_next = qfp;
-    }
-    qfp->qf_next = NULL;
-    qfp->qf_cleared = FALSE;
-    *lastp = qfp;
-    ++qfl->qf_count;
-    if (qfl->qf_index == 0 && qfp->qf_valid)	// first valid entry
-    {
-	qfl->qf_index = qfl->qf_count;
-	qfl->qf_ptr = qfp;
-    }
-
-    return QF_OK;
-#endif
+    return rs_qf_add_entry((void *)qfl, (const char *)dir, (const char *)fname,
+            (const char *)module, bufnum, (const char *)mesg, lnum, end_lnum,
+            col, end_col, vis_col, (const char *)pattern, nr, type, user_data,
+            valid);
 }
 
 /*
@@ -4037,83 +3937,9 @@ qf_list_entry(qfline_T *qfp, int qf_idx, int cursel)
  * ":clist": list all errors
  * ":llist": list all locations
  */
-    void
-qf_list(exarg_T *eap)
+void qf_list(exarg_T *eap)
 {
-#ifdef USE_RUST_QUICKFIX
     rs_qf_list((void *)eap);
-    return;
-#endif
-    qf_list_T	*qfl;
-    qfline_T	*qfp;
-    int		i;
-    int		idx1 = 1;
-    int		idx2 = -1;
-    char_u	*arg = eap->arg;
-    int		plus = FALSE;
-    int		all = eap->forceit;	// if not :cl!, only show
-					// recognised errors
-    qf_info_T	*qi;
-
-    if ((qi = qf_cmd_get_stack(eap, TRUE)) == NULL)
-	return;
-
-    if (qf_stack_empty(qi) || qf_list_empty(qf_get_curlist(qi)))
-    {
-	emsg(_(e_no_errors));
-	return;
-    }
-    if (*arg == '+')
-    {
-	++arg;
-	plus = TRUE;
-    }
-    if (!get_list_range(&arg, &idx1, &idx2) || *arg != NUL)
-    {
-	semsg(_(e_trailing_characters_str), arg);
-	return;
-    }
-    qfl = qf_get_curlist(qi);
-    if (plus)
-    {
-	i = qfl->qf_index;
-	idx2 = i + idx1;
-	idx1 = i;
-    }
-    else
-    {
-	i = qfl->qf_count;
-	if (idx1 < 0)
-	    idx1 = (-idx1 > i) ? 0 : idx1 + i + 1;
-	if (idx2 < 0)
-	    idx2 = (-idx2 > i) ? 0 : idx2 + i + 1;
-    }
-
-    // Shorten all the file names, so that it is easy to read
-    shorten_fnames(FALSE);
-
-    // Get the attributes for the different quickfix highlight items.  Note
-    // that this depends on syntax items defined in the qf.vim syntax file
-    qfFileAttr = syn_name2attr((char_u *)"qfFileName");
-    if (qfFileAttr == 0)
-	qfFileAttr = HL_ATTR(HLF_D);
-    qfSepAttr = syn_name2attr((char_u *)"qfSeparator");
-    if (qfSepAttr == 0)
-	qfSepAttr = HL_ATTR(HLF_D);
-    qfLineAttr = syn_name2attr((char_u *)"qfLineNr");
-    if (qfLineAttr == 0)
-	qfLineAttr = HL_ATTR(HLF_N);
-
-    if (qfl->qf_nonevalid)
-	all = TRUE;
-    FOR_ALL_QFL_ITEMS(qfl, qfp, i)
-    {
-	if ((qfp->qf_valid || all) && idx1 <= i && i <= idx2)
-	    qf_list_entry(qfp, i, i == qfl->qf_index);
-
-	ui_breakcheck();
-    }
-    qfga_clear();
 }
 
 /*


### PR DESCRIPTION
## Summary
- implement basic quickfix list creation and management in Rust
- expose FFI hooks and remove C fallbacks for quickfix routines
- drop `USE_RUST_QUICKFIX` build guard

## Testing
- `cargo test -- --test-threads=1` in `rust_quickfix`


------
https://chatgpt.com/codex/tasks/task_e_68b63cd957e08320bf5bfc54939db9d9