### PR TITLE
feat(rust_term): port terminal buffer to Rust

### DIFF
--- a/rust_term/Cargo.lock
+++ b/rust_term/Cargo.lock
@@ -13,14 +13,4 @@ name = "rust_term"
 version = "0.1.0"
 dependencies = [
  "libc",
- "termios",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
 ]

--- a/rust_term/Cargo.toml
+++ b/rust_term/Cargo.toml
@@ -5,6 +5,3 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-
-[target.'cfg(unix)'.dependencies]
-termios = "0.3"

--- a/rust_term/src/lib.rs
+++ b/rust_term/src/lib.rs
@@ -5,11 +5,150 @@ use std::os::raw::{c_char, c_int};
 #[cfg(unix)]
 use libc::{ioctl, winsize, STDOUT_FILENO, TIOCGWINSZ};
 
-#[cfg(unix)]
-use termios::Termios;
+/// Simple owned buffer used for terminal output.
+struct TermBuffer {
+    buf: Vec<u8>,
+    cap: usize,
+}
+
+impl TermBuffer {
+    fn new() -> Self {
+        // use a small default similar to Vim's OUT_SIZE
+        let cap = 1024;
+        Self { buf: Vec::with_capacity(cap), cap }
+    }
+
+    fn write_byte(&mut self, b: u8) {
+        self.buf.push(b);
+        if self.buf.len() >= self.cap {
+            // ignore errors on flush; caller can handle via explicit flush
+            let _ = self.flush();
+        }
+    }
+
+    fn write_str(&mut self, s: &str) {
+        for &b in s.as_bytes() {
+            self.write_byte(b);
+        }
+    }
+
+    fn flush(&mut self) -> c_int {
+        let mut out = stdout();
+        if out.write_all(&self.buf).is_ok() && out.flush().is_ok() {
+            self.buf.clear();
+            0
+        } else {
+            -1
+        }
+    }
+}
+
+/// Terminal state object holding the output buffer.
+pub struct Terminal {
+    buffer: TermBuffer,
+}
+
+impl Terminal {
+    fn new() -> Self {
+        Self { buffer: TermBuffer::new() }
+    }
+
+    fn move_cursor(&mut self, x: c_int, y: c_int) -> c_int {
+        self.buffer
+            .write_str(&format!("\x1B[{};{}H", y + 1, x + 1));
+        self.buffer.flush()
+    }
+
+    fn clear_screen(&mut self) -> c_int {
+        self.buffer.write_str("\x1B[2J");
+        self.buffer.flush()
+    }
+
+    fn print(&mut self, s: &str) -> c_int {
+        self.buffer.write_str(s);
+        self.buffer.flush()
+    }
+}
+
+// --- FFI exposed functions -------------------------------------------------
 
 #[no_mangle]
