### PR TITLE
Add Rust-based spell checker with FFI integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_spell"
+version = "0.1.0"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,10 +177,6 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
-
-[[package]]
-name = "spell"
-version = "0.1.0"
 
 [[package]]
 name = "syn"
@@ -230,7 +230,7 @@ version = "0.1.0"
 dependencies = [
  "diff",
  "rust_buffer",
- "spell",
+ "rust_spell",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["net", "time", "macros", "io-util", "rt"] }
-spell = { path = "rust/spell" }
+rust_spell = { path = "rust/spell" }
 diff = { path = "rust/diff" }
 rust_buffer = { path = "rust_buffer" }
 

--- a/rust/spell/Cargo.lock
+++ b/rust/spell/Cargo.lock
@@ -3,5 +3,5 @@
 version = 4
 
 [[package]]
-name = "spell"
+name = "rust_spell"
 version = "0.1.0"

--- a/rust/spell/Cargo.toml
+++ b/rust/spell/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spell"
+name = "rust_spell"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust/spell/src/lib.rs
+++ b/rust/spell/src/lib.rs
@@ -1,8 +1,169 @@
-use std::os::raw::{c_int, c_uchar};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::os::raw::{c_char, c_int, c_uchar};
+use std::sync::{Mutex, OnceLock};
 
 const WF_ONECAP: c_int = 0x02;
 const WF_ALLCAP: c_int = 0x04;
 const WF_KEEPCAP: c_int = 0x80;
