### PR TITLE
feat(gui_w32): queue events for testing

### DIFF
--- a/rust_gui_w32/src/lib.rs
+++ b/rust_gui_w32/src/lib.rs
@@ -1,15 +1,22 @@
 use rust_gui_core::backend::{GuiBackend, GuiEvent};
+use std::collections::VecDeque;
 
 /// Minimal Windows backend.  Real drawing is delegated to the platform APIs
 /// but for now these methods record actions for testing purposes.
 #[derive(Default)]
 pub struct W32Backend {
     pub drawn: Vec<String>,
+    pub events: VecDeque<GuiEvent>,
 }
 
 impl W32Backend {
     pub fn new() -> Self {
-        Self { drawn: Vec::new() }
+        Self { drawn: Vec::new(), events: VecDeque::new() }
+    }
+
+    /// Queue an event so it can later be retrieved by `poll_event`.
+    pub fn push_event(&mut self, ev: GuiEvent) {
+        self.events.push_back(ev);
     }
 }
 
@@ -19,7 +26,7 @@ impl GuiBackend for W32Backend {
     }
 
     fn poll_event(&mut self) -> Option<GuiEvent> {
-        None
+        self.events.pop_front()
     }
 }
 
@@ -28,9 +35,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn draw_records_text() {
+    fn draw_and_queue_event() {
         let mut backend = W32Backend::new();
         backend.draw_text("hello");
+        backend.push_event(GuiEvent::Click { x: 1, y: 2 });
         assert_eq!(backend.drawn, vec!["hello".to_string()]);
+        assert_eq!(backend.poll_event(), Some(GuiEvent::Click { x: 1, y: 2 }));
     }
 }


### PR DESCRIPTION
## Summary
- support event queue in Windows GUI backend
- add unit test ensuring events are processed

## Testing
- `cd rust_gui_w32 && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b66591b808832092f57c4f2bc62678