### PR TITLE
Add Rust-based search pattern handling

### DIFF
--- a/rust_search/Cargo.lock
+++ b/rust_search/Cargo.lock
@@ -115,6 +115,7 @@ name = "rust_search"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "once_cell",
  "regex",
  "tempfile",
 ]

--- a/rust_search/Cargo.toml
+++ b/rust_search/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = "0.2"
 regex = "1"
+once_cell = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust_search/include/rust_search.h
+++ b/rust_search/include/rust_search.h
@@ -14,4 +14,17 @@ void rust_find_pattern_in_path(char_u *ptr, int dir, int len, int whole,
                                int action, linenr_T start_lnum,
                                linenr_T end_lnum, int forceit, int silent);
 
+int rust_search_regcomp(char_u *pat, size_t patlen, char_u **used_pat,
+                        int pat_save, int pat_use, int options,
+                        void *regmatch);
+char_u *rust_get_search_pat(size_t *len);
+void rust_save_re_pat(int idx, char_u *pat, size_t patlen, int magic);
+void rust_save_search_patterns(void);
+void rust_restore_search_patterns(void);
+void rust_free_search_patterns(void);
+void rust_save_last_search_pattern(void);
+void rust_restore_last_search_pattern(void);
+char_u *rust_last_search_pattern(void);
+size_t rust_last_search_pattern_len(void);
+
 #endif // RUST_SEARCH_H


### PR DESCRIPTION
## Summary
- manage search patterns and state in Rust using once_cell
- expose pattern management FFI functions
- wire C search helpers to Rust implementations

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b64165396c8320b978c40eb28532cb