### PR TITLE
Improve scripting bindings with Result-based error handling

### DIFF
--- a/rust_mzsch/src/lib.rs
+++ b/rust_mzsch/src/lib.rs
@@ -1,11 +1,18 @@
 use libloading::Library;
 use std::os::raw::c_int;
 
+fn init() -> Result<(), ()> {
+    unsafe { Library::new("libmzscheme.so") }.map(|_| ()).map_err(|_| ())
+}
+
 /// Attempt to load the MzScheme library to verify availability.
 #[no_mangle]
 pub extern "C" fn vim_mzscheme_init() -> c_int {
-    match Library::new("libmzscheme.so") {
-        Ok(_) => 1,
-        Err(_) => 0,
-    }
+    init().map_or(0, |_| 1)
+}
+
+/// Alias exposed for compatibility with existing Vim commands.
+#[no_mangle]
+pub extern "C" fn mzscheme_init() -> c_int {
+    vim_mzscheme_init()
 }

--- a/rust_perl/src/lib.rs
+++ b/rust_perl/src/lib.rs
@@ -2,15 +2,25 @@ use perl_sys::*;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
+fn run_code(code: *const c_char) -> Result<(), ()> {
+    if code.is_null() {
+        return Err(());
+    }
+    let source = unsafe { CStr::from_ptr(code) }.to_str().map_err(|_| ())?;
+    unsafe {
+        eval_pv(source, 0);
+    }
+    Ok(())
+}
+
 /// Execute a snippet of Perl code.
 #[no_mangle]
 pub extern "C" fn vim_perl_exec(code: *const c_char) -> c_int {
-    if code.is_null() {
-        return 0;
-    }
-    unsafe {
-        let c_str = CStr::from_ptr(code);
-        eval_pv(c_str.to_str().unwrap_or(""), 0);
-    }
-    1
+    run_code(code).map_or(0, |_| 1)
+}
+
+/// Alias exposed for compatibility with existing Vim commands.
+#[no_mangle]
+pub extern "C" fn perl_execute(code: *const c_char) -> c_int {
+    vim_perl_exec(code)
 }

--- a/rust_python/src/lib.rs
+++ b/rust_python/src/lib.rs
@@ -2,31 +2,43 @@ use pyo3::prelude::*;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
+fn init() -> Result<(), ()> {
+    pyo3::prepare_freethreaded_python();
+    Ok(())
+}
+
+fn run_code(code: *const c_char) -> Result<(), ()> {
+    if code.is_null() {
+        return Err(());
+    }
+    let source = unsafe { CStr::from_ptr(code) }.to_str().map_err(|_| ())?;
+    Python::with_gil(|py| py.run(source, None, None)).map_err(|_| ())
+}
+
 /// Initialize the embedded Python interpreter for use within Vim.
 /// Returns 1 on success to mimic Vim's boolean conventions.
 #[no_mangle]
 pub extern "C" fn vim_python_init() -> c_int {
-    pyo3::prepare_freethreaded_python();
-    1
+    init().map_or(0, |_| 1)
 }
 
 /// Execute a snippet of Python code provided as a C string.
 /// Returns 1 when the code runs successfully, 0 otherwise.
 #[no_mangle]
 pub extern "C" fn vim_python_exec(code: *const c_char) -> c_int {
-    if code.is_null() {
-        return 0;
-    }
-    let c_str = unsafe { CStr::from_ptr(code) };
-    let source = match c_str.to_str() {
-        Ok(s) => s,
-        Err(_) => return 0,
-    };
+    run_code(code).map_or(0, |_| 1)
+}
 
-    Python::with_gil(|py| match py.run(source, None, None) {
-        Ok(_) => 1,
-        Err(_) => 0,
-    })
+/// Alias exposed for compatibility with existing Vim commands.
+#[no_mangle]
+pub extern "C" fn python_execute(code: *const c_char) -> c_int {
+    vim_python_exec(code)
+}
+
+/// Alias to initialize Python via a traditional name.
+#[no_mangle]
+pub extern "C" fn python_init() -> c_int {
+    vim_python_init()
 }
 
 #[cfg(test)]

