### PR TITLE
Add platform abstractions for terminal and pty

### DIFF
--- a/rust_pty/Cargo.toml
+++ b/rust_pty/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nix = { version = "0.27", features = ["term"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "io-util"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.27", features = ["term"] }

--- a/rust_pty/src/lib.rs
+++ b/rust_pty/src/lib.rs
@@ -1,20 +1,3 @@
-use nix::pty::{openpty, OpenptyResult};
-use std::io;
-use tokio::task;
-use nix::unistd::{read, write};
+mod platform;
 
-/// Open a new pseudo terminal using `nix`.
-pub fn open() -> io::Result<OpenptyResult> {
-    openpty(None, None).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-}
-
-/// Echo data back on the file descriptor using blocking reads wrapped in `tokio`.
-pub async fn echo_loop(fd: i32) -> io::Result<()> {
-    let mut buf = [0u8; 1024];
-    loop {
-        let n = task::spawn_blocking(move || read(fd, &mut buf)).await.unwrap()?;
-        if n == 0 { break; }
-        task::spawn_blocking(move || write(fd, &buf[..n])).await.unwrap()?;
-    }
-    Ok(())
-}
+pub use platform::{echo_loop, open, OpenptyResult};

--- a/rust_pty/src/platform/fallback.rs
+++ b/rust_pty/src/platform/fallback.rs
@@ -1,0 +1,11 @@
+use std::io;
+
+pub struct OpenptyResult;
+
+pub fn open() -> io::Result<OpenptyResult> {
+    Err(io::Error::new(io::ErrorKind::Other, "unsupported platform"))
+}
+
+pub async fn echo_loop(_fd: i32) -> io::Result<()> {
+    Err(io::Error::new(io::ErrorKind::Other, "unsupported platform"))
+}

--- a/rust_pty/src/platform/mod.rs
+++ b/rust_pty/src/platform/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::*;
+
+#[cfg(not(unix))]
+mod fallback;
+#[cfg(not(unix))]
+pub use fallback::*;

--- a/rust_pty/src/platform/unix.rs
+++ b/rust_pty/src/platform/unix.rs
@@ -1,0 +1,36 @@
+use nix::pty::openpty;
+pub use nix::pty::OpenptyResult;
+use nix::unistd::{read, write};
+use std::io;
+use tokio::task;
+
+pub fn open() -> io::Result<OpenptyResult> {
+    openpty(None, None).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+}
+
+pub async fn echo_loop(fd: i32) -> io::Result<()> {
+    let mut buf = [0u8; 1024];
+    loop {
+        let n = task::spawn_blocking({
+            let mut b = buf;
+            move || {
+                let res = read(fd, &mut b);
+                res.map(|n| (n, b))
+            }
+        })
+        .await
+        .unwrap()?;
+        let (n, tmp) = n;
+        buf = tmp;
+        if n == 0 {
+            break;
+        }
+        task::spawn_blocking({
+            let data = buf[..n].to_vec();
+            move || write(fd, &data).map(|_| ())
+        })
+        .await
+        .unwrap()?;
+    }
+    Ok(())
+}

--- a/rust_term/Cargo.lock
+++ b/rust_term/Cargo.lock
@@ -3,14 +3,37 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "rust_term"
 version = "0.1.0"
 dependencies = [
- "libc",
+ "nix",
 ]

--- a/rust_term/Cargo.toml
+++ b/rust_term/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"
+nix = { version = "0.27", features = ["term", "ioctl"] }

--- a/rust_term/src/lib.rs
+++ b/rust_term/src/lib.rs
@@ -2,8 +2,7 @@ use std::ffi::CStr;
 use std::io::{stdout, Write};
 use std::os::raw::{c_char, c_int};
 
-#[cfg(unix)]
-use libc::{ioctl, winsize, STDOUT_FILENO, TIOCGWINSZ};
+mod platform;
 
 /// Simple owned buffer used for terminal output.
 struct TermBuffer {
@@ -149,24 +148,7 @@ pub unsafe extern "C" fn rust_term_get_winsize(
     width: *mut c_int,
     height: *mut c_int,
 ) -> c_int {
-    #[cfg(unix)]
-    {
-        let mut ws: winsize = std::mem::zeroed();
-        if ioctl(STDOUT_FILENO, TIOCGWINSZ, &mut ws) == -1 {
-            return -1;
-        }
-        if !width.is_null() {
-            *width = ws.ws_col as c_int;
-        }
-        if !height.is_null() {
-            *height = ws.ws_row as c_int;
-        }
-        0
-    }
-    #[cfg(not(unix))]
-    {
-        -1
-    }
+    platform::get_winsize(width, height)
 }
 
 // --- Tests -----------------------------------------------------------------

--- a/rust_term/src/platform/fallback.rs
+++ b/rust_term/src/platform/fallback.rs
@@ -1,0 +1,5 @@
+use std::os::raw::c_int;
+
+pub unsafe fn get_winsize(_width: *mut c_int, _height: *mut c_int) -> c_int {
+    -1
+}

--- a/rust_term/src/platform/mod.rs
+++ b/rust_term/src/platform/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use unix::*;
+
+#[cfg(not(unix))]
+mod fallback;
+#[cfg(not(unix))]
+pub use fallback::*;

--- a/rust_term/src/platform/unix.rs
+++ b/rust_term/src/platform/unix.rs
@@ -1,0 +1,18 @@
+use std::os::raw::c_int;
+use nix::libc::{winsize, STDOUT_FILENO};
+
+nix::ioctl_read_bad!(tiocgwinsz, nix::libc::TIOCGWINSZ, winsize);
+
+pub unsafe fn get_winsize(width: *mut c_int, height: *mut c_int) -> c_int {
+    let mut ws: winsize = std::mem::zeroed();
+    if tiocgwinsz(STDOUT_FILENO, &mut ws).is_err() {
+        return -1;
+    }
+    if !width.is_null() {
+        *width = ws.ws_col as c_int;
+    }
+    if !height.is_null() {
+        *height = ws.ws_row as c_int;
+    }
+    0
+}


### PR DESCRIPTION
## Summary
- add platform-specific modules for rust_term using nix to query window size
- add platform abstraction for rust_pty with unix and fallback implementations

## Testing
- `cargo test --manifest-path rust_term/Cargo.toml`
- `cargo test --manifest-path rust_pty/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b789954a148320876e54557c796cb3