### PR TITLE
Add basic Vim9 echo command in Rust prototype

### DIFF
--- a/rust_vim9/src/compiler.rs
+++ b/rust_vim9/src/compiler.rs
@@ -21,5 +21,9 @@ fn compile_node(ast: &Ast, instrs: &mut Vec<Vim9Instr>) {
             compile_node(b, instrs);
             instrs.push(Vim9Instr::Add);
         }
+        Ast::Echo(expr) => {
+            compile_node(expr, instrs);
+            instrs.push(Vim9Instr::Echo);
+        }
     }
 }

--- a/rust_vim9/src/executor.rs
+++ b/rust_vim9/src/executor.rs
@@ -11,6 +11,11 @@ pub fn execute(prog: &Vim9Program) -> i64 {
                 let a = stack.pop().unwrap_or(0);
                 stack.push(a + b);
             }
+            Vim9Instr::Echo => {
+                if let Some(v) = stack.last() {
+                    println!("{}", v);
+                }
+            }
         }
     }
     stack.pop().unwrap_or(0)

--- a/rust_vim9/src/lib.rs
+++ b/rust_vim9/src/lib.rs
@@ -8,12 +8,12 @@ mod parser;
 mod compiler;
 mod executor;
 
-use parser::parse_addition;
+use parser::parse_line;
 use compiler::compile;
 use executor::execute;
 
 pub fn eval_expr(expr: &str) -> Option<i64> {
-    let ast = parse_addition(expr)?;
+    let ast = parse_line(expr)?;
     let prog = compile(&ast);
     Some(execute(&prog))
 }
@@ -64,6 +64,12 @@ mod tests {
     fn eval_simple_add() {
         let expr = "1 + 2 + 3";
         assert_eq!(eval_expr(expr), Some(6));
+    }
+
+    #[test]
+    fn echo_command_returns_value() {
+        let expr = "echo 4 + 5";
+        assert_eq!(eval_expr(expr), Some(9));
     }
 
     #[test]

--- a/rust_vim9/src/parser.rs
+++ b/rust_vim9/src/parser.rs
@@ -2,6 +2,7 @@
 pub enum Ast {
     Number(i64),
     Add(Box<Ast>, Box<Ast>),
+    Echo(Box<Ast>),
 }
 
 pub fn parse_addition(expr: &str) -> Option<Ast> {
@@ -14,4 +15,13 @@ pub fn parse_addition(expr: &str) -> Option<Ast> {
         ast = Ast::Add(Box::new(ast), Box::new(right));
     }
     Some(ast)
+}
+
+pub fn parse_line(line: &str) -> Option<Ast> {
+    let line = line.trim();
+    if let Some(rest) = line.strip_prefix("echo ") {
+        parse_addition(rest).map(|ast| Ast::Echo(Box::new(ast)))
+    } else {
+        parse_addition(line)
+    }
 }

--- a/rust_vim9/src/types.rs
+++ b/rust_vim9/src/types.rs
@@ -10,4 +10,5 @@ pub enum Vim9Type {
 pub enum Vim9Instr {
     Const(i64),
     Add,
+    Echo,
 }


### PR DESCRIPTION
## Summary
- Extend Vim9 AST and parser to recognise `echo` command
- Introduce `Echo` instruction and execution support
- Parse full command lines and test echo evaluation

## Testing
- `cargo test --manifest-path rust_vim9/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68b66e470af08320aa1867135b62dda1