### PR TITLE
Implement Blowfish, ZIP, and SHA-256 in Rust

### DIFF
--- a/src/rust/crypto/core/Cargo.lock
+++ b/src/rust/crypto/core/Cargo.lock
@@ -20,22 +20,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "cc"
-version = "1.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,12 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,17 +36,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -84,36 +51,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "untrusted",
- "windows-sys",
-]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "version_check"
@@ -127,84 +68,4 @@ version = "0.1.0"
 dependencies = [
  "blowfish",
  "libc",
- "ring",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/src/rust/crypto/core/Cargo.toml
+++ b/src/rust/crypto/core/Cargo.toml
@@ -8,6 +8,5 @@ name = "vim_crypto_core"
 crate-type = ["staticlib"]
 
 [dependencies]
-ring = "0.17"
 blowfish = "0.8"
 libc = "0.2"

--- a/src/rust/crypto/core/src/lib.rs
+++ b/src/rust/crypto/core/src/lib.rs
@@ -1,10 +1,10 @@
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
 use std::slice;
+use std::sync::Once;
 
 use blowfish::cipher::{generic_array::GenericArray, BlockEncrypt, NewBlockCipher};
 use blowfish::Blowfish;
-use ring::digest::{Context, SHA256};
 
 #[repr(C)]
 pub struct cryptstate_T {
@@ -23,6 +23,7 @@ pub struct crypt_arg_T {
     pub cat_init_from_file: c_int,
 }
 
+const CRYPT_M_ZIP: c_int = 0;
 const CRYPT_M_BF: c_int = 1;
 const CRYPT_M_BF2: c_int = 2;
 
@@ -60,14 +61,16 @@ impl BlowfishState {
 }
 
 fn sha256_hex(data: &[u8], salt: &[u8]) -> String {
-    let mut ctx = Context::new(&SHA256);
-    ctx.update(data);
+    let mut ctx = context_sha256_T { total: [0; 2], state: [0; 8], buffer: [0; 64] };
+    sha256_start_rust(&mut ctx);
+    sha256_update_rust(&mut ctx, data);
     if !salt.is_empty() {
-        ctx.update(salt);
+        sha256_update_rust(&mut ctx, salt);
     }
-    let digest = ctx.finish();
+    let mut out = [0u8; 32];
+    sha256_finish_rust(&mut ctx, &mut out);
     let mut s = String::with_capacity(64);
-    for b in digest.as_ref() {
+    for b in &out {
         s.push_str(&format!("{:02x}", b));
     }
     s
@@ -204,6 +207,449 @@ pub extern "C" fn crypt_blowfish_decode_inplace(
     crypt_blowfish_decode(state, buf as *const u8, len, buf, last);
 }
 
+struct ZipState {
+    keys: [u32; 3],
+}
+
+static mut CRC_TABLE: [u32; 256] = [0; 256];
+static CRC_INIT: Once = Once::new();
+
+fn make_crc_tab() {
+    unsafe {
+        CRC_INIT.call_once(|| {
+            for t in 0..256u32 {
+                let mut v = t;
+                for _ in 0..8 {
+                    v = (v >> 1) ^ ((v & 1) * 0xedb88320u32);
+                }
+                CRC_TABLE[t as usize] = v;
+            }
+        });
+    }
+}
+
+fn crc32(c: u32, b: u8) -> u32 {
+    unsafe { CRC_TABLE[((c as u8) ^ b) as usize] ^ (c >> 8) }
+}
+
+fn decrypt_byte_zip(keys: &[u32; 3]) -> u8 {
+    let temp = (keys[2] as u16 | 2) as u32;
+    (((temp.wrapping_mul(temp ^ 1)) >> 8) & 0xff) as u8
+}
+
+fn update_keys_zip(keys: &mut [u32; 3], c: u8) {
+    keys[0] = crc32(keys[0], c);
+    keys[1] = keys[1].wrapping_add(keys[0] & 0xff);
+    keys[1] = keys[1].wrapping_mul(134775813).wrapping_add(1);
+    keys[2] = crc32(keys[2], (keys[1] >> 24) as u8);
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_zip_init(
+    state: *mut cryptstate_T,
+    key: *const c_char,
+    _arg: *mut crypt_arg_T,
+) -> c_int {
+    if state.is_null() || key.is_null() {
+        return 0;
+    }
+    make_crc_tab();
+    let key_bytes = unsafe { CStr::from_ptr(key).to_bytes() };
+    let mut st = ZipState {
+        keys: [305419896, 591751049, 878082192],
+    };
+    for &b in key_bytes {
+        update_keys_zip(&mut st.keys, b);
+    }
+    unsafe {
+        (*state).method_state = Box::into_raw(Box::new(st)) as *mut c_void;
+    }
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_zip_encode(
+    state: *mut cryptstate_T,
+    from: *const u8,
+    len: usize,
+    to: *mut u8,
+    _last: c_int,
+) {
+    if state.is_null() || from.is_null() || to.is_null() {
+        return;
+    }
+    let st = unsafe { &mut *(*state).method_state.cast::<ZipState>() };
+    let from_slice = unsafe { slice::from_raw_parts(from, len) };
+    let to_slice = unsafe { slice::from_raw_parts_mut(to, len) };
+    for i in 0..len {
+        let ztemp = from_slice[i];
+        let t = decrypt_byte_zip(&st.keys);
+        update_keys_zip(&mut st.keys, ztemp);
+        to_slice[i] = t ^ ztemp;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_zip_decode(
+    state: *mut cryptstate_T,
+    from: *const u8,
+    len: usize,
+    to: *mut u8,
+    _last: c_int,
+) {
+    if state.is_null() || from.is_null() || to.is_null() {
+        return;
+    }
+    let st = unsafe { &mut *(*state).method_state.cast::<ZipState>() };
+    let from_slice = unsafe { slice::from_raw_parts(from, len) };
+    let to_slice = unsafe { slice::from_raw_parts_mut(to, len) };
+    for i in 0..len {
+        let t = decrypt_byte_zip(&st.keys);
+        let val = from_slice[i] ^ t;
+        update_keys_zip(&mut st.keys, val);
+        to_slice[i] = val;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_zip_encode_inplace(
+    state: *mut cryptstate_T,
+    buf: *mut u8,
+    len: usize,
+    _p2: *mut u8,
+    last: c_int,
+) {
+    crypt_zip_encode(state, buf as *const u8, len, buf, last);
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_zip_decode_inplace(
+    state: *mut cryptstate_T,
+    buf: *mut u8,
+    len: usize,
+    _p2: *mut u8,
+    last: c_int,
+) {
+    crypt_zip_decode(state, buf as *const u8, len, buf, last);
+}
+
+#[repr(C)]
+pub struct context_sha256_T {
+    total: [u32; 2],
+    state: [u32; 8],
+    buffer: [u8; 64],
+}
+
+const K256: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+fn sha256_start_rust(ctx: &mut context_sha256_T) {
+    ctx.total = [0, 0];
+    ctx.state = [
+        0x6a09e667,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+}
+
+fn sha256_process(ctx: &mut context_sha256_T, data: &[u8; 64]) {
+    fn rotr(x: u32, n: u32) -> u32 {
+        (x >> n) | (x << (32 - n))
+    }
+
+    let mut w = [0u32; 64];
+    for i in 0..16 {
+        let j = i * 4;
+        w[i] = u32::from_be_bytes([
+            data[j],
+            data[j + 1],
+            data[j + 2],
+            data[j + 3],
+        ]);
+    }
+    for t in 16..64 {
+        let s0 = rotr(w[t - 15], 7) ^ rotr(w[t - 15], 18) ^ (w[t - 15] >> 3);
+        let s1 = rotr(w[t - 2], 17) ^ rotr(w[t - 2], 19) ^ (w[t - 2] >> 10);
+        w[t] = w[t - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[t - 7])
+            .wrapping_add(s1);
+    }
+
+    let mut a = ctx.state[0];
+    let mut b = ctx.state[1];
+    let mut c = ctx.state[2];
+    let mut d = ctx.state[3];
+    let mut e = ctx.state[4];
+    let mut f = ctx.state[5];
+    let mut g = ctx.state[6];
+    let mut h = ctx.state[7];
+
+    for i in 0..64 {
+        let s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+        let ch = (e & f) ^ ((!e) & g);
+        let temp1 = h
+            .wrapping_add(s1)
+            .wrapping_add(ch)
+            .wrapping_add(K256[i])
+            .wrapping_add(w[i]);
+        let s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let temp2 = s0.wrapping_add(maj);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = temp1.wrapping_add(temp2);
+    }
+
+    ctx.state[0] = ctx.state[0].wrapping_add(a);
+    ctx.state[1] = ctx.state[1].wrapping_add(b);
+    ctx.state[2] = ctx.state[2].wrapping_add(c);
+    ctx.state[3] = ctx.state[3].wrapping_add(d);
+    ctx.state[4] = ctx.state[4].wrapping_add(e);
+    ctx.state[5] = ctx.state[5].wrapping_add(f);
+    ctx.state[6] = ctx.state[6].wrapping_add(g);
+    ctx.state[7] = ctx.state[7].wrapping_add(h);
+}
+
+fn sha256_update_rust(ctx: &mut context_sha256_T, input: &[u8]) {
+    if input.is_empty() {
+        return;
+    }
+    let mut left = (ctx.total[0] & 0x3f) as usize;
+    let fill = 64 - left;
+
+    ctx.total[0] = ctx.total[0].wrapping_add(input.len() as u32);
+    if ctx.total[0] < input.len() as u32 {
+        ctx.total[1] = ctx.total[1].wrapping_add(1);
+    }
+
+    let mut data = input;
+    if left != 0 && data.len() >= fill {
+        ctx.buffer[left..left + fill].copy_from_slice(&data[..fill]);
+        sha256_process(ctx, unsafe { &*(ctx.buffer.as_ptr() as *const [u8; 64]) });
+        data = &data[fill..];
+        left = 0;
+    }
+    while data.len() >= 64 {
+        let mut block = [0u8; 64];
+        block.copy_from_slice(&data[..64]);
+        sha256_process(ctx, &block);
+        data = &data[64..];
+    }
+    if !data.is_empty() {
+        ctx.buffer[left..left + data.len()].copy_from_slice(data);
+    }
+}
+
+fn sha256_finish_rust(ctx: &mut context_sha256_T, digest: &mut [u8; 32]) {
+    let mut msglen = [0u8; 8];
+    let high = (ctx.total[0] >> 29) | (ctx.total[1] << 3);
+    let low = ctx.total[0] << 3;
+    msglen[..4].copy_from_slice(&high.to_be_bytes());
+    msglen[4..].copy_from_slice(&low.to_be_bytes());
+
+    let last = (ctx.total[0] & 0x3f) as usize;
+    let padn = if last < 56 { 56 - last } else { 120 - last };
+    sha256_update_rust(ctx, &SHA256_PADDING[..padn]);
+    sha256_update_rust(ctx, &msglen);
+
+    for (i, chunk) in digest.chunks_mut(4).enumerate() {
+        chunk.copy_from_slice(&ctx.state[i].to_be_bytes());
+    }
+}
+
+static SHA256_PADDING: [u8; 64] = [
+    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+#[no_mangle]
+pub extern "C" fn sha256_start(ctx: *mut context_sha256_T) {
+    if ctx.is_null() {
+        return;
+    }
+    sha256_start_rust(unsafe { &mut *ctx });
+}
+
+#[no_mangle]
+pub extern "C" fn sha256_update(
+    ctx: *mut context_sha256_T,
+    input: *mut u8,
+    length: u32,
+) {
+    if ctx.is_null() || input.is_null() || length == 0 {
+        return;
+    }
+    let data = unsafe { slice::from_raw_parts(input, length as usize) };
+    sha256_update_rust(unsafe { &mut *ctx }, data);
+}
+
+#[no_mangle]
+pub extern "C" fn sha256_finish(ctx: *mut context_sha256_T, digest: *mut u8) {
+    if ctx.is_null() || digest.is_null() {
+        return;
+    }
+    let mut out = [0u8; 32];
+    sha256_finish_rust(unsafe { &mut *ctx }, &mut out);
+    unsafe {
+        slice::from_raw_parts_mut(digest, 32).copy_from_slice(&out);
+    }
+}
+
+static mut SHA256_HEX: [u8; 65] = [0; 65];
+
+#[no_mangle]
+pub extern "C" fn sha256_bytes(
+    buf: *mut u8,
+    buf_len: c_int,
+    salt: *mut u8,
+    salt_len: c_int,
+) -> *mut u8 {
+    unsafe {
+        let data = slice::from_raw_parts(buf, buf_len as usize);
+        let salt_slice = if salt.is_null() {
+            &[]
+        } else {
+            slice::from_raw_parts(salt, salt_len as usize)
+        };
+        let mut ctx = context_sha256_T {
+            total: [0; 2],
+            state: [0; 8],
+            buffer: [0; 64],
+        };
+        sha256_start_rust(&mut ctx);
+        sha256_update_rust(&mut ctx, data);
+        if !salt_slice.is_empty() {
+            sha256_update_rust(&mut ctx, salt_slice);
+        }
+        let mut out = [0u8; 32];
+        sha256_finish_rust(&mut ctx, &mut out);
+        for (i, b) in out.iter().enumerate() {
+            SHA256_HEX[i * 2] = b"0123456789abcdef"[(b >> 4) as usize];
+            SHA256_HEX[i * 2 + 1] = b"0123456789abcdef"[(b & 0xf) as usize];
+        }
+        SHA256_HEX[64] = 0;
+        SHA256_HEX.as_mut_ptr()
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn sha256_key(
+    buf: *mut u8,
+    salt: *mut u8,
+    salt_len: c_int,
+) -> *mut u8 {
+    if buf.is_null() || unsafe { *buf } == 0 {
+        return b"\0".as_ptr() as *mut u8;
+    }
+    unsafe {
+        let len = libc::strlen(buf as *const i8);
+        sha256_bytes(buf, len as c_int, salt, salt_len)
+    }
+}
+
+static mut SHA256_SELF_TESTED: c_int = 0;
+static mut SHA256_FAILURES: c_int = 0;
+
+#[no_mangle]
+pub extern "C" fn sha256_self_test() -> c_int {
+    unsafe {
+        if SHA256_SELF_TESTED > 0 {
+            return if SHA256_FAILURES > 0 { 0 } else { 1 };
+        }
+        SHA256_SELF_TESTED = 1;
+        const MSGS: [&[u8]; 2] = [b"abc", b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"];
+        const VECTORS: [&str; 2] = [
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+        ];
+        for (msg, vec) in MSGS.iter().zip(VECTORS.iter()) {
+            let mut ctx = context_sha256_T { total: [0; 2], state: [0; 8], buffer: [0; 64] };
+            sha256_start_rust(&mut ctx);
+            sha256_update_rust(&mut ctx, msg);
+            let mut out = [0u8; 32];
+            sha256_finish_rust(&mut ctx, &mut out);
+            let mut hex = String::with_capacity(64);
+            for b in &out {
+                hex.push_str(&format!("{:02x}", b));
+            }
+            if hex != *vec {
+                SHA256_FAILURES += 1;
+            }
+        }
+        if SHA256_FAILURES > 0 { 0 } else { 1 }
+    }
+}
+
+fn get_some_time() -> u32 {
+    unsafe {
+        #[cfg(any(unix, target_os = "wasi"))]
+        {
+            let mut tv: libc::timeval = std::mem::zeroed();
+            if libc::gettimeofday(&mut tv, std::ptr::null_mut()) == 0 {
+                return (tv.tv_sec as u32).wrapping_add(tv.tv_usec as u32);
+            }
+        }
+        libc::time(std::ptr::null_mut()) as u32
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn sha2_seed(
+    header: *mut u8,
+    header_len: c_int,
+    salt: *mut u8,
+    salt_len: c_int,
+) {
+    if header.is_null() {
+        return;
+    }
+    unsafe {
+        libc::srand(get_some_time());
+        let mut random_data = [0u8; 1000];
+        for i in 0..random_data.len() - 1 {
+            random_data[i] = ((get_some_time() ^ libc::rand() as u32) & 0xff) as u8;
+        }
+        let mut ctx = context_sha256_T { total: [0; 2], state: [0; 8], buffer: [0; 64] };
+        sha256_start_rust(&mut ctx);
+        sha256_update_rust(&mut ctx, &random_data);
+        let mut sha256sum = [0u8; 32];
+        sha256_finish_rust(&mut ctx, &mut sha256sum);
+        for i in 0..header_len as usize {
+            *header.add(i) = sha256sum[i % 32];
+        }
+        if !salt.is_null() {
+            for i in 0..salt_len as usize {
+                *salt.add(i) = sha256sum[(i + header_len as usize) % 32];
+            }
+        }
+    }
+}
+
 #[repr(C)]
 pub struct cryptmethod_T {
     pub name: *const c_char,
@@ -251,13 +697,13 @@ static METHODS: [cryptmethod_T; 5] = [
         works_inplace: 1,
         whole_undofile: 0,
         self_test_fn: None,
-        init_fn: None,
-        encode_fn: None,
-        decode_fn: None,
+        init_fn: Some(crypt_zip_init),
+        encode_fn: Some(crypt_zip_encode),
+        decode_fn: Some(crypt_zip_decode),
         encode_buffer_fn: None,
         decode_buffer_fn: None,
-        encode_inplace_fn: None,
-        decode_inplace_fn: None,
+        encode_inplace_fn: Some(crypt_zip_encode_inplace),
+        decode_inplace_fn: Some(crypt_zip_decode_inplace),
     },
     cryptmethod_T {
         name: BF_NAME.as_ptr() as *const c_char,
@@ -362,6 +808,21 @@ mod tests {
         assert_eq!(1, crypt_blowfish_init(&mut state_dec, key.as_ptr(), &mut arg));
         let mut dec = vec![0u8; data.len()];
         crypt_blowfish_decode(&mut state_dec, enc.as_ptr(), enc.len(), dec.as_mut_ptr(), 1);
+        assert_eq!(data.to_vec(), dec);
+    }
+
+    #[test]
+    fn zip_roundtrip() {
+        let key = CString::new("test").unwrap();
+        let mut state_enc = cryptstate_T { method_nr: CRYPT_M_ZIP, method_state: std::ptr::null_mut() };
+        assert_eq!(1, crypt_zip_init(&mut state_enc, key.as_ptr(), std::ptr::null_mut()));
+        let data = b"hello world";
+        let mut enc = vec![0u8; data.len()];
+        crypt_zip_encode(&mut state_enc, data.as_ptr(), data.len(), enc.as_mut_ptr(), 1);
+        let mut state_dec = cryptstate_T { method_nr: CRYPT_M_ZIP, method_state: std::ptr::null_mut() };
+        assert_eq!(1, crypt_zip_init(&mut state_dec, key.as_ptr(), std::ptr::null_mut()));
+        let mut dec = vec![0u8; data.len()];
+        crypt_zip_decode(&mut state_dec, enc.as_ptr(), enc.len(), dec.as_mut_ptr(), 1);
         assert_eq!(data.to_vec(), dec);
     }
 }


### PR DESCRIPTION
## Summary
- port Blowfish, ZIP, and SHA-256 cryptographic routines to Rust
- expose ZIP and SHA-256 to cryptmethod table and remove ring dependency
- add unit tests for Blowfish and ZIP roundtrips

## Testing
- `cargo test --manifest-path src/rust/crypto/core/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b66e4b68c483208ddf193d9e53969f