### PR TITLE
Add Rust-backed option parser

### DIFF
--- a/rust_option/build.rs
+++ b/rust_option/build.rs
@@ -1,7 +1,7 @@
 fn main() {
-    println!("cargo:rerun-if-changed=../src/rust_option.h");
+    println!("cargo:rerun-if-changed=../src/option_rs.h");
     let bindings = bindgen::Builder::default()
-        .header("../src/rust_option.h")
+        .header("../src/option_rs.h")
         .allowlist_type("rs_opt_t")
         .generate()
         .expect("Unable to generate bindings");

--- a/src/option.c
+++ b/src/option.c
@@ -38,7 +38,7 @@
 #define IN_OPTION_C
 #include "vim.h"
 #include "optiondefs.h"
-#include "rust_option.h"
+#include "option_rs.h"
 
 static const rs_opt_t *rs_option_table = NULL;
 static size_t rs_option_count = 0;
@@ -134,7 +134,16 @@ set_init_default_shell(void)
 	set_string_default_esc("sh", p, TRUE);
 #endif
     if (rs_verify_option("shell"))
-        rs_set_option("shell", (char *)p);
+    {
+        size_t len = STRLEN(p) + 7; // "shell=" + NUL
+        char *buf = (char *)alloc(len);
+        if (buf != NULL)
+        {
+            vim_snprintf(buf, len, "shell=%s", p);
+            rs_parse_option(buf);
+            vim_free(buf);
+        }
+    }
 }
 
 /*

--- a/src/option_rs.h
+++ b/src/option_rs.h
@@ -1,0 +1,16 @@
+#ifndef OPTION_RS_H
+#define OPTION_RS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "rust_option.h"
+
+bool rs_parse_option(const char *assignment);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OPTION_RS_H

--- a/src/optionstr.c
+++ b/src/optionstr.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "option_rs.h"
 
 static char_u shm_buf[SHM_LEN];
 static int set_shm_recursive = 0;
@@ -625,6 +626,21 @@ set_string_option(
     vim_free(saved_oldval_g);
     vim_free(saved_newval);
 #endif
+    if (errmsg == NULL)
+    {
+        char_u *fullname = get_option_fullname(opt_idx);
+        if (fullname != NULL)
+        {
+            size_t len = STRLEN(fullname) + STRLEN(s) + 2;
+            char *buf = (char *)alloc(len);
+            if (buf != NULL)
+            {
+                vim_snprintf(buf, len, "%s=%s", fullname, s);
+                rs_parse_option(buf);
+                vim_free(buf);
+            }
+        }
+    }
     return errmsg;
 }
 


### PR DESCRIPTION
## Summary
- introduce `Opt` struct and parser in `rust_option` with FFI `rs_parse_option`
- wire up new `option_rs.h` and use parser when setting defaults and string options
- add tests covering option parsing and C-side integration

## Testing
- `cargo test --manifest-path rust_option/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b66e53471c8320a0030d769007acca