### PR TITLE
Add rust_spell crate with basic FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_spell"
+version = "0.1.0"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +225,7 @@ version = "0.1.0"
 dependencies = [
  "diff",
  "rust_buffer",
+ "rust_spell",
  "spell",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ tokio = { version = "1", features = ["net", "time", "macros", "io-util", "rt"] }
 spell = { path = "rust/spell" }
 diff = { path = "rust/diff" }
 rust_buffer = { path = "rust_buffer" }
+rust_spell = { path = "rust_spell" }
 
 [lib]
 name = "vim_channel"

--- a/rust_spell/Cargo.toml
+++ b/rust_spell/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_spell"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "rust_spell"
+crate-type = ["staticlib"]
+
+[dependencies]

--- a/rust_spell/src/lib.rs
+++ b/rust_spell/src/lib.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use std::sync::{Mutex, OnceLock};
+
+static WORDS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+#[no_mangle]
+pub extern "C" fn rs_spell_add_word(word: *const c_char) {
+    if word.is_null() {
+        return;
+    }
+    let cstr = unsafe { CStr::from_ptr(word) };
+    if let Ok(w) = cstr.to_str() {
+        WORDS.get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .unwrap()
+            .insert(w.to_string());
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_spell_check(word: *const c_char) -> c_int {
+    if word.is_null() {
+        return 0;
+    }
+    let cstr = unsafe { CStr::from_ptr(word) };
+    if let Ok(w) = cstr.to_str() {
+        if let Some(set) = WORDS.get() {
+            if set.lock().unwrap().contains(w) {
+                return 1;
+            }
+        }
+    }
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn rs_spell_clear() {
+    if let Some(set) = WORDS.get() {
+        set.lock().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn add_and_check() {
+        let hello = CString::new("hello").unwrap();
+        let world = CString::new("world").unwrap();
+        rs_spell_clear();
+        rs_spell_add_word(hello.as_ptr());
+        assert_eq!(rs_spell_check(hello.as_ptr()), 1);
+        assert_eq!(rs_spell_check(world.as_ptr()), 0);
+        rs_spell_add_word(world.as_ptr());
+        assert_eq!(rs_spell_check(world.as_ptr()), 1);
+        rs_spell_clear();
+        assert_eq!(rs_spell_check(hello.as_ptr()), 0);
+    }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ VIEWNAME = view
 
 include auto/config.mk
 #.include "auto/config.mk"
-CFLAGS += -DUSE_RUST_REGEX
+CFLAGS += -DUSE_RUST_REGEX -DUSE_RUST_SPELL
 CClink = $(CC)
 
 #}}}
@@ -1388,6 +1388,8 @@ RUST_CHANNEL_DIR = ../rust_channel
 RUST_CHANNEL_LIB = $(RUST_CHANNEL_DIR)/target/release/librust_channel.a
 RUST_GUI_DIR = ../rust_gui
 RUST_GUI_LIB = $(RUST_GUI_DIR)/target/release/librust_gui.a
+RUST_SPELL_DIR = ../rust_spell
+RUST_SPELL_LIB = $(RUST_SPELL_DIR)/target/release/librust_spell.a
 
 # Note: MZSCHEME_LIBS must come before LIBS, because LIBS adds -lm which is
 # needed by racket.
@@ -1407,6 +1409,7 @@ ALL_LIBS = \
            $(RUST_BUFFER_LIB) \
            $(RUST_CHANNEL_LIB) \
            $(RUST_GUI_LIB) \
+           $(RUST_SPELL_LIB) \
            $(LUA_LIBS) \
            $(PERL_LIBS) \
            $(PYTHON_LIBS) \
@@ -1444,7 +1447,10 @@ $(RUST_CHANNEL_LIB):
 	cd $(RUST_CHANNEL_DIR) && cargo build --release
 
 $(RUST_GUI_LIB):
-        cd $(RUST_GUI_DIR) && cargo build --release
+	cd $(RUST_GUI_DIR) && cargo build --release
+
+$(RUST_SPELL_LIB):
+	cd $(RUST_SPELL_DIR) && cargo build --release
 DEST_LANG = $(DESTDIR)$(LANGSUBLOC)
 DEST_COMP = $(DESTDIR)$(COMPSUBLOC)
 DEST_KMAP = $(DESTDIR)$(KMAPSUBLOC)
@@ -2109,7 +2115,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_BUFFER_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_BUFFER_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_SPELL_LIB)
 	@$(BUILD_DATE_MSG)
 	@LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) $(OBJ) $(ALL_LIBS)" \

--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -20,6 +20,10 @@
 # include <float.h>
 #endif
 
+#ifdef USE_RUST_SPELL
+# include "spell_rs.h"
+#endif
+
 static void f_and(typval_T *argvars, typval_T *rettv);
 #ifdef FEAT_BEVAL
 static void f_balloon_gettext(typval_T *argvars, typval_T *rettv);
@@ -149,6 +153,11 @@ static void f_repeat(typval_T *argvars, typval_T *rettv);
 #ifdef FEAT_EVAL
 // Forward declaration for Rust regex integration builtin
 static void f_rust_regex_match(typval_T *argvars, typval_T *rettv);
+#ifdef USE_RUST_SPELL
+static void f_rust_spell_add(typval_T *argvars, typval_T *rettv);
+static void f_rust_spell_check(typval_T *argvars, typval_T *rettv);
+static void f_rust_spell_clear(typval_T *argvars, typval_T *rettv);
+#endif
 #endif
 #ifdef FEAT_RUBY
 static void f_rubyeval(typval_T *argvars, typval_T *rettv);
@@ -2570,6 +2579,14 @@ static const funcentry_T global_functions[] =
 			ret_list_any,	    f_matchstrpos},
     {"rust_regex_match", 2, 4, FEARG_1,      arg24_match_func,
                         ret_number_bool,    f_rust_regex_match},
+#ifdef USE_RUST_SPELL
+      {"rust_spell_add",  1, 1, FEARG_1,      arg1_string,
+                        ret_void,           f_rust_spell_add},
+      {"rust_spell_check",1, 1, FEARG_1,      arg1_string,
+                        ret_number_bool,    f_rust_spell_check},
+      {"rust_spell_clear",0, 0, 0,            NULL,
+                        ret_void,           f_rust_spell_clear},
+#endif
     {"max",		1, 1, FEARG_1,	    arg1_list_or_tuple_or_dict,
 			ret_max_min,	    f_max},
     {"menu_info",	1, 2, FEARG_1,	    arg2_string,
@@ -9580,6 +9597,32 @@ f_rust_regex_match(typval_T *argvars, typval_T *rettv)
     rettv->vval.v_number = 0;
 #endif
 }
+
+#ifdef USE_RUST_SPELL
+    static void
+f_rust_spell_add(typval_T *argvars, typval_T *rettv)
+{
+    char_u *word = tv_get_string(&argvars[0]);
+    rs_spell_add_word((const char *)word);
+    rettv->v_type = VAR_VOID;
+}
+
+    static void
+f_rust_spell_check(typval_T *argvars, typval_T *rettv)
+{
+    char_u *word = tv_get_string(&argvars[0]);
+    rettv->v_type = VAR_NUMBER;
+    rettv->vval.v_number = rs_spell_check((const char *)word);
+}
+
+    static void
+f_rust_spell_clear(typval_T *argvars, typval_T *rettv)
+{
+    (void)argvars;
+    rs_spell_clear();
+    rettv->v_type = VAR_VOID;
+}
+#endif
 
     static void
 max_min(typval_T *argvars, typval_T *rettv, int domax)

--- a/src/spell_rs.h
+++ b/src/spell_rs.h
@@ -1,0 +1,18 @@
+#ifndef SPELL_RS_H
+#define SPELL_RS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void rs_spell_add_word(const char *word);
+int rs_spell_check(const char *word);
+void rs_spell_clear(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SPELL_RS_H

--- a/src/testdir/test_rust_spell.vim
+++ b/src/testdir/test_rust_spell.vim
@@ -1,0 +1,15 @@
+" Tests for rust spell FFI functions
+
+func Test_rust_spell_basic()
+  if !exists('*rust_spell_add') || !exists('*rust_spell_check')
+    throw 'rust spell functions not available'
+  endif
+  call rust_spell_clear()
+  call rust_spell_add('hello')
+  call assert_equal(1, rust_spell_check('hello'))
+  call assert_equal(0, rust_spell_check('world'))
+  call rust_spell_add('world')
+  call assert_equal(1, rust_spell_check('world'))
+  call rust_spell_clear()
+  call assert_equal(0, rust_spell_check('hello'))
+endfunc


### PR DESCRIPTION
## Summary
- Add new `rust_spell` crate implementing a minimal in-memory dictionary with FFI
- Wire spell helpers into Vim via `spell_rs.h` and new eval functions
- Extend build system to compile and link the Rust spell library and include a basic test

## Testing
- `cargo test -p rust_spell`
- `make -C src/testdir test_rust_spell.res` *(fails: ../vim: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6416dee4c8320af92fcf066881a70