### PR TITLE
feat: add highlight support to rust screen buffer

### DIFF
--- a/src/screen_rs.h
+++ b/src/screen_rs.h
@@ -13,6 +13,7 @@ ScreenBuffer *rs_screen_new(int width, int height);
 void rs_screen_free(ScreenBuffer *buf);
 void rs_screen_draw_text(ScreenBuffer *buf, int row, int col, const char *text, uint8_t attr);
 void rs_screen_clear_line(ScreenBuffer *buf, int row, uint8_t attr);
+void rs_screen_highlight(ScreenBuffer *buf, int row, int col, int len, uint8_t attr);
 typedef void (*rs_flush_cb)(int row, const char *text, const uint8_t *attr, int len);
 void rs_screen_flush(ScreenBuffer *buf, rs_flush_cb cb);
 


### PR DESCRIPTION
## Summary
- add highlight_range to ScreenBuffer and C FFI binding
- expose new rs_screen_highlight function to C callers
- regression tests for attribute-only updates

## Testing
- `cargo test >/tmp/unit.log && tail -n 20 /tmp/unit.log`
- `cargo test >/tmp/draw.log && tail -n 20 /tmp/draw.log`


------
https://chatgpt.com/codex/tasks/task_e_68b66e5608a083208734a5c0bae0b1a2