### PR TITLE
Store memline handle per buffer

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -8,32 +8,37 @@ extern bool rs_ml_delete(void *buf, size_t lnum);
 extern bool rs_ml_replace(void *buf, size_t lnum, const char *line);
 extern unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
 
-static void *rs_buffer = NULL;
-
 int ml_open(buf_T *buf)
 {
-    rs_buffer = rs_ml_buffer_new();
-    // Initialize with one empty line, as Vim expects buffers to have at
-    // least one line.
-    (void)rs_ml_append(rs_buffer, 0, "");
-    if (buf != NULL)
-        buf->b_ml.ml_line_count = 1;
+    // Allocate a fresh Rust memline buffer and store the opaque pointer in
+    // b_ml.ml_mfp.  The rest of the memline_T fields are unused by the Rust
+    // backend but keeping them allows existing code to keep working.
+    buf->b_ml.ml_mfp = (memfile_T *)rs_ml_buffer_new();
+    if (buf->b_ml.ml_mfp == NULL)
+        return FAIL;
+
+    // Initialize with one empty line, as Vim expects buffers to have at least
+    // one line.
+    (void)rs_ml_append((void *)buf->b_ml.ml_mfp, 0, "");
+    buf->b_ml.ml_line_count = 1;
     return OK;
 }
 
-void ml_close(buf_T *buf UNUSED, int del_file UNUSED)
+void ml_close(buf_T *buf, int del_file UNUSED)
 {
-    if (rs_buffer != NULL)
+    if (buf != NULL && buf->b_ml.ml_mfp != NULL)
     {
-        rs_ml_buffer_free(rs_buffer);
-        rs_buffer = NULL;
+        rs_ml_buffer_free((void *)buf->b_ml.ml_mfp);
+        buf->b_ml.ml_mfp = NULL;
     }
 }
 
 int ml_append(linenr_T lnum, char_u *line, colnr_T len UNUSED, int newfile UNUSED)
 {
+    void *rs_buffer = (void *)curbuf->b_ml.ml_mfp;
     if (rs_ml_append(rs_buffer, (size_t)lnum, (const char *)line)) {
-        // Vim uses 1-based line numbers; appending after lnum increases count by 1.
+        // Vim uses 1-based line numbers; appending after lnum increases count
+        // by 1.
         ++curbuf->b_ml.ml_line_count;
         return OK;
     }
@@ -42,6 +47,7 @@ int ml_append(linenr_T lnum, char_u *line, colnr_T len UNUSED, int newfile UNUSE
 
 int ml_delete(linenr_T lnum)
 {
+    void *rs_buffer = (void *)curbuf->b_ml.ml_mfp;
     if (rs_ml_delete(rs_buffer, (size_t)lnum)) {
         if (curbuf->b_ml.ml_line_count > 0)
             --curbuf->b_ml.ml_line_count;
@@ -52,11 +58,6 @@ int ml_delete(linenr_T lnum)
 
 int ml_replace(linenr_T lnum, char_u *line, int copy UNUSED)
 {
+    void *rs_buffer = (void *)curbuf->b_ml.ml_mfp;
     return rs_ml_replace(rs_buffer, (size_t)lnum, (const char *)line) ? OK : FAIL;
-}
-
-// Accessor to the underlying Rust buffer for use in compatibility stubs.
-void *vim_rs_memline_buf(void)
-{
-    return rs_buffer;
 }

--- a/src/memline_compat.c
+++ b/src/memline_compat.c
@@ -2,7 +2,6 @@
 
 #include "vim.h"
 
-extern void *vim_rs_memline_buf(void);
 extern unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
 
 void ml_set_crypt_key(buf_T *buf, char_u *old_key, char_u *old_cm)
@@ -28,7 +27,7 @@ static char_u empty_line[] = "";
 char_u *ml_get(linenr_T lnum)
 {
     size_t len = 0;
-    char_u *p = (char_u *)rs_ml_get_line(vim_rs_memline_buf(), (size_t)lnum, 0, &len);
+    char_u *p = (char_u *)rs_ml_get_line((void *)curbuf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
     curbuf->b_ml.ml_line_ptr = p;
     curbuf->b_ml.ml_line_lnum = lnum;
     curbuf->b_ml.ml_line_len = (colnr_T)(len + 1);
@@ -57,7 +56,7 @@ char_u *ml_get_cursor(void)
 colnr_T ml_get_len(linenr_T lnum)
 {
     size_t len = 0;
-    (void)rs_ml_get_line(vim_rs_memline_buf(), (size_t)lnum, 0, &len);
+    (void)rs_ml_get_line((void *)curbuf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
     return (colnr_T)len;
 }
 
@@ -79,15 +78,15 @@ colnr_T ml_get_cursor_len(void)
 
 colnr_T ml_get_buf_len(buf_T *buf, linenr_T lnum)
 {
-    (void)buf; // single buffer backend for now
-    return ml_get_len(lnum);
+    size_t len = 0;
+    (void)rs_ml_get_line((void *)buf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
+    return (colnr_T)len;
 }
 
 char_u *ml_get_buf(buf_T *buf, linenr_T lnum, int will_change)
 {
-    (void)buf; // single buffer backend for now
     size_t len = 0;
-    char_u *p = (char_u *)rs_ml_get_line(vim_rs_memline_buf(), (size_t)lnum, will_change ? 1 : 0, &len);
+    char_u *p = (char_u *)rs_ml_get_line((void *)buf->b_ml.ml_mfp, (size_t)lnum, will_change ? 1 : 0, &len);
     curbuf->b_ml.ml_line_ptr = p;
     curbuf->b_ml.ml_line_lnum = lnum;
     curbuf->b_ml.ml_line_len = (colnr_T)(len + 1);


### PR DESCRIPTION
## Summary
- keep a Rust memline handle per `buf_T` instead of a global
- update compatibility functions to access the buffer-specific handle

## Testing
- `cargo test --manifest-path rust_buffer/Cargo.toml`
- `cargo test --manifest-path rust_memline/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b789682390832096823ebdeda53433