### PR TITLE
Add rudimentary Rust-based diff module and screen update hook

### DIFF
--- a/rust_diff/Cargo.toml
+++ b/rust_diff/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_diff"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+diff = { path = "../rust/diff" }
+

--- a/rust_diff/include/rust_diff.h
+++ b/rust_diff/include/rust_diff.h
@@ -1,0 +1,21 @@
+#ifndef RUST_DIFF_H
+#define RUST_DIFF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    RUST_DIFF_EXTERNAL = 0,
+    RUST_DIFF_XDIFF = 1,
+} DiffMode;
+
+char *rs_diff_files(const char *file1, const char *file2, DiffMode mode);
+void rs_diff_free(char *ptr);
+void rs_diff_update_screen(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUST_DIFF_H

--- a/rust_diff/src/lib.rs
+++ b/rust_diff/src/lib.rs
@@ -1,0 +1,118 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void, c_long};
+use std::process::Command;
+use std::ptr;
+
+use diff::{mmfile_t, mmbuffer_t, xdemitcb_t, xdl_diff};
+
+#[repr(C)]
+pub enum DiffMode {
+    External = 0,
+    Xdiff = 1,
+}
+
+unsafe extern "C" fn collect(priv_: *mut c_void, mb: *mut mmbuffer_t, nbuf: c_int) -> c_int {
+    if priv_.is_null() || mb.is_null() {
+        return -1;
+    }
+    let bufs = std::slice::from_raw_parts(mb, nbuf as usize);
+    let out = &mut *(priv_ as *mut String);
+    for b in bufs {
+        let slice = std::slice::from_raw_parts((*b).ptr as *const u8, (*b).size as usize);
+        out.push_str(std::str::from_utf8(slice).unwrap_or(""));
+    }
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn rs_diff_files(f1: *const c_char, f2: *const c_char, mode: DiffMode) -> *mut c_char {
+    if f1.is_null() || f2.is_null() {
+        return ptr::null_mut();
+    }
+    let file1 = unsafe { CStr::from_ptr(f1) }.to_string_lossy().into_owned();
+    let file2 = unsafe { CStr::from_ptr(f2) }.to_string_lossy().into_owned();
+
+    match mode {
+        DiffMode::External => {
+            let output = Command::new("diff").arg("-u").arg(&file1).arg(&file2).output();
+            match output {
+                Ok(out) => CString::new(String::from_utf8_lossy(&out.stdout).to_string()).unwrap().into_raw(),
+                Err(_) => ptr::null_mut(),
+            }
+        }
+        DiffMode::Xdiff => {
+            let a = match std::fs::read(&file1) {
+                Ok(v) => v,
+                Err(_) => return ptr::null_mut(),
+            };
+            let b = match std::fs::read(&file2) {
+                Ok(v) => v,
+                Err(_) => return ptr::null_mut(),
+            };
+            let mf1 = mmfile_t { ptr: a.as_ptr() as *const c_char, size: a.len() as c_long };
+            let mf2 = mmfile_t { ptr: b.as_ptr() as *const c_char, size: b.len() as c_long };
+            let mut output = String::new();
+            let mut ecb = xdemitcb_t { priv_: &mut output as *mut _ as *mut c_void, out_hunk: None, out_line: Some(collect) };
+            let res = unsafe { xdl_diff(&mf1, &mf2, ptr::null(), ptr::null(), &mut ecb) };
+            if res != 0 {
+                return ptr::null_mut();
+            }
+            CString::new(output).unwrap().into_raw()
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_diff_free(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe { drop(CString::from_raw(ptr)); }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_diff_update_screen() {
+    // Placeholder for integrating with screen updating.  Currently this just logs.
+    eprintln!("rs_diff_update_screen called");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::write;
+    use std::ffi::{CStr, CString};
+    use std::env::temp_dir;
+
+    #[test]
+    fn external_diff() {
+        let dir = temp_dir();
+        let f1 = dir.join("a.txt");
+        let f2 = dir.join("b.txt");
+        write(&f1, "a\nb\n").unwrap();
+        write(&f2, "a\nc\n").unwrap();
+        let c1 = CString::new(f1.to_str().unwrap()).unwrap();
+        let c2 = CString::new(f2.to_str().unwrap()).unwrap();
+        let ptr = rs_diff_files(c1.as_ptr(), c2.as_ptr(), DiffMode::External);
+        assert!(!ptr.is_null());
+        let diff = unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() };
+        rs_diff_free(ptr);
+        assert!(diff.contains("-b"));
+        assert!(diff.contains("+c"));
+    }
+
+    #[test]
+    fn xdiff_diff() {
+        let dir = temp_dir();
+        let f1 = dir.join("c.txt");
+        let f2 = dir.join("d.txt");
+        write(&f1, "a\nb\n").unwrap();
+        write(&f2, "a\nc\n").unwrap();
+        let c1 = CString::new(f1.to_str().unwrap()).unwrap();
+        let c2 = CString::new(f2.to_str().unwrap()).unwrap();
+        let ptr = rs_diff_files(c1.as_ptr(), c2.as_ptr(), DiffMode::Xdiff);
+        assert!(!ptr.is_null());
+        let diff = unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() };
+        rs_diff_free(ptr);
+        assert!(diff.contains("-b"));
+        assert!(diff.contains("+c"));
+    }
+}

--- a/src/diff.c
+++ b/src/diff.c
@@ -18,6 +18,7 @@
 
 #include "vim.h"
 #include "xdiff/xdiff.h"
+#include "rust_diff.h"
 
 #if defined(FEAT_DIFF) || defined(PROTO)
 
@@ -755,15 +756,19 @@ diff_redraw(
 
     if (wp_other != NULL && curwin->w_p_scb)
     {
-	if (used_max_fill_curwin)
-	    // The current window was set to use the maximum number of filler
-	    // lines, may need to reduce them.
-	    diff_set_topline(wp_other, curwin);
-	else if (used_max_fill_other)
-	    // The other window was set to use the maximum number of filler
-	    // lines, may need to reduce them.
-	    diff_set_topline(curwin, wp_other);
+        if (used_max_fill_curwin)
+            // The current window was set to use the maximum number of filler
+            // lines, may need to reduce them.
+            diff_set_topline(wp_other, curwin);
+        else if (used_max_fill_other)
+            // The other window was set to use the maximum number of filler
+            // lines, may need to reduce them.
+            diff_set_topline(curwin, wp_other);
     }
+
+    // Notify Rust side that diff redraw finished so that the screen can be
+    // updated appropriately.
+    rs_diff_update_screen();
 }
 
     static void

--- a/src/rust_diff.h
+++ b/src/rust_diff.h
@@ -1,0 +1,6 @@
+#ifndef RUST_DIFF_WRAPPER_H
+#define RUST_DIFF_WRAPPER_H
+
+#include "../rust_diff/include/rust_diff.h"
+
+#endif // RUST_DIFF_WRAPPER_H


### PR DESCRIPTION
## Summary
- introduce `rust_diff` crate providing external and xdiff-based diffing with FFI helpers
- expose header and screen refresh stub and wire it into `src/diff.c`
- basic tests for both diff algorithms

## Testing
- `cargo test -p rust_diff`

------
https://chatgpt.com/codex/tasks/task_e_68b7e45de8808320be280ecd2f603392