### PR TITLE
Use Rust for Windows tick count and tty detection

### DIFF
--- a/rust_os_mswin/Cargo.lock
+++ b/rust_os_mswin/Cargo.lock
@@ -3,9 +3,16 @@
 version = 4
 
 [[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
 name = "rust_os_mswin"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "windows",
 ]
 

--- a/rust_os_mswin/Cargo.toml
+++ b/rust_os_mswin/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 windows = { version = "0.52", features = ["Win32_System_SystemInformation"] }
+libc = "0.2"
 
 [lib]
 name = "rust_os_mswin"

--- a/rust_os_mswin/src/lib.rs
+++ b/rust_os_mswin/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(target_os = "windows")]
 
+use libc::{c_int, _isatty};
 use windows::Win32::System::SystemInformation::GetTickCount;
 
 #[no_mangle]
@@ -15,4 +16,10 @@ pub extern "C" fn os_mswin_shutdown() {
 #[no_mangle]
 pub extern "C" fn os_mswin_get_tick_count() -> u32 {
     unsafe { GetTickCount() }
+}
+
+/// Simple wrapper around the CRT `_isatty` to detect console handles.
+#[no_mangle]
+pub extern "C" fn os_mswin_isatty(fd: c_int) -> c_int {
+    unsafe { _isatty(fd) }
 }

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -11,6 +11,9 @@
  * misc2.c: Various functions.
  */
 #include "vim.h"
+#ifdef MSWIN
+# include "rust_os_mswin.h"
+#endif
 
 static char_u	*username = NULL; // cached result of mch_get_user_name()
 
@@ -2984,7 +2987,7 @@ elapsed(struct timeval *start_tv)
     long
 elapsed(DWORD start_tick)
 {
-    DWORD	now = GetTickCount();
+    DWORD	now = os_mswin_get_tick_count();
 
     return (long)now - (long)start_tick;
 }

--- a/src/os_mswin.c
+++ b/src/os_mswin.c
@@ -14,6 +14,7 @@
  */
 
 #include "vim.h"
+#include "rust_os_mswin.h"
 
 #include <sys/types.h>
 #include <signal.h>
@@ -190,8 +191,8 @@ mch_input_isatty(void)
 	return TRUE;	    // GUI always has a tty
 #endif
 #if !defined(FEAT_GUI_MSWIN) || defined(VIMDLL)
-    if (isatty(read_cmd_fd))
-	return TRUE;
+    if (os_mswin_isatty(read_cmd_fd))
+        return TRUE;
     return FALSE;
 #endif
 }

--- a/src/rust_os_mswin.h
+++ b/src/rust_os_mswin.h
@@ -1,0 +1,11 @@
+#ifndef RUST_OS_MSWIN_H
+#define RUST_OS_MSWIN_H
+
+#include <stdint.h>
+
+void os_mswin_startup(void);
+void os_mswin_shutdown(void);
+uint32_t os_mswin_get_tick_count(void);
+int os_mswin_isatty(int fd);
+
+#endif // RUST_OS_MSWIN_H


### PR DESCRIPTION
## Summary
- expose `os_mswin_isatty` in Rust and call from C
- route elapsed tick count via Rust `os_mswin_get_tick_count`
- add header for Rust Windows OS helpers

## Testing
- `cargo check --manifest-path rust_os_mswin/Cargo.toml --target x86_64-pc-windows-msvc` *(fails: can't find crate for `core` - target not installed)*
- `cargo test` *(fails: no matching package named `perl-sys` found)*

------
https://chatgpt.com/codex/tasks/task_e_68b789615e148320832c20cd28ffc7ac