### PR TITLE
refactor: remove unnecessary mut

### DIFF
--- a/rust_memline/src/lib.rs
+++ b/rust_memline/src/lib.rs
@@ -24,7 +24,7 @@ impl MemBuffer {
         }
 
         let insert_at = lnum + 1;
-        let mut tail: BTreeMap<usize, String> = self.lines.split_off(&insert_at);
+        let tail: BTreeMap<usize, String> = self.lines.split_off(&insert_at);
         self.lines.insert(insert_at, line.to_string());
         for (i, (_, l)) in tail.into_iter().enumerate() {
             self.lines.insert(insert_at + 1 + i, l);


### PR DESCRIPTION
## Summary
- clean up MemBuffer append logic by dropping unused mut qualifier

## Testing
- `cargo test -p rust_memline`
- `cargo test -p rust_alloc`
- `cargo test -p rust_buffer`
- `cargo test -p rust_text`


------
https://chatgpt.com/codex/tasks/task_e_68b7bd42055c83209fb06a25262a4043