### PR TITLE
Add rust_regexp crate with fuzzy and line match utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +79,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -114,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,12 +170,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbindgen"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
- "clap",
+ "clap 3.2.25",
  "heck",
  "indexmap",
  "log",
@@ -196,6 +220,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,11 +274,30 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstyle",
+ "clap_lex 0.7.5",
 ]
 
 [[package]]
@@ -238,6 +308,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clipboard-win"
@@ -272,10 +348,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.47",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cursor-icon"
@@ -402,6 +539,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +629,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +662,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -667,6 +844,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +1018,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polling"
@@ -961,6 +1181,26 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1392,6 +1632,14 @@ name = "rust_regex_engine"
 version = "0.1.0"
 
 [[package]]
+name = "rust_regexp"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "regex",
+]
+
+[[package]]
 name = "rust_screen"
 version = "0.1.0"
 dependencies = [
@@ -1550,10 +1798,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -1765,6 +2028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,6 +2133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +2155,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2017,6 +2358,16 @@ dependencies = [
  "log",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rust_regexp/Cargo.toml
+++ b/rust_regexp/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_regexp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+regex = "1"

--- a/rust_regexp/benches/regexp.rs
+++ b/rust_regexp/benches/regexp.rs
@@ -1,0 +1,19 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use regex::Regex;
+use rust_regexp::search;
+
+fn bench_search(c: &mut Criterion) {
+    let pat = b"foo.*bar";
+    let text = b"foo something bar";
+    c.bench_function("rust_regexp", |b| {
+        b.iter(|| search(black_box(pat), black_box(text), false))
+    });
+
+    let re = Regex::new("foo.*bar").unwrap();
+    c.bench_function("regex_crate", |b| {
+        b.iter(|| re.is_match(black_box("foo something bar")))
+    });
+}
+
+criterion_group!(benches, bench_search);
+criterion_main!(benches);

--- a/rust_regexp/src/fuzzy.rs
+++ b/rust_regexp/src/fuzzy.rs
@@ -1,0 +1,29 @@
+/// Very small and naive fuzzy matcher.
+///
+/// The function checks whether all characters of `needle` appear in `haystack`
+/// in the same order.  Matching is case insensitive.  When successful the
+/// index of the last matched character is returned.
+pub fn fuzzy_match(needle: &str, haystack: &str) -> Option<usize> {
+    let mut iter = haystack.chars().enumerate();
+    let mut last = 0usize;
+    for ch in needle.chars() {
+        match iter.find(|(_, c)| c.eq_ignore_ascii_case(&ch)) {
+            Some((idx, _)) => {
+                last = idx;
+            }
+            None => return None,
+        }
+    }
+    Some(last)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_fuzzy() {
+        assert_eq!(fuzzy_match("fz", "fuzzy"), Some(2));
+        assert_eq!(fuzzy_match("abc", "acb"), None);
+    }
+}

--- a/rust_regexp/src/lib.rs
+++ b/rust_regexp/src/lib.rs
@@ -1,0 +1,287 @@
+//! Lightweight regular expression and related matching utilities used by the
+//! Rust port of Vim.  This crate started as a direct translation of the small
+//! C regex engine used in the Vim sources (see `regexp.c`, `regexp_bt.c` and
+//! `regexp_nfa.c`).  The goal of this crate is not to be feature complete but
+//! to offer a reasonably small and safe interface for the parts of the Vim
+//! code base that require regular expression functionality.
+//!
+//! In addition to the traditional regex engine the original C code also
+//! exposes fuzzy matching and a simple line based matching algorithm.  These
+//! have been reimplemented in safe Rust and are available through the
+//! [`fuzzy_match`] and [`line_match`] helpers.
+
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_long, c_void};
+
+mod fuzzy;
+mod linematch;
+
+pub use fuzzy::fuzzy_match;
+pub use linematch::line_match;
+
+// A very small regular expression engine.  It only understands a few meta
+// characters and is intended as a placeholder for the full Vim engine.
+// Supported syntax:
+//  - Literals
+//  - '.'      : matches any single character
+//  - '*'      : zero or more of the previous item
+//  - '^'      : anchor at start of the string
+//  - '$'      : anchor at end of the string
+// No capturing groups or character classes are implemented.
+// Flag bit 1 enables case-insensitive matching.
+
+#[repr(C)]
+pub struct RegProg {
+    pattern: Vec<u8>,
+    ic: bool,
+}
+
+fn eq_byte(a: u8, b: u8, ic: bool) -> bool {
+    if ic {
+        a.to_ascii_lowercase() == b.to_ascii_lowercase()
+    } else {
+        a == b
+    }
+}
+
+// Try to match `pat` against `text` starting at the first character.  Returns
+// the length of the match when successful.
+fn match_here(pat: &[u8], text: &[u8], ic: bool) -> Option<usize> {
+    if pat.is_empty() {
+        return Some(0);
+    }
+    if pat.len() >= 2 && pat[1] == b'*' {
+        return match_star(pat[0], &pat[2..], text, ic);
+    }
+    match pat[0] {
+        b'$' if pat.len() == 1 => {
+            if text.is_empty() {
+                Some(0)
+            } else {
+                None
+            }
+        }
+        c if !text.is_empty() && (c == b'.' || eq_byte(c, text[0], ic)) => {
+            match_here(&pat[1..], &text[1..], ic).map(|l| l + 1)
+        }
+        _ => None,
+    }
+}
+
+fn match_star(c: u8, pat: &[u8], text: &[u8], ic: bool) -> Option<usize> {
+    let mut i = 0;
+    while i <= text.len() {
+        if let Some(l) = match_here(pat, &text[i..], ic) {
+            return Some(i + l);
+        }
+        if i == text.len() {
+            break;
+        }
+        if c != b'.' && !eq_byte(c, text[i], ic) {
+            break;
+        }
+        i += 1;
+    }
+    None
+}
+
+// Search for a match of `pat` anywhere in `text`.
+/// Search for a match of `pat` anywhere in `text`.
+///
+/// This function is public so it can be used by benchmarks without having to
+/// go through the `vim_reg*` FFI wrappers.
+pub fn search(pat: &[u8], text: &[u8], ic: bool) -> Option<(usize, usize)> {
+    if pat.first() == Some(&b'^') {
+        return match_here(&pat[1..], text, ic).map(|l| (0, l));
+    }
+    let mut i = 0;
+    while i <= text.len() {
+        if let Some(l) = match_here(pat, &text[i..], ic) {
+            return Some((i, i + l));
+        }
+        if i == text.len() {
+            break;
+        }
+        i += 1;
+    }
+    None
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regcomp(pattern: *const c_char, flags: c_int) -> *mut RegProg {
+    if pattern.is_null() {
+        return std::ptr::null_mut();
+    }
+    let c_str = unsafe { CStr::from_ptr(pattern) };
+    let pattern_str = match c_str.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    // Reject patterns containing constructs we do not understand.
+    let bytes = pattern_str.as_bytes();
+    let mut prev_was_atom = false;
+    for &b in bytes {
+        match b {
+            b'.' | b'^' | b'$' => prev_was_atom = true,
+            b'*' => {
+                if !prev_was_atom {
+                    return std::ptr::null_mut();
+                }
+                prev_was_atom = false;
+            }
+            b'[' | b']' | b'(' | b')' | b'+' | b'?' | b'{' | b'}' | b'|' | b'\\' => {
+                return std::ptr::null_mut();
+            }
+            _ => prev_was_atom = true,
+        }
+    }
+    Box::into_raw(Box::new(RegProg {
+        pattern: bytes.to_vec(),
+        ic: (flags & 1) != 0,
+    }))
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regfree(prog: *mut RegProg) {
+    if !prog.is_null() {
+        unsafe { drop(Box::from_raw(prog)) };
+    }
+}
+
+#[repr(C)]
+pub struct RegMatch {
+    pub regprog: *mut RegProg,
+    pub startp: [*const c_char; 10],
+    pub endp: [*const c_char; 10],
+    pub rm_matchcol: c_int,
+    pub rm_ic: c_int,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Lpos {
+    pub lnum: c_long,
+    pub col: c_int,
+}
+
+#[repr(C)]
+pub struct RegMMMatch {
+    pub regprog: *mut RegProg,
+    pub startpos: [Lpos; 10],
+    pub endpos: [Lpos; 10],
+    pub rmm_matchcol: c_int,
+    pub rmm_ic: c_int,
+    pub rmm_maxcol: c_int,
+}
+
+fn regexec_internal(rmp: *mut RegMatch, line: *const c_char, col: c_int) -> c_int {
+    if rmp.is_null() || line.is_null() {
+        return 0;
+    }
+    let prog_ptr = unsafe { (*rmp).regprog };
+    if prog_ptr.is_null() {
+        return 0;
+    }
+    let prog = unsafe { &*prog_ptr };
+    let line_bytes = unsafe { CStr::from_ptr(line).to_bytes() };
+    if (col as usize) > line_bytes.len() {
+        return 0;
+    }
+    let slice = &line_bytes[(col as usize)..];
+    if let Some((s, e)) = search(&prog.pattern, slice, prog.ic) {
+        let m = unsafe { &mut *rmp };
+        for i in 0..10 {
+            m.startp[i] = std::ptr::null();
+            m.endp[i] = std::ptr::null();
+        }
+        unsafe {
+            m.startp[0] = line.add(col as usize + s);
+            m.endp[0] = line.add(col as usize + e);
+        }
+        return 1;
+    }
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regexec(rmp: *mut RegMatch, line: *const c_char, col: c_int) -> c_int {
+    regexec_internal(rmp, line, col)
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regexec_nl(rmp: *mut RegMatch, line: *const c_char, col: c_int) -> c_int {
+    regexec_internal(rmp, line, col)
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regexec_multi(
+    rmp: *mut RegMMMatch,
+    _win: *mut c_void,
+    buf: *mut c_void,
+    lnum: c_long,
+    col: c_int,
+    timed_out: *mut c_int,
+) -> c_long {
+    if !timed_out.is_null() {
+        unsafe { *timed_out = 0 };
+    }
+    if rmp.is_null() || buf.is_null() {
+        return 0;
+    }
+    unsafe {
+        let lines = buf as *const *const c_char;
+        let line_ptr = *lines.add((lnum - 1) as usize);
+        if line_ptr.is_null() {
+            return 0;
+        }
+        let mut rm = RegMatch {
+            regprog: (*rmp).regprog,
+            startp: [std::ptr::null(); 10],
+            endp: [std::ptr::null(); 10],
+            rm_matchcol: 0,
+            rm_ic: (*rmp).rmm_ic,
+        };
+        if regexec_internal(&mut rm, line_ptr, col) == 1 {
+            let m = &mut *rmp;
+            for i in 0..10 {
+                m.startpos[i] = Lpos { lnum: 0, col: 0 };
+                m.endpos[i] = Lpos { lnum: 0, col: 0 };
+            }
+            m.startpos[0] = Lpos {
+                lnum,
+                col: rm.startp[0].offset_from(line_ptr) as c_int,
+            };
+            m.endpos[0] = Lpos {
+                lnum,
+                col: rm.endp[0].offset_from(line_ptr) as c_int,
+            };
+            m.rmm_matchcol = col;
+            return lnum;
+        }
+    }
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn vim_regsub(
+    prog: *mut RegProg,
+    text: *const c_char,
+    sub: *const c_char,
+) -> *mut c_char {
+    if prog.is_null() || text.is_null() || sub.is_null() {
+        return std::ptr::null_mut();
+    }
+    let prog = unsafe { &*prog };
+    let text_str = unsafe { CStr::from_ptr(text).to_bytes() };
+    let sub_str = unsafe { CStr::from_ptr(sub).to_bytes() };
+    if let Some((s, e)) = search(&prog.pattern, text_str, prog.ic) {
+        let mut result = Vec::new();
+        result.extend_from_slice(&text_str[..s]);
+        result.extend_from_slice(sub_str);
+        result.extend_from_slice(&text_str[e..]);
+        CString::new(result).unwrap().into_raw()
+    } else {
+        // No match -> return original text
+        CString::new(text_str).unwrap().into_raw()
+    }
+}

--- a/rust_regexp/src/linematch.rs
+++ b/rust_regexp/src/linematch.rs
@@ -1,0 +1,31 @@
+/// Compute the Levenshtein distance between two lines of text.
+///
+/// This is a very small utility used by a few pieces of the Vim source to
+/// measure the similarity of two lines.
+pub fn line_match(a: &str, b: &str) -> usize {
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0; b.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.chars().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            cur[j + 1] = std::cmp::min(
+                std::cmp::min(cur[j] + 1, prev[j + 1] + 1),
+                prev[j] + cost,
+            );
+        }
+        prev.clone_from_slice(&cur);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distance() {
+        assert_eq!(line_match("kitten", "sitting"), 3);
+        assert_eq!(line_match("same", "same"), 0);
+    }
+}

--- a/rust_regexp/tests/fuzzy.rs
+++ b/rust_regexp/tests/fuzzy.rs
@@ -1,0 +1,7 @@
+use rust_regexp::fuzzy_match;
+
+#[test]
+fn fuzz_basic() {
+    assert_eq!(fuzzy_match("fz", "fuzzy"), Some(2));
+    assert_eq!(fuzzy_match("abc", "acb"), None);
+}

--- a/rust_regexp/tests/linematch.rs
+++ b/rust_regexp/tests/linematch.rs
@@ -1,0 +1,7 @@
+use rust_regexp::line_match;
+
+#[test]
+fn distance_basic() {
+    assert_eq!(line_match("kitten", "sitting"), 3);
+    assert_eq!(line_match("same", "same"), 0);
+}

--- a/rust_regexp/tests/regexp.rs
+++ b/rust_regexp/tests/regexp.rs
@@ -1,0 +1,125 @@
+use rust_regexp::{
+    vim_regcomp, vim_regexec, vim_regexec_multi, vim_regexec_nl, vim_regfree, vim_regsub, Lpos,
+    RegMMMatch, RegMatch,
+};
+use std::ffi::{CStr, CString};
+use std::os::raw::c_void;
+
+#[test]
+fn basic_match_and_exec_nl() {
+    let pat = CString::new("foo").unwrap();
+    let text = CString::new("foo bar").unwrap();
+    unsafe {
+        let prog = vim_regcomp(pat.as_ptr(), 0);
+        assert!(!prog.is_null());
+        let mut rm = RegMatch {
+            regprog: prog,
+            startp: [std::ptr::null(); 10],
+            endp: [std::ptr::null(); 10],
+            rm_matchcol: 0,
+            rm_ic: 0,
+        };
+        assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
+        assert_eq!(vim_regexec_nl(&mut rm, text.as_ptr(), 0), 1);
+        vim_regfree(prog);
+    }
+}
+
+#[test]
+fn substitution_and_flags() {
+    let pat = CString::new("foo").unwrap();
+    let text = CString::new("Foo bar").unwrap();
+    unsafe {
+        // enable case-insensitive match using flag bit 1
+        let prog = vim_regcomp(pat.as_ptr(), 1);
+        assert!(!prog.is_null());
+        let sub = CString::new("baz").unwrap();
+        let replaced = vim_regsub(prog, text.as_ptr(), sub.as_ptr());
+        let c_str = CStr::from_ptr(replaced);
+        assert_eq!(c_str.to_str().unwrap(), "baz bar");
+        vim_regfree(prog);
+    }
+}
+
+#[test]
+fn capture_offsets() {
+    // Use a pattern with a '.' meta character and ensure offsets for the
+    // whole match are filled in.
+    let pat = CString::new("a.c").unwrap();
+    let text = CString::new("zabc").unwrap();
+    unsafe {
+        let prog = vim_regcomp(pat.as_ptr(), 0);
+        assert!(!prog.is_null());
+        let mut rm = RegMatch {
+            regprog: prog,
+            startp: [std::ptr::null(); 10],
+            endp: [std::ptr::null(); 10],
+            rm_matchcol: 0,
+            rm_ic: 0,
+        };
+        assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
+        assert!(!rm.startp[0].is_null());
+        assert!(!rm.endp[0].is_null());
+        vim_regfree(prog);
+    }
+}
+
+#[test]
+fn regexec_multi_single_line() {
+    let pat = CString::new("bar").unwrap();
+    let line1 = CString::new("foo").unwrap();
+    let line2 = CString::new("bar baz").unwrap();
+    let lines = [line1.as_ptr(), line2.as_ptr()];
+    unsafe {
+        let prog = vim_regcomp(pat.as_ptr(), 0);
+        assert!(!prog.is_null());
+        let mut rmm = RegMMMatch {
+            regprog: prog,
+            startpos: [Lpos { lnum: 0, col: 0 }; 10],
+            endpos: [Lpos { lnum: 0, col: 0 }; 10],
+            rmm_matchcol: 0,
+            rmm_ic: 0,
+            rmm_maxcol: 0,
+        };
+        let matched = vim_regexec_multi(
+            &mut rmm,
+            std::ptr::null_mut(),
+            lines.as_ptr() as *mut c_void,
+            2,
+            0,
+            std::ptr::null_mut(),
+        );
+        assert_eq!(matched, 2);
+        assert_eq!(rmm.startpos[0].lnum, 2);
+        assert_eq!(rmm.startpos[0].col, 0);
+        vim_regfree(prog);
+    }
+}
+
+#[test]
+fn invalid_pattern_returns_null() {
+    let pat = CString::new("[a-").unwrap();
+    unsafe {
+        let prog = vim_regcomp(pat.as_ptr(), 0);
+        assert!(prog.is_null());
+    }
+}
+
+#[test]
+fn non_match_returns_zero() {
+    let pat = CString::new("foo").unwrap();
+    let text = CString::new("bar").unwrap();
+    unsafe {
+        let prog = vim_regcomp(pat.as_ptr(), 0);
+        assert!(!prog.is_null());
+        let mut rm = RegMatch {
+            regprog: prog,
+            startp: [std::ptr::null(); 10],
+            endp: [std::ptr::null(); 10],
+            rm_matchcol: 0,
+            rm_ic: 0,
+        };
+        assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 0);
+        vim_regfree(prog);
+    }
+}


### PR DESCRIPTION
## Summary
- create `rust_regexp` crate consolidating small regex engine and exposing fuzzy and line matching helpers
- port existing regex tests and add new tests for fuzzy and line algorithms
- add Criterion benchmark comparing crate to `regex`

## Testing
- `cargo test -p rust_regexp`


------
https://chatgpt.com/codex/tasks/task_e_68b7e4490394832090a43fa072227b0b