### PR TITLE
Integrate Rust-backed line retrieval

### DIFF
--- a/rust_memline/src/lib.rs
+++ b/rust_memline/src/lib.rs
@@ -24,7 +24,7 @@ impl MemBuffer {
         }
 
         let insert_at = lnum + 1;
-        let mut tail: BTreeMap<usize, String> = self.lines.split_off(&insert_at);
+        let tail: BTreeMap<usize, String> = self.lines.split_off(&insert_at);
         self.lines.insert(insert_at, line.to_string());
         for (i, (_, l)) in tail.into_iter().enumerate() {
             self.lines.insert(insert_at + 1 + i, l);

--- a/src/memline.c
+++ b/src/memline.c
@@ -8,6 +8,8 @@ extern bool rs_ml_delete(void *buf, size_t lnum);
 extern bool rs_ml_replace(void *buf, size_t lnum, const char *line);
 extern unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
 
+static char_u empty_line[] = "";
+
 int ml_open(buf_T *buf)
 {
     // Allocate a fresh Rust memline buffer and store the opaque pointer in
@@ -60,4 +62,99 @@ int ml_replace(linenr_T lnum, char_u *line, int copy UNUSED)
 {
     void *rs_buffer = (void *)curbuf->b_ml.ml_mfp;
     return rs_ml_replace(rs_buffer, (size_t)lnum, (const char *)line) ? OK : FAIL;
+}
+
+char_u *ml_get(linenr_T lnum)
+{
+    size_t len = 0;
+    char_u *p = (char_u *)rs_ml_get_line((void *)curbuf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
+    curbuf->b_ml.ml_line_ptr = p;
+    curbuf->b_ml.ml_line_lnum = lnum;
+    curbuf->b_ml.ml_line_len = (colnr_T)(len + 1);
+    curbuf->b_ml.ml_line_textlen = (colnr_T)(len + 1);
+    curbuf->b_ml.ml_flags &= ~ML_ALLOCATED;
+    return p;
+}
+
+char_u *ml_get_pos(pos_T *pos)
+{
+    if (pos == NULL) return empty_line;
+    return ml_get(pos->lnum);
+}
+
+char_u *ml_get_curline(void)
+{
+    return ml_get(curbuf->b_ml.ml_line_count > 0 ? curwin->w_cursor.lnum : 1);
+}
+
+char_u *ml_get_cursor(void)
+{
+    return ml_get(curwin->w_cursor.lnum);
+}
+
+colnr_T ml_get_len(linenr_T lnum)
+{
+    size_t len = 0;
+    (void)rs_ml_get_line((void *)curbuf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
+    return (colnr_T)len;
+}
+
+colnr_T ml_get_pos_len(pos_T *pos)
+{
+    if (pos == NULL) return 0;
+    return ml_get_len(pos->lnum);
+}
+
+colnr_T ml_get_curline_len(void)
+{
+    return ml_get_len(curwin->w_cursor.lnum);
+}
+
+colnr_T ml_get_cursor_len(void)
+{
+    return ml_get_len(curwin->w_cursor.lnum);
+}
+
+colnr_T ml_get_buf_len(buf_T *buf, linenr_T lnum)
+{
+    size_t len = 0;
+    (void)rs_ml_get_line((void *)buf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
+    return (colnr_T)len;
+}
+
+char_u *ml_get_buf(buf_T *buf, linenr_T lnum, int will_change)
+{
+    size_t len = 0;
+    char_u *p = (char_u *)rs_ml_get_line((void *)buf->b_ml.ml_mfp, (size_t)lnum, will_change ? 1 : 0, &len);
+    curbuf->b_ml.ml_line_ptr = p;
+    curbuf->b_ml.ml_line_lnum = lnum;
+    curbuf->b_ml.ml_line_len = (colnr_T)(len + 1);
+    curbuf->b_ml.ml_line_textlen = (colnr_T)(len + 1);
+    if (will_change)
+        curbuf->b_ml.ml_flags |= ML_ALLOCATED;
+    else
+        curbuf->b_ml.ml_flags &= ~ML_ALLOCATED;
+    return p;
+}
+
+int ml_line_alloced(void) { return (curbuf->b_ml.ml_flags & ML_ALLOCATED) != 0; }
+
+int ml_append_flags(linenr_T lnum, char_u *line, colnr_T len, int flags)
+{
+    (void)lnum; (void)flags; (void)len; return ml_append(lnum, line, len, FALSE);
+}
+
+int ml_append_buf(buf_T *buf, linenr_T lnum, char_u *line, colnr_T len, int newfile)
+{
+    (void)buf; return ml_append(lnum, line, len, newfile);
+}
+
+int ml_replace_len(linenr_T lnum, char_u *line_arg, colnr_T len_arg, int has_props, int copy)
+{
+    (void)has_props; (void)copy; (void)len_arg; return ml_replace(lnum, line_arg, FALSE);
+}
+
+int ml_delete_flags(linenr_T lnum, int flags)
+{
+    (void)flags; return ml_delete(lnum);
 }

--- a/src/memline_compat.c
+++ b/src/memline_compat.c
@@ -2,7 +2,6 @@
 
 #include "vim.h"
 
-extern unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
 
 void ml_set_crypt_key(buf_T *buf, char_u *old_key, char_u *old_cm)
 { (void)buf; (void)old_key; (void)old_cm; }
@@ -22,95 +21,6 @@ void get_b0_dict(char_u *fname, dict_T *d) { (void)fname; (void)d; }
 void ml_sync_all(int check_file, int check_char) { (void)check_file; (void)check_char; }
 void ml_preserve(buf_T *buf, int message) { (void)buf; (void)message; }
 
-static char_u empty_line[] = "";
-
-char_u *ml_get(linenr_T lnum)
-{
-    size_t len = 0;
-    char_u *p = (char_u *)rs_ml_get_line((void *)curbuf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
-    curbuf->b_ml.ml_line_ptr = p;
-    curbuf->b_ml.ml_line_lnum = lnum;
-    curbuf->b_ml.ml_line_len = (colnr_T)(len + 1);
-    curbuf->b_ml.ml_line_textlen = (colnr_T)(len + 1);
-    // 読み取り用途では ML_ALLOCATED は立てない
-    curbuf->b_ml.ml_flags &= ~ML_ALLOCATED;
-    return p;
-}
-
-char_u *ml_get_pos(pos_T *pos)
-{
-    if (pos == NULL) return empty_line;
-    return ml_get(pos->lnum);
-}
-
-char_u *ml_get_curline(void)
-{
-    return ml_get(curbuf->b_ml.ml_line_count > 0 ? curwin->w_cursor.lnum : 1);
-}
-
-char_u *ml_get_cursor(void)
-{
-    return ml_get(curwin->w_cursor.lnum);
-}
-
-colnr_T ml_get_len(linenr_T lnum)
-{
-    size_t len = 0;
-    (void)rs_ml_get_line((void *)curbuf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
-    return (colnr_T)len;
-}
-
-colnr_T ml_get_pos_len(pos_T *pos)
-{
-    if (pos == NULL) return 0;
-    return ml_get_len(pos->lnum);
-}
-
-colnr_T ml_get_curline_len(void)
-{
-    return ml_get_len(curwin->w_cursor.lnum);
-}
-
-colnr_T ml_get_cursor_len(void)
-{
-    return ml_get_len(curwin->w_cursor.lnum);
-}
-
-colnr_T ml_get_buf_len(buf_T *buf, linenr_T lnum)
-{
-    size_t len = 0;
-    (void)rs_ml_get_line((void *)buf->b_ml.ml_mfp, (size_t)lnum, 0, &len);
-    return (colnr_T)len;
-}
-
-char_u *ml_get_buf(buf_T *buf, linenr_T lnum, int will_change)
-{
-    size_t len = 0;
-    char_u *p = (char_u *)rs_ml_get_line((void *)buf->b_ml.ml_mfp, (size_t)lnum, will_change ? 1 : 0, &len);
-    curbuf->b_ml.ml_line_ptr = p;
-    curbuf->b_ml.ml_line_lnum = lnum;
-    curbuf->b_ml.ml_line_len = (colnr_T)(len + 1);
-    curbuf->b_ml.ml_line_textlen = (colnr_T)(len + 1);
-    if (will_change)
-        curbuf->b_ml.ml_flags |= ML_ALLOCATED;
-    else
-        curbuf->b_ml.ml_flags &= ~ML_ALLOCATED;
-    return p;
-}
-
-int ml_line_alloced(void) { return (curbuf->b_ml.ml_flags & ML_ALLOCATED) != 0; }
-
-int ml_append_flags(linenr_T lnum, char_u *line, colnr_T len, int flags)
-{ (void)lnum; (void)flags; (void)len; return ml_append(lnum, line, len, FALSE); }
-
-int ml_append_buf(buf_T *buf, linenr_T lnum, char_u *line, colnr_T len, int newfile)
-{ (void)buf; return ml_append(lnum, line, len, newfile); }
-
-int ml_replace_len(linenr_T lnum, char_u *line_arg, colnr_T len_arg, int has_props, int copy)
-{ (void)has_props; (void)copy; (void)len_arg; return ml_replace(lnum, line_arg, FALSE); }
-
-int ml_delete_flags(linenr_T lnum, int flags)
-{ (void)flags; return ml_delete(lnum); }
 
 void ml_setmarked(linenr_T lnum) { (void)lnum; }
 linenr_T ml_firstmarked(void) { return 0; }


### PR DESCRIPTION
## Summary
- connect memline line retrieval helpers to the Rust memline buffer
- streamline memline compatibility layer
- drop unnecessary mutable binding in Rust memline append

## Testing
- `cargo test -p rust_memline`
- `make -C src memline.o memline_compat.o` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c6f18be0832094cedfa07b2c1b13