### PR TITLE
Modularize GUI backends and add Rust platform bridge

### DIFF
--- a/rust_gui/src/lib.rs
+++ b/rust_gui/src/lib.rs
@@ -1,10 +1,10 @@
-use rust_gui_core::{GuiCore};
 #[cfg(target_os = "linux")]
-use rust_gui_core::backend::linux::LinuxBackend as Backend;
-#[cfg(target_os = "windows")]
-use rust_gui_core::backend::windows::WindowsBackend as Backend;
+use rust_gui_core::backend::gtk::GtkBackend as Backend;
 #[cfg(target_os = "macos")]
 use rust_gui_core::backend::macos::MacBackend as Backend;
+#[cfg(target_os = "windows")]
+use rust_gui_core::backend::w32::W32Backend as Backend;
+use rust_gui_core::GuiCore;
 use rust_gui_core::GuiEvent;
 
 /// Run the GUI.  This is exposed to the C code via `gui_rust.c`.

--- a/rust_gui_core/src/backend/gtk.rs
+++ b/rust_gui_core/src/backend/gtk.rs
@@ -1,0 +1,34 @@
+use super::{GuiBackend, GuiEvent};
+use std::collections::VecDeque;
+
+/// Backend implementation for GTK environments on Unix.
+/// Drawing operations are recorded and events are stored in a queue.
+#[derive(Default)]
+pub struct GtkBackend {
+    pub drawn: Vec<String>,
+    pub events: VecDeque<GuiEvent>,
+}
+
+impl GtkBackend {
+    pub fn new() -> Self {
+        Self {
+            drawn: Vec::new(),
+            events: VecDeque::new(),
+        }
+    }
+
+    /// Queue an event for later processing; primarily used in tests.
+    pub fn push_event(&mut self, ev: GuiEvent) {
+        self.events.push_back(ev);
+    }
+}
+
+impl GuiBackend for GtkBackend {
+    fn draw_text(&mut self, text: &str) {
+        self.drawn.push(text.to_string());
+    }
+
+    fn poll_event(&mut self) -> Option<GuiEvent> {
+        self.events.pop_front()
+    }
+}

--- a/rust_gui_core/src/backend/macos.rs
+++ b/rust_gui_core/src/backend/macos.rs
@@ -1,0 +1,18 @@
+use super::{GuiBackend, GuiEvent};
+
+/// Stub backend for macOS.  A full implementation would bridge to Cocoa APIs.
+#[derive(Default)]
+pub struct MacBackend;
+
+impl MacBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl GuiBackend for MacBackend {
+    fn draw_text(&mut self, _text: &str) {}
+    fn poll_event(&mut self) -> Option<GuiEvent> {
+        None
+    }
+}

--- a/rust_gui_core/src/backend/mod.rs
+++ b/rust_gui_core/src/backend/mod.rs
@@ -18,70 +18,10 @@ pub trait GuiBackend {
 }
 
 #[cfg(target_os = "linux")]
-pub mod linux {
-    use super::{GuiBackend, GuiEvent};
-    use std::collections::VecDeque;
-
-    /// Simple backend used for tests and non-GUI environments on Linux.
-    /// Drawing operations are recorded and events are stored in a queue.
-    #[derive(Default)]
-    pub struct LinuxBackend {
-        pub drawn: Vec<String>,
-        pub events: VecDeque<GuiEvent>,
-    }
-
-    impl LinuxBackend {
-        pub fn new() -> Self {
-            Self { drawn: Vec::new(), events: VecDeque::new() }
-        }
-
-        /// Queue an event for later processing; primarily used in tests.
-        pub fn push_event(&mut self, ev: GuiEvent) {
-            self.events.push_back(ev);
-        }
-    }
-
-    impl GuiBackend for LinuxBackend {
-        fn draw_text(&mut self, text: &str) {
-            self.drawn.push(text.to_string());
-        }
-
-        fn poll_event(&mut self) -> Option<GuiEvent> {
-            self.events.pop_front()
-        }
-    }
-}
+pub mod gtk;
 
 #[cfg(target_os = "windows")]
-pub mod windows {
-    use super::{GuiBackend, GuiEvent};
-
-    #[derive(Default)]
-    pub struct WindowsBackend;
-
-    impl WindowsBackend {
-        pub fn new() -> Self { Self }
-    }
-
-    impl GuiBackend for WindowsBackend {
-        fn draw_text(&mut self, _text: &str) {}
-        fn poll_event(&mut self) -> Option<GuiEvent> { None }
-    }
-}
+pub mod w32;
 
 #[cfg(target_os = "macos")]
