### PR TITLE
Integrate GUI backend with feature flags in rust_drawscreen

### DIFF
--- a/rust_drawscreen/Cargo.toml
+++ b/rust_drawscreen/Cargo.toml
@@ -5,6 +5,16 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
+rust_gui_core = { path = "../rust_gui_core" }
+rust_gui_x11 = { path = "../rust_gui_x11", optional = true }
+rust_gui_w32 = { path = "../rust_gui_w32", optional = true }
+
+[features]
+# Select which backend implementation to use.  Windows is the default so
+# that tests run on platforms without an X server.
+default = ["w32"]
+x11 = ["rust_gui_x11"]
+w32 = ["rust_gui_w32"]
 
 [lib]
 name = "rust_drawscreen"

--- a/rust_drawscreen/src/lib.rs
+++ b/rust_drawscreen/src/lib.rs
@@ -1,12 +1,22 @@
 use libc::c_int;
-use std::sync::OnceLock;
+use rust_gui_core::GuiCore;
+use std::sync::{Mutex, OnceLock};
 
-// Store screen dimensions provided by C side.
+// Store screen dimensions provided by C side and a handle to the GUI backend.
 static SCREEN_SIZE: OnceLock<(c_int, c_int)> = OnceLock::new();
+static GUI: OnceLock<Mutex<GuiCore<Backend>>> = OnceLock::new();
+
+#[cfg(feature = "x11")]
+use rust_gui_x11::X11Backend as Backend;
+#[cfg(feature = "w32")]
+use rust_gui_w32::W32Backend as Backend;
 
 #[no_mangle]
 pub extern "C" fn rs_drawscreen_init(width: c_int, height: c_int) {
     let _ = SCREEN_SIZE.set((width, height));
+    let backend = Backend::new();
+    let gui = GuiCore::new(backend);
+    let _ = GUI.set(Mutex::new(gui));
 }
 
 #[no_mangle]
@@ -15,6 +25,11 @@ pub extern "C" fn rs_update_screen(typ: c_int) {
         eprintln!("update_screen type={} size={}x{}", typ, w, h);
     } else {
         eprintln!("update_screen called before init: type={}", typ);
+    }
+
+    if let Some(gui) = GUI.get() {
+        let mut gui = gui.lock().unwrap();
+        gui.draw_text(&format!("update_screen type={typ}"));
     }
 }
 
@@ -27,5 +42,21 @@ mod tests {
         rs_drawscreen_init(80, 24);
         rs_update_screen(1);
         assert!(SCREEN_SIZE.get().is_some());
+
+        // When using the w32 backend the drawn text is recorded and can be
+        // inspected here.  This verifies that `rs_update_screen` forwards to
+        // the backend through the common GUI interface.
+        #[cfg(feature = "w32")]
+        {
+            let drawn = GUI
+                .get()
+                .unwrap()
+                .lock()
+                .unwrap()
+                .backend_mut()
+                .drawn
+                .clone();
+            assert_eq!(drawn, vec!["update_screen type=1".to_string()]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add optional X11 and Windows GUI backends to rust_drawscreen
- forward screen updates through shared GuiCore interface
- test drawing logic via Windows backend

## Testing
- `cargo test -p rust_drawscreen`

------
https://chatgpt.com/codex/tasks/task_e_68b7bf54b85c83209b1d2b77b66f4a1c