+
+#[derive(Default)]
+struct TrieNode {
+    children: HashMap<char, TrieNode>,
+    end: bool,
+}
+
+#[derive(Default)]
+struct Trie {
+    root: TrieNode,
+    words: Vec<String>,
+}
+
+impl Trie {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&mut self, word: &str) {
+        let mut node = &mut self.root;
+        for ch in word.chars() {
+            node = node.children.entry(ch).or_insert_with(TrieNode::default);
+        }
+        if !node.end {
+            node.end = true;
+            self.words.push(word.to_string());
+        }
+    }
+
+    fn contains(&self, word: &str) -> bool {
+        let mut node = &self.root;
+        for ch in word.chars() {
+            match node.children.get(&ch) {
+                Some(next) => node = next,
+                None => return false,
+            }
+        }
+        node.end
+    }
+
+    fn load_from_file(&mut self, path: &str) -> bool {
+        if let Ok(file) = File::open(path) {
+            let reader = BufReader::new(file);
+            for line in reader.lines().flatten() {
+                let word = line.trim();
+                if !word.is_empty() {
+                    self.insert(word);
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn save_to_file(&self, path: &str) -> bool {
+        if let Ok(mut file) = File::create(path) {
+            for w in &self.words {
+                if writeln!(file, "{}", w).is_err() {
+                    return false;
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn suggestions(&self, word: &str, max: usize) -> Vec<String> {
+        let mut items: Vec<(usize, &String)> = self
+            .words
+            .iter()
+            .map(|w| (levenshtein(w, word), w))
+            .collect();
+        items.sort_by_key(|(d, _)| *d);
+        items
+            .into_iter()
+            .take(max)
+            .map(|(_, w)| w.clone())
+            .collect()
+    }
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let mut costs: Vec<usize> = (0..=b.chars().count()).collect();
+    for (i, ca) in a.chars().enumerate() {
+        let mut last = i;
+        costs[0] = i + 1;
+        for (j, cb) in b.chars().enumerate() {
+            let new = if ca == cb { last } else { last + 1 };
+            last = costs[j + 1];
+            costs[j + 1] = std::cmp::min(std::cmp::min(costs[j] + 1, costs[j + 1] + 1), new);
+        }
+    }
+    costs[b.chars().count()]
+}
+
+static TRIE: OnceLock<Mutex<Trie>> = OnceLock::new();
+
+fn trie() -> &'static Mutex<Trie> {
+    TRIE.get_or_init(|| Mutex::new(Trie::new()))
+}
+
+#[no_mangle]
+pub extern "C" fn rs_spell_load_dictionary(path: *const c_char) -> bool {
+    if path.is_null() {
+        return false;
+    }
+    let c_str = unsafe { CStr::from_ptr(path) };
+    if let Ok(p) = c_str.to_str() {
+        let mut trie = trie().lock().unwrap();
+        trie.load_from_file(p)
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_spell_check(word: *const c_char) -> bool {
+    if word.is_null() {
+        return false;
+    }
+    let c_str = unsafe { CStr::from_ptr(word) };
+    if let Ok(w) = c_str.to_str() {
+        let trie = trie().lock().unwrap();
+        trie.contains(w)
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_spell_best_suggestion(word: *const c_char) -> *mut c_char {
+    if word.is_null() {
+        return std::ptr::null_mut();
+    }
+    let c_str = unsafe { CStr::from_ptr(word) };
+    if let Ok(w) = c_str.to_str() {
+        let trie = trie().lock().unwrap();
+        if let Some(sug) = trie.suggestions(w, 1).get(0) {
+            if let Ok(c) = CString::new(sug.as_str()) {
+                return c.into_raw();
+            }
+        }
+    }
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_spell_free_cstring(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe {
+            CString::from_raw(s);
+        };
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn captype(word: *const c_uchar, end: *const c_uchar) -> c_int {
@@ -12,13 +173,14 @@ pub extern "C" fn captype(word: *const c_uchar, end: *const c_uchar) -> c_int {
     unsafe {
         let len = if end.is_null() {
             let mut l = 0;
-            while *word.add(l) != 0 { l += 1; }
+            while *word.add(l) != 0 {
+                l += 1;
+            }
             l
         } else {
             end.offset_from(word) as usize
         };
         let bytes = std::slice::from_raw_parts(word, len);
-        // Find first alphabetic character
         let mut idx = 0;
         while idx < bytes.len() && !bytes[idx].is_ascii_alphabetic() {
             idx += 1;
@@ -73,4 +235,21 @@ mod tests {
         let w = CString::new("vIM").unwrap();
         assert_eq!(captype(w.as_ptr() as *const u8, std::ptr::null()), WF_KEEPCAP);
     }
+
+    #[test]
+    fn multilang_lookup_and_suggest() {
+        let mut t = Trie::new();
+        t.insert("hello");
+        t.insert("hola");
+        t.insert("bonjour");
+        t.insert("こんにちは");
+
+        assert!(t.contains("hola"));
+        assert!(t.contains("こんにちは"));
+        assert!(!t.contains("adios"));
+
+        let sug = t.suggestions("bonjor", 2);
+        assert!(sug.contains(&"bonjour".to_string()));
+    }
 }
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -1411,6 +1411,8 @@ RUST_BUFFER_DIR = ../rust_buffer
 RUST_BUFFER_LIB = $(RUST_BUFFER_DIR)/target/release/librust_buffer.a
 RUST_CHANNEL_DIR = ../rust_channel
 RUST_CHANNEL_LIB = $(RUST_CHANNEL_DIR)/target/release/librust_channel.a
+RUST_SPELL_DIR = ../rust/spell
+RUST_SPELL_LIB = $(RUST_SPELL_DIR)/target/release/librust_spell.a
 
 # Note: MZSCHEME_LIBS must come before LIBS, because LIBS adds -lm which is
 # needed by racket.
@@ -1429,6 +1431,7 @@ ALL_LIBS = \
            $(RUST_MEM_LIB) \
            $(RUST_BUFFER_LIB) \
            $(RUST_CHANNEL_LIB) \
+           $(RUST_SPELL_LIB) \
            $(LUA_LIBS) \
            $(PERL_LIBS) \
            $(PYTHON_LIBS) \
@@ -1463,7 +1466,10 @@ $(RUST_BUFFER_LIB):
         cd $(RUST_BUFFER_DIR) && cargo build --release
 
 $(RUST_CHANNEL_LIB):
-	cd $(RUST_CHANNEL_DIR) && cargo build --release
+        cd $(RUST_CHANNEL_DIR) && cargo build --release
+
+$(RUST_SPELL_LIB):
+        cd $(RUST_SPELL_DIR) && cargo build --release
 DEST_LANG = $(DESTDIR)$(LANGSUBLOC)
 DEST_COMP = $(DESTDIR)$(COMPSUBLOC)
 DEST_KMAP = $(DESTDIR)$(KMAPSUBLOC)

--- a/src/rust_spell.h
+++ b/src/rust_spell.h
@@ -1,0 +1,12 @@
+#ifndef RUST_SPELL_H
+#define RUST_SPELL_H
+
+#include <stdbool.h>
+
+bool rs_spell_load_dictionary(const char *path);
+bool rs_spell_check(const char *word);
+char *rs_spell_best_suggestion(const char *word);
+void rs_spell_free_cstring(char *s);
+
+#endif // RUST_SPELL_H
+

--- a/src/spell.c
+++ b/src/spell.c
@@ -67,6 +67,7 @@
 
 #define IN_SPELL_C
 #include "vim.h"
+#include "rust_spell.h"
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
@@ -240,6 +241,20 @@ spell_check(
     // We always use the characters up to the next non-word character,
     // also for bad words.
     mi.mi_end = mi.mi_fend;
+
+    {
+        int wordlen = (int)(mi.mi_end - mi.mi_word);
+        char_u save = mi.mi_word[wordlen];
+        mi.mi_word[wordlen] = NUL;
+        if (rs_spell_check((const char *)mi.mi_word))
+        {
+            mi.mi_word[wordlen] = save;
+            if (attrp != NULL)
+                *attrp = HLF_COUNT;
+            return wordlen;
+        }
+        mi.mi_word[wordlen] = save;
+    }
 
     // Check caps type later.
     mi.mi_capflags = 0;

--- a/src/spellfile.c
+++ b/src/spellfile.c
@@ -238,6 +238,7 @@
  */
 
 #include "vim.h"
+#include "rust_spell.h"
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
@@ -3514,8 +3515,14 @@ spell_read_dic(spellinfo_T *spin, char_u *fname, afffile_T *affile)
     fd = mch_fopen((char *)fname, "r");
     if (fd == NULL)
     {
-	semsg(_(e_cant_open_file_str), fname);
-	return FAIL;
+        semsg(_(e_cant_open_file_str), fname);
+        return FAIL;
+    }
+
+    if (rs_spell_load_dictionary((const char *)fname))
+    {
+        fclose(fd);
+        return OK;
     }
 
     // The hashtable is only used to detect duplicated words.

--- a/src/spellsuggest.c
+++ b/src/spellsuggest.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "rust_spell.h"
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
@@ -735,6 +736,20 @@ spell_suggest_list(
     int		i;
     suggest_T	*stp;
     char_u	*wcopy;
+
+    char *rust_sug = rs_spell_best_suggestion((const char *)word);
+    if (rust_sug != NULL)
+    {
+        ga_init2(gap, sizeof(char_u *), 1);
+        if (ga_grow(gap, 1) == OK)
+        {
+            wcopy = vim_strsave((char_u *)rust_sug);
+            if (wcopy != NULL)
+                ((char_u **)gap->ga_data)[gap->ga_len++] = wcopy;
+        }
+        rs_spell_free_cstring(rust_sug);
+        return;
+    }
 
     spell_find_suggest(word, 0, &sug, maxcount, FALSE, need_cap, interactive);
 


### PR DESCRIPTION
## Summary
- implement `rust_spell` crate providing trie-based dictionary, FFI hooks, and suggestion logic
- wire Vim's C spell code to use Rust helpers for dictionary I/O and basic suggestions
- update build system to compile and link the new crate

## Testing
- `cargo test` in `rust/spell`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b63c9d21888320be0e70124cd49069