### PR TITLE
Add rust_job crate for async job handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ diff = { path = "rust/diff" }
 rust_buffer = { path = "rust_buffer" }
 rust_python = { path = "rust_python" }
 rust_profiler = { path = "rust_profiler" }
+rust_job = { path = "rust_job" }
 rust_debugger = { path = "rust_debugger" }
 rust_pty = { path = "rust_pty" }
 rust_wayland = { path = "rust_wayland" }

--- a/rust_job/Cargo.toml
+++ b/rust_job/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust_job"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["process", "macros", "rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+name = "rust_job"
+path = "src/lib.rs"
+crate-type = ["staticlib", "rlib"]

--- a/rust_job/src/lib.rs
+++ b/rust_job/src/lib.rs
@@ -1,0 +1,67 @@
+use std::ffi::{CStr};
+use std::os::raw::{c_char, c_int};
+use tokio::process::Command;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct JobConfig {
+    pub cmd: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug)]
+pub enum JobError {
+    Json(serde_json::Error),
+    Io(std::io::Error),
+}
+
+impl From<serde_json::Error> for JobError {
+    fn from(e: serde_json::Error) -> Self { JobError::Json(e) }
+}
+
+impl From<std::io::Error> for JobError {
+    fn from(e: std::io::Error) -> Self { JobError::Io(e) }
+}
+
+pub fn run_job(config: JobConfig) -> Result<i32, JobError> {
+    let rt = tokio::runtime::Runtime::new().map_err(JobError::Io)?;
+    let status = rt.block_on(async {
+        Command::new(&config.cmd).args(&config.args).status().await
+    })?;
+    Ok(status.code().unwrap_or_default())
+}
+
+#[no_mangle]
+pub extern "C" fn job_start(config_json: *const c_char, exit_code: *mut c_int) -> bool {
+    if config_json.is_null() || exit_code.is_null() {
+        return false;
+    }
+    let cstr = unsafe { CStr::from_ptr(config_json) };
+    let json_str = match cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    match serde_json::from_str::<JobConfig>(json_str) {
+        Ok(cfg) => match run_job(cfg) {
+            Ok(code) => {
+                unsafe { *exit_code = code; }
+                true
+            }
+            Err(_) => false,
+        },
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_true() {
+        let cfg = JobConfig { cmd: "true".into(), args: vec![] };
+        let code = run_job(cfg).expect("run true");
+        assert_eq!(code, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `rust_job` crate using Tokio for async process execution
- expose `job_start` C API with JSON-based configuration via Serde
- wire `rust_job` into top-level dependencies

## Testing
- `cargo test --manifest-path rust_job/Cargo.toml`
- `cargo check` *(fails: no matching package named `perl-sys` found)*

------
https://chatgpt.com/codex/tasks/task_e_68b669888b7c832080b2207546657f08