### PR TITLE
feat: move message rendering to rust

### DIFF
--- a/rust_message/src/lib.rs
+++ b/rust_message/src/lib.rs
@@ -1,5 +1,6 @@
 use libc::{c_char, c_int, malloc, free};
 use std::ffi::CStr;
+use std::io::{self, Write};
 use std::ptr;
 
 #[repr(C)]
@@ -124,6 +125,18 @@ pub unsafe extern "C" fn rs_check_msg_hist() {
     while msg_hist_len > 0 && msg_hist_len > msg_hist_max {
         rs_delete_first_msg();
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_render_msg(s: *const c_char, attr: c_int) {
+    if s.is_null() {
+        return;
+    }
+    let cstr = CStr::from_ptr(s);
+    let bytes = cstr.to_bytes();
+    let formatted = format_with_attr(bytes, attr);
+    let _ = io::stdout().write_all(&formatted[..formatted.len() - 1]);
+    let _ = io::stdout().flush();
 }
 
 #[cfg(test)]

--- a/src/message.c
+++ b/src/message.c
@@ -17,6 +17,7 @@
 extern void rs_add_msg_hist(char_u *s, int len, int attr);
 extern int rs_delete_first_msg(void);
 extern void rs_check_msg_hist(void);
+extern void rs_render_msg(char_u *s, int attr);
 
 static void hit_return_msg(void);
 static void msg_home_replace_attr(char_u *fname, int attr);
@@ -190,9 +191,8 @@ msg_attr_keep(
     if (buf != NULL)
 	s = (char *)buf;
 
-    msg_outtrans_attr((char_u *)s, attr);
-    msg_clr_eos();
-    retval = msg_end();
+    rs_render_msg((char_u *)s, attr);
+    retval = TRUE;
 
     if (keep && retval && vim_strsize((char_u *)s)
 			    < (int)(Rows - cmdline_row - 1) * Columns + sc_col)


### PR DESCRIPTION
## Summary
- add `rs_render_msg` for rendering messages with attributes in Rust
- route `msg_attr_keep` through Rust FFI for message display

## Testing
- `cargo test` in `rust_message`
- `make -C src run_message_test` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b63cd1eaa08320b8f2aa648b90864d