### PR TITLE
Port basic ex command helpers to Rust

### DIFF
--- a/rust_excmd/src/lib.rs
+++ b/rust_excmd/src/lib.rs
@@ -1,44 +1,181 @@
 use std::os::raw::{c_int, c_void};
+use std::ptr;
 
 pub type CharU = u8;
 pub type GetlineOpt = c_int;
 
 pub type Fgetline = Option<unsafe extern "C" fn(c_int, *mut c_void, c_int, GetlineOpt) -> *mut CharU>;
 
+const FAIL: c_int = 0;
+const MAGIC_ON: c_int = 3;
+const MAGIC_ALL: c_int = 4;
+
+extern "C" {
+    static mut trylevel: c_int;
+    static mut emsg_silent: c_int;
+    static mut force_abort: c_int;
+    fn aborting() -> c_int;
+}
+
 #[no_mangle]
 pub extern "C" fn rust_do_cmdline(
-    _cmdline: *mut CharU,
-    _fgetline: Fgetline,
-    _cookie: *mut c_void,
-    _flags: c_int,
+    mut cmdline: *mut CharU,
+    fgetline: Fgetline,
+    cookie: *mut c_void,
+    flags: c_int,
 ) -> c_int {
-    // Placeholder implementation delegating Ex command processing to Rust.
+    unsafe {
+        loop {
+            if cmdline.is_null() || *cmdline == 0 {
+                if let Some(fg) = fgetline {
+                    cmdline = fg(0, cookie, 0, 0);
+                    if cmdline.is_null() {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+            let mut cmdp = cmdline;
+            let next = rust_do_one_cmd(&mut cmdp, flags, ptr::null_mut(), fgetline, cookie);
+            if next.is_null() {
+                break;
+            }
+            cmdline = next;
+        }
+    }
     0
 }
 
 #[no_mangle]
 pub extern "C" fn rust_do_one_cmd(
-    _cmdlinep: *mut *mut CharU,
+    cmdlinep: *mut *mut CharU,
     _flags: c_int,
     _cstack: *mut c_void,
     _fgetline: Fgetline,
     _cookie: *mut c_void,
 ) -> *mut CharU {
-    // Placeholder that currently does nothing and returns NULL.
-    std::ptr::null_mut()
+    unsafe {
+        let cmdline = *cmdlinep;
+        if cmdline.is_null() || *cmdline == 0 {
+            return ptr::null_mut();
+        }
+        let mut p = cmdline;
+        while *p != 0 && *p != b'|' && *p != b'\n' {
+            p = p.add(1);
+        }
+        if *p == 0 {
+            *cmdlinep = p;
+            ptr::null_mut()
+        } else {
+            *p = 0;
+            p = p.add(1);
+            *cmdlinep = p;
+            p
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_add_bufnum(bufnrs: *mut c_int, bufnump: *mut c_int, nr: c_int) {
+    unsafe {
+        let mut i = 0;
+        while i < *bufnump {
+            if *bufnrs.add(i as usize) == nr {
+                return;
+            }
+            i += 1;
+        }
+        *bufnrs.add(*bufnump as usize) = nr;
+        *bufnump += 1;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_empty_pattern_magic(p: *const CharU, len: usize, magic_val: c_int) -> c_int {
+    unsafe {
+        let mut len = len as isize;
+        while len >= 2
+            && *p.offset(len - 2) == b'\\'
+            && b"mMvVcCZ".contains(&*p.offset(len - 1))
+        {
+            len -= 2;
+        }
+        if len == 0 {
+            1
+        } else if len > 1
+            && *p.offset(len - 1) == b'|'
+            && ((*p.offset(len - 2) == b'\\' && magic_val == MAGIC_ON)
+                || (*p.offset(len - 2) != b'\\' && magic_val == MAGIC_ALL))
+        {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_should_abort(retcode: c_int) -> c_int {
+    unsafe {
+        if (retcode == FAIL && trylevel != 0 && emsg_silent == 0) || aborting() != 0 {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_update_force_abort(cause_abort: c_int) {
+    unsafe {
+        if cause_abort != 0 {
+            force_abort = 1;
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ptr;
+
+    #[no_mangle]
+    static mut trylevel: c_int = 0;
+    #[no_mangle]
+    static mut emsg_silent: c_int = 0;
+    #[no_mangle]
+    static mut force_abort: c_int = 0;
+
+    #[no_mangle]
+    extern "C" fn aborting() -> c_int { 0 }
 
     #[test]
     fn call_stubs() {
-        let mut cmd: *mut CharU = std::ptr::null_mut();
-        let res = rust_do_cmdline(cmd, None, std::ptr::null_mut(), 0);
+        let mut buf = b"cmd1|cmd2".to_vec();
+        buf.push(0);
+        let mut cmdline = buf.as_mut_ptr();
+        let res = rust_do_cmdline(cmdline, None, ptr::null_mut(), 0);
         assert_eq!(res, 0);
 
-        let res2 = rust_do_one_cmd(&mut cmd, 0, std::ptr::null_mut(), None, std::ptr::null_mut());
-        assert!(res2.is_null());
+        let mut buf2 = b"abc|def".to_vec();
+        buf2.push(0);
+        let mut ptrp = buf2.as_mut_ptr();
+        let next = rust_do_one_cmd(&mut ptrp, 0, ptr::null_mut(), None, ptr::null_mut());
+        assert!(!next.is_null());
+
+        let mut bufs = [1, 2, 0];
+        let mut num = 2;
+        rust_add_bufnum(bufs.as_mut_ptr(), &mut num, 3);
+        assert_eq!(num, 3);
+
+        let pat = b"foo\\|bar";
+        let res = rust_empty_pattern_magic(pat.as_ptr(), pat.len(), MAGIC_ON);
+        assert_eq!(res, 0);
+
+        assert_eq!(rust_should_abort(0), 0);
+        unsafe { force_abort = 0; }
+        rust_update_force_abort(1);
+        unsafe { assert_eq!(force_abort, 1); }
     }
 }

--- a/src/ex_cmds2.c
+++ b/src/ex_cmds2.c
@@ -270,17 +270,12 @@ can_abandon(buf_T *buf, int forceit)
 
 /*
  * Add a buffer number to "bufnrs", unless it's already there.
- */
-    static void
+*/
+extern void rust_add_bufnum(int *bufnrs, int *bufnump, int nr);
+static void
 add_bufnum(int *bufnrs, int *bufnump, int nr)
 {
-    int i;
-
-    for (i = 0; i < *bufnump; ++i)
-	if (bufnrs[i] == nr)
-	    return;
-    bufnrs[*bufnump] = nr;
-    *bufnump = *bufnump + 1;
+    rust_add_bufnum(bufnrs, bufnump, nr);
 }
 
 /*

--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -12,6 +12,8 @@
  */
 
 #include "vim.h"
+extern void rust_update_force_abort(int cause_abort);
+extern int rust_should_abort(int retcode);
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
@@ -101,8 +103,7 @@ aborting(void)
     void
 update_force_abort(void)
 {
-    if (cause_abort)
-	force_abort = TRUE;
+    rust_update_force_abort(cause_abort);
 }
 
 /*
@@ -114,7 +115,7 @@ update_force_abort(void)
     int
 should_abort(int retcode)
 {
-    return ((retcode == FAIL && trylevel != 0 && !emsg_silent) || aborting());
+    return rust_should_abort(retcode);
 }
 
 /*

--- a/src/ex_getln.c
+++ b/src/ex_getln.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+extern int rust_empty_pattern_magic(char_u *p, size_t len, int magic_val);
 
 // Return value when handling keys in command-line mode.
 #define CMDLINE_NOT_CHANGED	1
@@ -100,21 +101,7 @@ empty_pattern(char_u *p, size_t len, int delim)
     static int
 empty_pattern_magic(char_u *p, size_t len, magic_T magic_val)
 {
-    // remove trailing \v and the like
-    while (len >= 2 && p[len - 2] == '\\'
-			&& vim_strchr((char_u *)"mMvVcCZ", p[len - 1]) != NULL)
-	len -= 2;
-
-    // true, if the pattern is empty, or the pattern ends with \| and magic is
-    // set (or it ends with '|' and very magic is set)
-    return len == 0
-	|| (
-	    len > 1 && p[len - 1] == '|'
-	    && (
-		(p[len - 2] == '\\' && magic_val == MAGIC_ON) ||
-		(p[len - 2] != '\\' && magic_val == MAGIC_ALL)
-	    )
-	);
+    return rust_empty_pattern_magic(p, len, magic_val);
 }
 
 // Struct to store the viewstate during 'incsearch' highlighting.


### PR DESCRIPTION
## Summary
- Implement minimal `rust_do_cmdline` and `rust_do_one_cmd` in the `rust_excmd` crate to handle basic Ex command parsing.
- Add Rust implementations for `add_bufnum`, pattern emptiness checks, and evaluation helpers with corresponding C wrappers.
- Hook C sources to call the new Rust functions.

## Testing
- `cargo test` in `rust_excmd`


------
https://chatgpt.com/codex/tasks/task_e_68b645c3f8d483208d4c6bd7a8a70ee4