### PR TITLE
Implement Blowfish crypto in Rust

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1457,10 +1457,10 @@ $(RUST_MEM_LIB):
 	cd $(RUST_MEM_DIR) && cargo build --release
 
 $(RUST_REGEX_LIB):
-        cd $(RUST_REGEX_DIR) && cargo build --release
+	cd $(RUST_REGEX_DIR) && cargo build --release
 
 $(RUST_BUFFER_LIB):
-        cd $(RUST_BUFFER_DIR) && cargo build --release
+	cd $(RUST_BUFFER_DIR) && cargo build --release
 
 $(RUST_CHANNEL_LIB):
 	cd $(RUST_CHANNEL_DIR) && cargo build --release

--- a/src/blowfish.c
+++ b/src/blowfish.c
@@ -22,7 +22,13 @@
 
 #include "vim.h"
 
-#if defined(FEAT_CRYPT) || defined(PROTO)
+/*
+ * This file implements the Blowfish cipher in C.  It is kept for
+ * backwards compatibility but is deprecated when the Rust based crypto
+ * implementation is available.  When FEAT_RUST_CRYPT is defined the
+ * Rust code provides the Blowfish routines and this file becomes empty.
+ */
+#if (defined(FEAT_CRYPT) && !defined(FEAT_RUST_CRYPT)) || defined(PROTO)
 
 #define BF_BLOCK    8
 #define BF_BLOCK_MASK 7
@@ -683,4 +689,4 @@ blowfish_self_test(void)
     }
     return OK;
 }
-#endif // FEAT_CRYPT
+#endif // (FEAT_CRYPT && !FEAT_RUST_CRYPT) || PROTO