-pub mod macos {
-    use super::{GuiBackend, GuiEvent};
-
-    #[derive(Default)]
-    pub struct MacBackend;
-
-    impl MacBackend {
-        pub fn new() -> Self { Self }
-    }
-
-    impl GuiBackend for MacBackend {
-        fn draw_text(&mut self, _text: &str) {}
-        fn poll_event(&mut self) -> Option<GuiEvent> { None }
-    }
-}
+pub mod macos;

--- a/rust_gui_core/src/backend/w32.rs
+++ b/rust_gui_core/src/backend/w32.rs
@@ -1,0 +1,19 @@
+use super::{GuiBackend, GuiEvent};
+
+/// Minimal Windows backend.  Real drawing is delegated to the platform APIs
+/// but for now these methods are no-ops.
+#[derive(Default)]
+pub struct W32Backend;
+
+impl W32Backend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl GuiBackend for W32Backend {
+    fn draw_text(&mut self, _text: &str) {}
+    fn poll_event(&mut self) -> Option<GuiEvent> {
+        None
+    }
+}

--- a/rust_gui_core/src/lib.rs
+++ b/rust_gui_core/src/lib.rs
@@ -51,13 +51,13 @@ pub mod dialog {
 mod tests {
     use super::*;
     #[cfg(target_os = "linux")]
-    use crate::backend::linux::LinuxBackend;
+    use crate::backend::gtk::GtkBackend;
 
     /// Verify that drawing forwards to the backend and that queued
     /// events are processed in order.
     #[test]
     fn draw_and_process_events() {
-        let mut backend = LinuxBackend::new();
+        let mut backend = GtkBackend::new();
         backend.push_event(GuiEvent::Key('x'));
         backend.push_event(GuiEvent::Click { x: 10, y: 20 });
         let mut core = GuiCore::new(backend);
@@ -69,7 +69,9 @@ mod tests {
         {
             assert_eq!(core.backend_mut().drawn, vec!["hello".to_string()]);
         }
-        assert_eq!(seen,
-                   vec![GuiEvent::Key('x'), GuiEvent::Click { x: 10, y: 20 }]);
+        assert_eq!(
+            seen,
+            vec![GuiEvent::Key('x'), GuiEvent::Click { x: 10, y: 20 }]
+        );
     }
 }

--- a/src/gui_gtk.c
+++ b/src/gui_gtk.c
@@ -1,13 +1,11 @@
 #include "vim.h"
 
-#ifdef FEAT_GUI_GTK
-
-extern void rs_gui_run(void);
+#if defined(FEAT_GUI_GTK) && defined(FEAT_GUI_RUST)
+# include "gui_rust.h"
 
 int gui_mch_init(void)
 {
     rs_gui_run();
     return OK;
 }
-
 #endif

--- a/src/gui_rust.c
+++ b/src/gui_rust.c
@@ -4,7 +4,9 @@
 /*
  * Minimal C shell delegating GUI handling to the Rust implementation.
  */
+#ifdef FEAT_GUI_RUST
 void gui_start(char_u *arg UNUSED)
 {
     rs_gui_run();
 }
+#endif

--- a/src/gui_w32.c
+++ b/src/gui_w32.c
@@ -25,6 +25,17 @@
 
 #include "vim.h"
 
+#ifdef FEAT_GUI_RUST
+# include "gui_rust.h"
+
+int gui_mch_init(void)
+{
+    rs_gui_run();
+    return OK;
+}
+
+#else
+
 #if defined(FEAT_DIRECTX)
 # include "gui_dwrite.h"
 #endif
@@ -9259,3 +9270,4 @@ test_gui_w32_sendevent(char_u *event, dict_T *args)
     }
 }
 #endif
+#endif /* FEAT_GUI_RUST */


### PR DESCRIPTION
## Summary
- Split GUI backends into per-platform Rust modules (gtk, w32, macos)
- Route `rust_gui` to the appropriate backend
- Add `FEAT_GUI_RUST` bridge in `gui_w32.c`, `gui_gtk.c` and `gui_rust.c`

## Testing
- `cargo test --manifest-path rust_gui_core/Cargo.toml`
- `cargo test --manifest-path rust_gui/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b645c5b03c83208ff1182b990a87b8