-pub unsafe extern "C" fn rust_term_get_winsize(width: *mut c_int, height: *mut c_int) -> c_int {
+pub extern "C" fn rust_term_new() -> *mut Terminal {
+    Box::into_raw(Box::new(Terminal::new()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_free(term: *mut Terminal) {
+    if !term.is_null() {
+        drop(Box::from_raw(term));
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_out_char(term: *mut Terminal, c: c_int) -> c_int {
+    if term.is_null() {
+        return -1;
+    }
+    let term = &mut *term;
+    term.buffer.write_byte(c as u8);
+    0
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_out_flush(term: *mut Terminal) -> c_int {
+    if term.is_null() {
+        return -1;
+    }
+    (&mut *term).buffer.flush()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_move_cursor(
+    term: *mut Terminal,
+    x: c_int,
+    y: c_int,
+) -> c_int {
+    if term.is_null() {
+        return -1;
+    }
+    (&mut *term).move_cursor(x, y)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_clear_screen(term: *mut Terminal) -> c_int {
+    if term.is_null() {
+        return -1;
+    }
+    (&mut *term).clear_screen()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_print(
+    term: *mut Terminal,
+    s: *const c_char,
+) -> c_int {
+    if term.is_null() || s.is_null() {
+        return -1;
+    }
+    let term = &mut *term;
+    let c_str = CStr::from_ptr(s);
+    match c_str.to_str() {
+        Ok(s) => term.print(s),
+        Err(_) => -1,
+    }
+}
+
+/// Returns the number of colors supported by the terminal.
+#[no_mangle]
+pub extern "C" fn rust_term_color_count() -> c_int {
+    8
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_term_get_winsize(
+    width: *mut c_int,
+    height: *mut c_int,
+) -> c_int {
     #[cfg(unix)]
     {
         let mut ws: winsize = std::mem::zeroed();
@@ -30,72 +169,37 @@ pub unsafe extern "C" fn rust_term_get_winsize(width: *mut c_int, height: *mut c
     }
 }
 
-fn write_esc(seq: &str) -> c_int {
-    #[cfg(unix)]
-    {
-        let _ = Termios::from_fd(STDOUT_FILENO);
-    }
-    let mut out = stdout();
-    if out.write_all(seq.as_bytes()).is_ok() && out.flush().is_ok() {
-        0
-    } else {
-        -1
-    }
-}
-
-/// Returns the number of colors supported by the terminal.
-#[no_mangle]
-pub extern "C" fn rust_term_color_count() -> c_int {
-    8
-}
-
-/// Move the cursor to the given position.
-#[no_mangle]
-pub extern "C" fn rust_term_move_cursor(x: c_int, y: c_int) -> c_int {
-    write_esc(&format!("\x1B[{};{}H", y + 1, x + 1))
-}
-
-/// Clear the entire screen.
-#[no_mangle]
-pub extern "C" fn rust_term_clear_screen() -> c_int {
-    write_esc("\x1B[2J")
-}
-
-/// Print a string to the terminal.
-#[no_mangle]
-pub unsafe extern "C" fn rust_term_print(s: *const c_char) -> c_int {
-    if s.is_null() {
-        return -1;
-    }
-    let c_str = CStr::from_ptr(s);
-    if let Ok(str_slice) = c_str.to_str() {
-        let mut out = stdout();
-        if out.write_all(str_slice.as_bytes()).is_ok() && out.flush().is_ok() {
-            str_slice.len() as c_int
-        } else {
-            -1
-        }
-    } else {
-        -1
-    }
-}
+// --- Tests -----------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
 
     #[test]
-    fn call_functions() {
+    fn basic_output() {
+        let term = unsafe { rust_term_new() };
+        assert!(!term.is_null());
+        unsafe {
+            assert_eq!(rust_term_move_cursor(term, 0, 0), 0);
+            assert_eq!(rust_term_clear_screen(term), 0);
+            let s = CString::new("test").unwrap();
+            assert_eq!(rust_term_print(term, s.as_ptr()), 0);
+            assert_eq!(rust_term_out_char(term, b'\n' as c_int), 0);
+            assert_eq!(rust_term_out_flush(term), 0);
+            rust_term_free(term);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn get_winsize() {
         let mut w = 0;
         let mut h = 0;
         unsafe {
+            // Might return zero when stdout is not a TTY; ensure no crash.
             let _ = rust_term_get_winsize(&mut w, &mut h);
         }
-        let _ = rust_term_color_count();
-        let _ = rust_term_move_cursor(0, 0);
-        let _ = rust_term_clear_screen();
-        let c_string = std::ffi::CString::new("test").unwrap();
-        let _ = unsafe { rust_term_print(c_string.as_ptr()) };
     }
 }
 

--- a/rust_term/tests/terminals.rs
+++ b/rust_term/tests/terminals.rs
@@ -1,0 +1,42 @@
+use rust_term::*;
+use std::ffi::CString;
+
+#[test]
+fn create_and_flush() {
+    let term = unsafe { rust_term_new() };
+    assert!(!term.is_null());
+    unsafe {
+        assert_eq!(rust_term_out_char(term, b'A' as i32), 0);
+        assert_eq!(rust_term_out_flush(term), 0);
+        rust_term_free(term);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn unix_terminal_size() {
+    let mut w = 0;
+    let mut h = 0;
+    // Terminal size may be zero when running without a TTY, just ensure call succeeds
+    let _ = unsafe { rust_term_get_winsize(&mut w, &mut h) };
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_color_count() {
+    assert!(rust_term_color_count() >= 8);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wayland_simulation() {
+    std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
+    let term = unsafe { rust_term_new() };
+    assert!(!term.is_null());
+    unsafe {
+        let s = CString::new("wayland").unwrap();
+        assert_eq!(rust_term_print(term, s.as_ptr()), 0);
+        rust_term_free(term);
+    }
+    std::env::remove_var("WAYLAND_DISPLAY");
+}

--- a/src/rust_term.h
+++ b/src/rust_term.h
@@ -3,10 +3,19 @@
 
 #include <stddef.h>
 
+typedef struct rust_term Terminal;
+
+Terminal *rust_term_new(void);
+void rust_term_free(Terminal *term);
+
+int rust_term_out_char(Terminal *term, int c);
+int rust_term_out_flush(Terminal *term);
+
+int rust_term_move_cursor(Terminal *term, int x, int y);
+int rust_term_clear_screen(Terminal *term);
+int rust_term_print(Terminal *term, const char *s);
+
 int rust_term_get_winsize(int *width, int *height);
 int rust_term_color_count(void);
-int rust_term_move_cursor(int x, int y);
-int rust_term_clear_screen(void);
-int rust_term_print(const char *s);
 
 #endif // RUST_TERM_H


### PR DESCRIPTION
## Summary
- implement `Terminal` with owned output buffer and expose FFI helpers
- simplify dependencies and provide C header for new API
- add integration tests for Unix, Windows, and Wayland scenarios

## Testing
- `cd rust_term && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b66593e87c8320a136d3e60441a61b