### PR TITLE
feat(eval): add rust evaluator and FFI

### DIFF
--- a/rust_eval/Cargo.lock
+++ b/rust_eval/Cargo.lock
@@ -3,5 +3,14 @@
 version = 4
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "rust_eval"
 version = "0.1.0"
+dependencies = [
+ "once_cell",
+]

--- a/rust_eval/Cargo.toml
+++ b/rust_eval/Cargo.toml
@@ -8,4 +8,5 @@ name = "rust_eval"
 crate-type = ["staticlib", "rlib"]
 
 [dependencies]
+once_cell = "1"
 


### PR DESCRIPTION
## Summary
- implement simple evaluator for expressions, variables, and function calls
- expose Rust API and C FFI entrypoints for evaluation
- add Vimscript/Vim9script compatibility tests

## Testing
- `cargo test -p rust_eval`

------
https://chatgpt.com/codex/tasks/task_e_68b66592306483209eb542855b72029e