--- a/rust_ruby/src/lib.rs
+++ b/rust_ruby/src/lib.rs
@@ -2,22 +2,23 @@ use magnus::{eval, Value};
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
+fn run_code(code: *const c_char) -> Result<(), ()> {
+    if code.is_null() {
+        return Err(());
+    }
+    let source = unsafe { CStr::from_ptr(code) }.to_str().map_err(|_| ())?;
+    let _cleanup = unsafe { magnus::embed::init() };
+    eval::<Value>(source).map(|_| ()).map_err(|_| ())
+}
+
 /// Execute Ruby code using the embedded interpreter.
 #[no_mangle]
 pub extern "C" fn vim_ruby_exec(code: *const c_char) -> c_int {
-    if code.is_null() {
-        return 0;
-    }
-    let c_str = unsafe { CStr::from_ptr(code) };
-    let source = match c_str.to_str() {
-        Ok(s) => s,
-        Err(_) => return 0,
-    };
-    if magnus::embed::init().is_err() {
-        return 0;
-    }
-    match eval::<Value>(source) {
-        Ok(_) => 1,
-        Err(_) => 0,
-    }
+    run_code(code).map_or(0, |_| 1)
+}
+
+/// Alias exposed for compatibility with existing Vim commands.
+#[no_mangle]
+pub extern "C" fn ruby_execute(code: *const c_char) -> c_int {
+    vim_ruby_exec(code)
 }

--- a/rust_tcl/src/lib.rs
+++ b/rust_tcl/src/lib.rs
@@ -1,19 +1,33 @@
 use std::os::raw::{c_char, c_int};
 use tcl_sys::{Tcl_CreateInterp, Tcl_DeleteInterp, Tcl_Eval, TCL_OK};
 
-/// Execute a Tcl command string.
-#[no_mangle]
-pub extern "C" fn vim_tcl_exec(code: *const c_char) -> c_int {
+fn run_code(code: *const c_char) -> Result<(), ()> {
     if code.is_null() {
-        return 0;
+        return Err(());
     }
     unsafe {
         let interp = Tcl_CreateInterp();
         if interp.is_null() {
-            return 0;
+            return Err(());
         }
         let result = Tcl_Eval(interp, code);
         Tcl_DeleteInterp(interp);
-        if result == TCL_OK as i32 { 1 } else { 0 }
+        if result == TCL_OK as i32 {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
+}
+
+/// Execute a Tcl command string.
+#[no_mangle]
+pub extern "C" fn vim_tcl_exec(code: *const c_char) -> c_int {
+    run_code(code).map_or(0, |_| 1)
+}
+
+/// Alias exposed for compatibility with existing Vim commands.
+#[no_mangle]
+pub extern "C" fn tcl_execute(code: *const c_char) -> c_int {
+    vim_tcl_exec(code)
 }


### PR DESCRIPTION
## Summary
- rewrite Python, Lua, Ruby, Perl, Tcl, and MzScheme bindings to use `Result`-based helpers
- expose `extern "C"` wrappers such as `python_execute` for Vim commands

## Testing
- `cargo test --manifest-path rust_python/Cargo.toml`
- `cargo test --manifest-path rust_lua/Cargo.toml` (fails: cannot find lua54 via pkg-config)
- `cargo test --manifest-path rust_ruby/Cargo.toml` (fails: missing `libruby.so` at runtime)
- `cargo test --manifest-path rust_perl/Cargo.toml` (fails: no matching package `perl-sys`)
- `cargo test --manifest-path rust_tcl/Cargo.toml` (fails: version `0.5` of `tcl-sys` not found)
- `cargo test --manifest-path rust_mzsch/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b66986d8508320b7241a0536238b0e