### PR TITLE
Add profiler and debugger crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_debugger"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "rust_profiler"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "rust_python"
 version = "0.1.0"
 dependencies = [
@@ -396,6 +412,8 @@ version = "0.1.0"
 dependencies = [
  "diff",
  "rust_buffer",
+ "rust_debugger",
+ "rust_profiler",
  "rust_python",
  "spell",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ spell = { path = "rust/spell" }
 diff = { path = "rust/diff" }
 rust_buffer = { path = "rust_buffer" }
 rust_python = { path = "rust_python" }
+rust_profiler = { path = "rust_profiler" }
+rust_debugger = { path = "rust_debugger" }
 
 [lib]
 name = "vim_channel"

--- a/rust_debugger/Cargo.toml
+++ b/rust_debugger/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust_debugger"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+once_cell = "1"
+libc = "0.2"

--- a/rust_debugger/src/lib.rs
+++ b/rust_debugger/src/lib.rs
@@ -1,0 +1,67 @@
+use std::collections::HashSet;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static BREAKPOINTS: Lazy<Mutex<HashSet<(String, i32)>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+
+fn cstr_to_string(s: *const c_char) -> Option<String> {
+    if s.is_null() { None } else { unsafe { CStr::from_ptr(s) }.to_str().ok().map(|s| s.to_string()) }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_debugger_add_breakpoint(file: *const c_char, line: c_int) -> c_int {
+    if let Some(f) = cstr_to_string(file) {
+        let mut bp = BREAKPOINTS.lock().unwrap();
+        bp.insert((f, line as i32));
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_debugger_remove_breakpoint(file: *const c_char, line: c_int) -> c_int {
+    if let Some(f) = cstr_to_string(file) {
+        let mut bp = BREAKPOINTS.lock().unwrap();
+        bp.remove(&(f, line as i32)) as c_int
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_debugger_check_breakpoint(file: *const c_char, line: c_int) -> c_int {
+    if let Some(f) = cstr_to_string(file) {
+        let bp = BREAKPOINTS.lock().unwrap();
+        if bp.contains(&(f, line as i32)) { 1 } else { 0 }
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_debugger_hit_breakpoint(file: *const c_char, line: c_int) -> c_int {
+    if rs_debugger_check_breakpoint(file, line) == 1 {
+        unsafe { libc::raise(libc::SIGTRAP) };
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn manage_breakpoints() {
+        let file = CString::new("test.rs").unwrap();
+        assert_eq!(rs_debugger_add_breakpoint(file.as_ptr(), 10), 1);
+        assert_eq!(rs_debugger_check_breakpoint(file.as_ptr(), 10), 1);
+        assert_eq!(rs_debugger_remove_breakpoint(file.as_ptr(), 10), 1);
+        assert_eq!(rs_debugger_check_breakpoint(file.as_ptr(), 10), 0);
+    }
+}

--- a/rust_profiler/Cargo.toml
+++ b/rust_profiler/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust_profiler"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+once_cell = "1"
+libc = "0.2"

--- a/rust_profiler/src/lib.rs
+++ b/rust_profiler/src/lib.rs
@@ -1,0 +1,62 @@
+use std::ffi::CString;
+use std::os::raw::{c_char, c_long};
+use std::time::Instant;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+static START: Lazy<Mutex<Option<Instant>>> = Lazy::new(|| Mutex::new(None));
+
+#[no_mangle]
+pub extern "C" fn rs_profiler_start() {
+    let mut s = START.lock().unwrap();
+    *s = Some(Instant::now());
+}
+
+#[no_mangle]
+pub extern "C" fn rs_profiler_stop() -> c_long {
+    let mut s = START.lock().unwrap();
+    if let Some(start) = s.take() {
+        let dur = start.elapsed();
+        dur.as_micros() as c_long
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_profiler_format(micros: c_long) -> *mut c_char {
+    let secs = micros / 1_000_000;
+    let rem = micros % 1_000_000;
+    let s = format!("{}.{:06} sec", secs, rem);
+    CString::new(s).unwrap().into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_profiler_string_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe { let _ = CString::from_raw(s); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::time::Duration;
+
+    #[test]
+    fn measure_time() {
+        rs_profiler_start();
+        std::thread::sleep(Duration::from_millis(1));
+        let us = rs_profiler_stop();
+        assert!(us > 0);
+    }
+
+    #[test]
+    fn format_output() {
+        let ptr = rs_profiler_format(123456);
+        let c = unsafe { CStr::from_ptr(ptr) };
+        assert_eq!(c.to_str().unwrap(), "0.123456 sec");
+        rs_profiler_string_free(ptr);
+    }
+}


### PR DESCRIPTION
## Summary
- add rust_profiler crate for timing and formatted reports
- add rust_debugger crate for breakpoint management and traps
- wire new crates into main Cargo.toml

## Testing
- `cargo test -p rust_profiler`
- `cargo test -p rust_debugger`
- `cargo check -p vim_channel`

------
https://chatgpt.com/codex/tasks/task_e_68b645b4eae88320a018d300a7b0e39c