### PR TITLE
Handle expose events in Rust GUI

### DIFF
--- a/rust_gui/src/lib.rs
+++ b/rust_gui/src/lib.rs
@@ -1,13 +1,14 @@
-#[cfg(all(target_os = "linux", feature = "gtk"))]
-use rust_gui_gtk::GtkBackend as Backend;
-#[cfg(all(target_os = "linux", not(feature = "gtk")))]
-use rust_gui_x11::X11Backend as Backend;
 #[cfg(target_os = "macos")]
 use rust_gui_core::backend::macos::MacBackend as Backend;
-#[cfg(target_os = "windows")]
-use rust_gui_w32::W32Backend as Backend;
+use rust_gui_core::GuiBackend;
 use rust_gui_core::GuiCore;
 use rust_gui_core::GuiEvent;
+#[cfg(all(target_os = "linux", feature = "gtk"))]
+use rust_gui_gtk::GtkBackend as Backend;
+#[cfg(target_os = "windows")]
+use rust_gui_w32::W32Backend as Backend;
+#[cfg(all(target_os = "linux", not(feature = "gtk")))]
+use rust_gui_x11::X11Backend as Backend;
 
 /// Run the GUI.  This is exposed to the C code via `gui_rust.c`.
 #[no_mangle]
@@ -15,6 +16,10 @@ pub extern "C" fn rs_gui_run() {
     let backend = Backend::new();
     let mut gui = GuiCore::new(backend);
     gui.draw_text("Vim Rust GUI");
-    // Process any queued events; in this simple example we just ignore them.
-    gui.process_events(|_e: GuiEvent| {});
+    // Redraw the window whenever an expose event is received.
+    while let Some(ev) = gui.backend_mut().poll_event() {
+        if let GuiEvent::Expose = ev {
+            gui.draw_text("Vim Rust GUI");
+        }
+    }
 }

--- a/rust_gui_core/src/backend/mod.rs
+++ b/rust_gui_core/src/backend/mod.rs
@@ -5,6 +5,8 @@ pub enum GuiEvent {
     Key(char),
     /// Mouse click at the given coordinates.
     Click { x: i32, y: i32 },
+    /// The window was exposed and needs to be redrawn.
+    Expose,
 }
 
 /// Abstraction over platform specific drawing and event handling.

--- a/rust_gui_core/src/lib.rs
+++ b/rust_gui_core/src/lib.rs
@@ -61,7 +61,10 @@ mod tests {
 
     impl TestBackend {
         fn new() -> Self {
-            Self { drawn: Vec::new(), events: VecDeque::new() }
+            Self {
+                drawn: Vec::new(),
+                events: VecDeque::new(),
+            }
         }
         fn push_event(&mut self, ev: GuiEvent) {
             self.events.push_back(ev);
@@ -85,6 +88,7 @@ mod tests {
         let mut backend = TestBackend::new();
         backend.push_event(GuiEvent::Key('x'));
         backend.push_event(GuiEvent::Click { x: 10, y: 20 });
+        backend.push_event(GuiEvent::Expose);
         let mut core = GuiCore::new(backend);
         core.draw_text("hello");
         let mut seen = Vec::new();
@@ -92,7 +96,11 @@ mod tests {
         assert_eq!(core.backend_mut().drawn, vec!["hello".to_string()]);
         assert_eq!(
             seen,
-            vec![GuiEvent::Key('x'), GuiEvent::Click { x: 10, y: 20 }]
+            vec![
+                GuiEvent::Key('x'),
+                GuiEvent::Click { x: 10, y: 20 },
+                GuiEvent::Expose,
+            ]
         );
     }
 }

--- a/rust_gui_gtk/src/lib.rs
+++ b/rust_gui_gtk/src/lib.rs
@@ -12,7 +12,10 @@ pub struct GtkBackend {
 
 impl GtkBackend {
     pub fn new() -> Self {
-        Self { drawn: Vec::new(), events: VecDeque::new() }
+        Self {
+            drawn: Vec::new(),
+            events: VecDeque::new(),
+        }
     }
 
     /// Queue an event for later processing; primarily used in tests.

--- a/rust_gui_x11/src/lib.rs
+++ b/rust_gui_x11/src/lib.rs
@@ -1,6 +1,9 @@
 use rust_gui_core::backend::{GuiBackend, GuiEvent};
 use x11rb::connection::Connection;
-use x11rb::protocol::xproto::{ConnectionExt as _, EventMask, KeyPressEvent, ButtonPressEvent, WindowClass, CreateWindowAux, CreateGCAux, Gcontext, Window};
+use x11rb::protocol::xproto::{
+    ButtonPressEvent, ConnectionExt as _, CreateGCAux, CreateWindowAux, EventMask, ExposeEvent,
+    Gcontext, KeyPressEvent, Window, WindowClass,
+};
 use x11rb::rust_connection::RustConnection;
 
 /// Backend implementation using the X11 protocol via x11rb.
@@ -26,9 +29,8 @@ impl X11Backend {
             0,
             WindowClass::INPUT_OUTPUT,
             0,
-            &CreateWindowAux::new().event_mask(
-                EventMask::EXPOSURE | EventMask::KEY_PRESS | EventMask::BUTTON_PRESS,
-            ),
+            &CreateWindowAux::new()
+                .event_mask(EventMask::EXPOSURE | EventMask::KEY_PRESS | EventMask::BUTTON_PRESS),
         )
         .unwrap();
         conn.map_window(window).unwrap();
@@ -59,9 +61,13 @@ impl GuiBackend for X11Backend {
                     let ch = char::from_u32(detail.into()).unwrap_or('\0');
                     Some(GuiEvent::Key(ch))
                 }
-                Event::ButtonPress(ButtonPressEvent { event_x, event_y, .. }) => {
-                    Some(GuiEvent::Click { x: event_x.into(), y: event_y.into() })
-                }
+                Event::ButtonPress(ButtonPressEvent {
+                    event_x, event_y, ..
+                }) => Some(GuiEvent::Click {
+                    x: event_x.into(),
+                    y: event_y.into(),
+                }),
+                Event::Expose(ExposeEvent { .. }) => Some(GuiEvent::Expose),
                 _ => None,
             }
         } else {

--- a/src/gui_rust.c
+++ b/src/gui_rust.c
@@ -3,6 +3,7 @@
 
 /*
  * Minimal C shell delegating GUI handling to the Rust implementation.
+ * The Rust side owns the event loop and drawing logic.
  */
 #ifdef FEAT_GUI_RUST
 void gui_start(char_u *arg UNUSED)


### PR DESCRIPTION
## Summary
- support new `Expose` event in `GuiEvent`
- X11 backend emits expose events so the Rust GUI can redraw
- Rust GUI entry loop redraws on expose events and C shim documents event loop transfer

## Testing
- `cargo fmt --manifest-path rust_gui_core/Cargo.toml && cargo fmt --manifest-path rust_gui_x11/Cargo.toml && cargo fmt --manifest-path rust_gui/Cargo.toml && cargo fmt --manifest-path rust_gui_gtk/Cargo.toml`
- `cargo test --manifest-path rust_gui_core/Cargo.toml`
- `cargo test --manifest-path rust_gui_x11/Cargo.toml`
- `cargo test --manifest-path rust_gui/Cargo.toml`
- `cargo test --manifest-path rust_gui_gtk/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b66985ce648320af83b476805bf76e