### PR TITLE
Add Rust-based cscope interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust_tcl = { path = "rust_tcl", optional = true }
 rust_mzsch = { path = "rust_mzsch", optional = true }
 rust_xcmdsrv = { path = "rust_xcmdsrv", optional = true }
 rust_ole = { path = "rust_ole", optional = true }
+rust_cscope = { path = "rust_cscope", optional = true }
 rust_alloc = { path = "rust_alloc" }
 
 [features]
@@ -34,6 +35,7 @@ tcl = ["rust_tcl"]
 mzsch = ["rust_mzsch"]
 xcmdsrv = ["rust_xcmdsrv"]
 ole = ["rust_ole"]
+cscope = ["rust_cscope"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rust_os_mswin = { path = "rust_os_mswin" }

--- a/rust_cscope/Cargo.toml
+++ b/rust_cscope/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_cscope"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+

--- a/rust_cscope/src/lib.rs
+++ b/rust_cscope/src/lib.rs
@@ -1,0 +1,39 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use std::process::Command;
+
+fn run_cscope(query: *const c_char) -> Result<(), ()> {
+    if query.is_null() {
+        return Err(());
+    }
+    let q = unsafe { CStr::from_ptr(query) }.to_str().map_err(|_| ())?;
+    let status = Command::new("cscope").arg("-L").arg(q).status();
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        _ => Err(()),
+    }
+}
+
+/// Query cscope using the provided query string.
+/// Returns 1 on success, 0 on failure.
+#[no_mangle]
+pub extern "C" fn vim_cscope_query(query: *const c_char) -> c_int {
+    run_cscope(query).map_or(0, |_| 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn null_query_fails() {
+        assert_eq!(vim_cscope_query(std::ptr::null()), 0);
+    }
+
+    #[test]
+    fn non_null_query_does_not_crash() {
+        let q = CString::new("hello").unwrap();
+        let _ = vim_cscope_query(q.as_ptr());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `rust_cscope` crate providing safe FFI wrapper for cscope queries
- wire crate into main `Cargo.toml` and expose via optional `cscope` feature

## Testing
- `cargo test` in `rust_cscope`
- `cargo test --features cscope` *(fails: no matching package named `perl-sys` found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66e4a8b4c8320b8bde59580c1a470