--- a/src/crypt.c
+++ b/src/crypt.c
@@ -88,6 +88,8 @@ static void crypt_sodium_report_hash_params(unsigned long long opslimit, unsigne
 #endif
 
 #ifdef FEAT_RUST_CRYPT
+// Blowfish and other crypt methods implemented in Rust; see
+// src/rust/crypto/core.
 extern cryptmethod_T *rust_crypt_methods(void);
 # define cryptmethods rust_crypt_methods()
 #else

--- a/src/proto/blowfish.pro
+++ b/src/proto/blowfish.pro
@@ -1,6 +1,8 @@
 /* blowfish.c */
+#if !defined(FEAT_RUST_CRYPT)
 void crypt_blowfish_encode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
 void crypt_blowfish_decode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
 int crypt_blowfish_init(cryptstate_T *state, char_u *key, crypt_arg_T *arg);
 int blowfish_self_test(void);
+#endif
 /* vim: set ft=c : */

--- a/src/rust/crypto/core/src/lib.rs
+++ b/src/rust/crypto/core/src/lib.rs
@@ -1,10 +1,10 @@
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
+use std::slice;
 
-use blowfish::cipher::{BlockDecrypt, BlockEncrypt, NewBlockCipher};
-use blowfish::cipher::generic_array::GenericArray;
+use blowfish::cipher::{generic_array::GenericArray, BlockEncrypt, NewBlockCipher};
 use blowfish::Blowfish;
-use ring::digest::{digest, SHA256};
+use ring::digest::{Context, SHA256};
 
 #[repr(C)]
 pub struct cryptstate_T {
@@ -12,69 +12,198 @@ pub struct cryptstate_T {
     pub method_state: *mut c_void,
 }
 
+#[repr(C)]
+pub struct crypt_arg_T {
+    pub cat_salt: *mut u8,
+    pub cat_salt_len: c_int,
+    pub cat_seed: *mut u8,
+    pub cat_seed_len: c_int,
+    pub cat_add: *mut u8,
+    pub cat_add_len: c_int,
+    pub cat_init_from_file: c_int,
+}
+
+const CRYPT_M_BF: c_int = 1;
+const CRYPT_M_BF2: c_int = 2;
+
 struct BlowfishState {
     cipher: Blowfish,
+    cfb: [u8; 64],
+    cfb_len: usize,
+    randbyte_offset: usize,
+    update_offset: usize,
+}
+
+impl BlowfishState {
+    fn randbyte(&mut self) -> u8 {
+        if (self.randbyte_offset & 7) == 0 {
+            let start = self.randbyte_offset;
+            let mut block = GenericArray::clone_from_slice(&self.cfb[start..start + 8]);
+            self.cipher.encrypt_block(&mut block);
+            self.cfb[start..start + 8].copy_from_slice(&block);
+        }
+        let t = self.cfb[self.randbyte_offset];
+        self.randbyte_offset += 1;
+        if self.randbyte_offset == self.cfb_len {
+            self.randbyte_offset = 0;
+        }
+        t
+    }
+
+    fn cfb_update(&mut self, c: u8) {
+        self.cfb[self.update_offset] ^= c;
+        self.update_offset += 1;
+        if self.update_offset == self.cfb_len {
+            self.update_offset = 0;
+        }
+    }
+}
+
+fn sha256_hex(data: &[u8], salt: &[u8]) -> String {
+    let mut ctx = Context::new(&SHA256);
+    ctx.update(data);
+    if !salt.is_empty() {
+        ctx.update(salt);
+    }
+    let digest = ctx.finish();
+    let mut s = String::with_capacity(64);
+    for b in digest.as_ref() {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for i in (0..s.len()).step_by(2) {
+        let byte = u8::from_str_radix(&s[i..i + 2], 16).unwrap();
+        out.push(byte);
+    }
+    out
+}
+
+fn derive_key(password: &[u8], salt: &[u8]) -> Vec<u8> {
+    let mut key = sha256_hex(password, salt);
+    for _ in 0..1000 {
+        key = sha256_hex(key.as_bytes(), salt);
+    }
+    hex_to_bytes(&key)
+}
+
+fn cfb_init(state: &mut BlowfishState, seed: &[u8]) {
+    state.cfb.fill(0);
+    state.randbyte_offset = 0;
+    state.update_offset = 0;
+    if !seed.is_empty() {
+        let mi = std::cmp::max(seed.len(), state.cfb_len);
+        for i in 0..mi {
+            let idx = i % state.cfb_len;
+            state.cfb[idx] ^= seed[i % seed.len()];
+        }
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn crypt_blowfish_init(state: *mut cryptstate_T, key: *const c_char, _arg: *mut c_void) -> c_int {
-    if state.is_null() || key.is_null() {
+pub extern "C" fn crypt_blowfish_init(
+    state: *mut cryptstate_T,
+    key: *const c_char,
+    arg: *mut crypt_arg_T,
+) -> c_int {
+    if state.is_null() || key.is_null() || arg.is_null() {
         return 0;
     }
+
     let key_slice = unsafe { CStr::from_ptr(key).to_bytes() };
-    let digest = digest(&SHA256, key_slice);
-    let key_bytes = &digest.as_ref()[0..16];
-    let cipher = Blowfish::new_from_slice(key_bytes).unwrap();
-    let boxed = Box::new(BlowfishState { cipher });
+    let arg = unsafe { &*arg };
+    let salt = unsafe { slice::from_raw_parts(arg.cat_salt, arg.cat_salt_len as usize) };
+    let seed = unsafe { slice::from_raw_parts(arg.cat_seed, arg.cat_seed_len as usize) };
+
+    let key_bytes = derive_key(key_slice, salt);
+    let cipher = match Blowfish::new_from_slice(&key_bytes) {
+        Ok(c) => c,
+        Err(_) => return 0,
+    };
+    let cfb_len = if unsafe { (*state).method_nr } == CRYPT_M_BF {
+        64
+    } else {
+        8
+    };
+    let mut st = BlowfishState {
+        cipher,
+        cfb: [0u8; 64],
+        cfb_len,
+        randbyte_offset: 0,
+        update_offset: 0,
+    };
+    cfb_init(&mut st, seed);
     unsafe {
-        (*state).method_state = Box::into_raw(boxed) as *mut c_void;
+        (*state).method_state = Box::into_raw(Box::new(st)) as *mut c_void;
     }
     1
 }
 
 #[no_mangle]
-pub extern "C" fn crypt_blowfish_encode(state: *mut cryptstate_T, from: *const u8, len: usize, to: *mut u8, _last: c_int) {
+pub extern "C" fn crypt_blowfish_encode(
+    state: *mut cryptstate_T,
+    from: *const u8,
+    len: usize,
+    to: *mut u8,
+    _last: c_int,
+) {
     if state.is_null() || from.is_null() || to.is_null() {
         return;
     }
     let st = unsafe { &mut *(*state).method_state.cast::<BlowfishState>() };
-    let mut data = unsafe { std::slice::from_raw_parts(from, len).to_vec() };
-    for chunk in data.chunks_mut(8) {
-        if chunk.len() == 8 {
-            let mut block = GenericArray::from_mut_slice(chunk);
-            st.cipher.encrypt_block(&mut block);
-        }
+    for i in 0..len {
+        let ztemp = unsafe { *from.add(i) };
+        let t = st.randbyte();
+        st.cfb_update(ztemp);
+        unsafe { *to.add(i) = t ^ ztemp };
     }
-    unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), to, len); }
 }
 
 #[no_mangle]
-pub extern "C" fn crypt_blowfish_decode(state: *mut cryptstate_T, from: *const u8, len: usize, to: *mut u8, _last: c_int) {
+pub extern "C" fn crypt_blowfish_decode(
+    state: *mut cryptstate_T,
+    from: *const u8,
+    len: usize,
+    to: *mut u8,
+    _last: c_int,
+) {
     if state.is_null() || from.is_null() || to.is_null() {
         return;
     }
     let st = unsafe { &mut *(*state).method_state.cast::<BlowfishState>() };
-    let mut data = unsafe { std::slice::from_raw_parts(from, len).to_vec() };
-    for chunk in data.chunks_mut(8) {
-        if chunk.len() == 8 {
-            let mut block = GenericArray::from_mut_slice(chunk);
-            st.cipher.decrypt_block(&mut block);
-        }
+    for i in 0..len {
+        let t = st.randbyte();
+        let val = unsafe { *from.add(i) } ^ t;
+        st.cfb_update(val);
+        unsafe { *to.add(i) = val };
     }
-    unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), to, len); }
 }
 
 #[no_mangle]
-pub extern "C" fn crypt_blowfish_encode_inplace(state: *mut cryptstate_T, buf: *mut u8, len: usize, _p2: *mut u8, last: c_int) {
+pub extern "C" fn crypt_blowfish_encode_inplace(
+    state: *mut cryptstate_T,
+    buf: *mut u8,
+    len: usize,
+    _p2: *mut u8,
+    last: c_int,
+) {
     crypt_blowfish_encode(state, buf as *const u8, len, buf, last);
 }
 
 #[no_mangle]
-pub extern "C" fn crypt_blowfish_decode_inplace(state: *mut cryptstate_T, buf: *mut u8, len: usize, _p2: *mut u8, last: c_int) {
+pub extern "C" fn crypt_blowfish_decode_inplace(
+    state: *mut cryptstate_T,
+    buf: *mut u8,
+    len: usize,
+    _p2: *mut u8,
+    last: c_int,
+) {
     crypt_blowfish_decode(state, buf as *const u8, len, buf, last);
 }
 
-// Representation of cryptmethod_T from the C side
 #[repr(C)]
 pub struct cryptmethod_T {
     pub name: *const c_char,
@@ -85,13 +214,18 @@ pub struct cryptmethod_T {
     pub works_inplace: c_int,
     pub whole_undofile: c_int,
     pub self_test_fn: Option<extern "C" fn() -> c_int>,
-    pub init_fn: Option<extern "C" fn(*mut cryptstate_T, *const c_char, *mut c_void) -> c_int>,
+    pub init_fn:
+        Option<extern "C" fn(*mut cryptstate_T, *const c_char, *mut crypt_arg_T) -> c_int>,
     pub encode_fn: Option<extern "C" fn(*mut cryptstate_T, *const u8, usize, *mut u8, c_int)>,
     pub decode_fn: Option<extern "C" fn(*mut cryptstate_T, *const u8, usize, *mut u8, c_int)>,
-    pub encode_buffer_fn: Option<extern "C" fn(*mut cryptstate_T, *const u8, usize, *mut *mut u8, c_int) -> i64>,
-    pub decode_buffer_fn: Option<extern "C" fn(*mut cryptstate_T, *const u8, usize, *mut *mut u8, c_int) -> i64>,
-    pub encode_inplace_fn: Option<extern "C" fn(*mut cryptstate_T, *mut u8, usize, *mut u8, c_int)>,
-    pub decode_inplace_fn: Option<extern "C" fn(*mut cryptstate_T, *mut u8, usize, *mut u8, c_int)>,
+    pub encode_buffer_fn:
+        Option<extern "C" fn(*mut cryptstate_T, *const u8, usize, *mut *mut u8, c_int) -> i64>,
+    pub decode_buffer_fn:
+        Option<extern "C" fn(*mut cryptstate_T, *const u8, usize, *mut *mut u8, c_int) -> i64>,
+    pub encode_inplace_fn:
+        Option<extern "C" fn(*mut cryptstate_T, *mut u8, usize, *mut u8, c_int)>,
+    pub decode_inplace_fn:
+        Option<extern "C" fn(*mut cryptstate_T, *mut u8, usize, *mut u8, c_int)>,
 }
 
 unsafe impl Sync for cryptmethod_T {}
@@ -203,17 +337,31 @@ pub extern "C" fn rust_crypt_methods() -> *mut cryptmethod_T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
 
     #[test]
     fn blowfish_roundtrip() {
-        let mut state = cryptstate_T { method_nr: 0, method_state: std::ptr::null_mut() };
-        let key = std::ffi::CString::new("test").unwrap();
-        assert_eq!(1, crypt_blowfish_init(&mut state, key.as_ptr(), std::ptr::null_mut()));
+        let key = CString::new("test").unwrap();
+        let salt = b"12345678";
+        let seed = b"abcdefgh";
+        let mut arg = crypt_arg_T {
+            cat_salt: salt.as_ptr() as *mut u8,
+            cat_salt_len: salt.len() as c_int,
+            cat_seed: seed.as_ptr() as *mut u8,
+            cat_seed_len: seed.len() as c_int,
+            cat_add: std::ptr::null_mut(),
+            cat_add_len: 0,
+            cat_init_from_file: 0,
+        };
+        let mut state_enc = cryptstate_T { method_nr: CRYPT_M_BF2, method_state: std::ptr::null_mut() };
+        assert_eq!(1, crypt_blowfish_init(&mut state_enc, key.as_ptr(), &mut arg));
         let data = b"hello world";
         let mut enc = vec![0u8; data.len()];
+        crypt_blowfish_encode(&mut state_enc, data.as_ptr(), data.len(), enc.as_mut_ptr(), 1);
+        let mut state_dec = cryptstate_T { method_nr: CRYPT_M_BF2, method_state: std::ptr::null_mut() };
+        assert_eq!(1, crypt_blowfish_init(&mut state_dec, key.as_ptr(), &mut arg));
         let mut dec = vec![0u8; data.len()];
-        crypt_blowfish_encode(&mut state, data.as_ptr(), data.len(), enc.as_mut_ptr(), 1);
-        crypt_blowfish_decode(&mut state, enc.as_ptr(), enc.len(), dec.as_mut_ptr(), 1);
+        crypt_blowfish_decode(&mut state_dec, enc.as_ptr(), enc.len(), dec.as_mut_ptr(), 1);
         assert_eq!(data.to_vec(), dec);
     }
 }


### PR DESCRIPTION
## Summary
- Implement Blowfish and Blowfish2 in Rust with RustCrypto, providing C-compatible wrappers
- Use the Rust implementation from `crypt.c` and guard the legacy C version
- Adjust build rules for Rust components

## Testing
- `cargo test --manifest-path src/rust/crypto/core/Cargo.toml`
- `make -j4` *(fails: No rule to make target 'diff.c')*


------
https://chatgpt.com/codex/tasks/task_e_68b63cd0de948320afc96b37bb65e0d7