### PR TITLE
Add Rust blob, Blowfish, and SHA256 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_blob"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_blowfish"
+version = "0.1.0"
+dependencies = [
+ "blowfish",
+ "libc",
+ "rust_sha256",
+]
+
+[[package]]
 name = "rust_buffer"
 version = "0.1.0"
 dependencies = [
@@ -1411,6 +1427,13 @@ dependencies = [
 [[package]]
 name = "rust_session"
 version = "0.1.0"
+
+[[package]]
+name = "rust_sha256"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "rust_sign"
@@ -1840,6 +1863,8 @@ dependencies = [
  "cc",
  "diff",
  "rust_alloc",
+ "rust_blob",
+ "rust_blowfish",
  "rust_buffer",
  "rust_change",
  "rust_debugger",
@@ -1854,6 +1879,7 @@ dependencies = [
  "rust_profiler",
  "rust_pty",
  "rust_python",
+ "rust_sha256",
  "rust_spell",
  "rust_wayland",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ rust_change = { path = "rust_change" }
 rust_excmd = { path = "rust_excmd" }
 rust_alloc = { path = "rust_alloc" }
 rust_message = { path = "rust_message" }
+rust_blob = { path = "rust_blob" }
+rust_sha256 = { path = "rust_sha256" }
+rust_blowfish = { path = "rust_blowfish" }
 
 [features]
 default = []

--- a/rust_blob/Cargo.toml
+++ b/rust_blob/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_blob"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_blob"
+crate-type = ["staticlib", "rlib"]

--- a/rust_blob/src/lib.rs
+++ b/rust_blob/src/lib.rs
@@ -1,0 +1,95 @@
+use libc::{c_int, c_long};
+
+#[repr(C)]
+pub struct blob_T {
+    data: Vec<u8>,
+    refcount: i32,
+}
+
+#[no_mangle]
+pub extern "C" fn blob_alloc() -> *mut blob_T {
+    Box::into_raw(Box::new(blob_T { data: Vec::new(), refcount: 1 }))
+}
+
+#[no_mangle]
+pub extern "C" fn blob_free(b: *mut blob_T) {
+    if b.is_null() { return; }
+    unsafe { drop(Box::from_raw(b)); }
+}
+
+#[no_mangle]
+pub extern "C" fn blob_unref(b: *mut blob_T) {
+    if b.is_null() { return; }
+    unsafe {
+        (*b).refcount -= 1;
+        if (*b).refcount <= 0 {
+            drop(Box::from_raw(b));
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn blob_len(b: *const blob_T) -> c_long {
+    if b.is_null() { return 0; }
+    let br = unsafe { &*b };
+    br.data.len() as c_long
+}
+
+#[no_mangle]
+pub extern "C" fn blob_get(b: *const blob_T, idx: c_int) -> c_int {
+    let br = unsafe { &*b };
+    br.data[idx as usize] as c_int
+}
+
+#[no_mangle]
+pub extern "C" fn blob_set(b: *mut blob_T, idx: c_int, byte: c_int) {
+    let data = unsafe { &mut (*b).data };
+    let idx = idx as usize;
+    if idx >= data.len() {
+        data.resize(idx + 1, 0);
+    }
+    data[idx] = byte as u8;
+}
+
+#[no_mangle]
+pub extern "C" fn blob_set_append(b: *mut blob_T, idx: c_int, byte: c_int) {
+    blob_set(b, idx, byte);
+}
+
+#[no_mangle]
+pub extern "C" fn blob_equal(b1: *const blob_T, b2: *const blob_T) -> c_int {
+    if b1 == b2 { return 1; }
+    let v1 = unsafe { &*b1 };
+    let v2 = unsafe { &*b2 };
+    (v1.data == v2.data) as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_blob() {
+        unsafe {
+            let b = blob_alloc();
+            blob_set(b, 0, 1);
+            blob_set(b, 1, 2);
+            assert_eq!(blob_len(b), 2);
+            assert_eq!(blob_get(b, 1), 2);
+            blob_unref(b);
+        }
+    }
+
+    #[test]
+    fn equality() {
+        unsafe {
+            let b1 = blob_alloc();
+            let b2 = blob_alloc();
+            blob_set(b1, 0, 42);
+            blob_set(b2, 0, 42);
+            assert_eq!(blob_equal(b1, b2), 1);
+            blob_unref(b1);
+            blob_unref(b2);
+        }
+    }
+}

--- a/rust_blowfish/Cargo.toml
+++ b/rust_blowfish/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust_blowfish"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+blowfish = "0.8"
+rust_sha256 = { path = "../rust_sha256" }
+
+[lib]
+name = "rust_blowfish"
+crate-type = ["staticlib", "rlib"]

--- a/rust_blowfish/src/lib.rs
+++ b/rust_blowfish/src/lib.rs
@@ -1,0 +1,183 @@
+use libc::{c_char, c_int, c_void};
+use std::ffi::CStr;
+use std::slice;
+
+use blowfish::cipher::{generic_array::GenericArray, BlockEncrypt, NewBlockCipher};
+use blowfish::Blowfish;
+use rust_sha256::sha256_digest;
+
+#[repr(C)]
+pub struct cryptstate_T {
+    pub method_nr: c_int,
+    pub method_state: *mut c_void,
+}
+
+#[repr(C)]
+pub struct crypt_arg_T {
+    pub cat_salt: *mut u8,
+    pub cat_salt_len: c_int,
+    pub cat_seed: *mut u8,
+    pub cat_seed_len: c_int,
+    pub cat_add: *mut u8,
+    pub cat_add_len: c_int,
+    pub cat_init_from_file: c_int,
+}
+
+const CRYPT_M_BF: c_int = 1;
+const CRYPT_M_BF2: c_int = 2;
+
+struct BlowfishState {
+    cipher: Blowfish,
+    cfb: Vec<u8>,
+    cfb_len: usize,
+    randbyte_offset: usize,
+    update_offset: usize,
+}
+
+impl BlowfishState {
+    fn randbyte(&mut self) -> u8 {
+        if (self.randbyte_offset & 7) == 0 {
+            let start = self.randbyte_offset;
+            let mut block = GenericArray::clone_from_slice(&self.cfb[start..start + 8]);
+            self.cipher.encrypt_block(&mut block);
+            self.cfb[start..start + 8].copy_from_slice(&block);
+        }
+        let t = self.cfb[self.randbyte_offset];
+        self.randbyte_offset += 1;
+        if self.randbyte_offset == self.cfb_len {
+            self.randbyte_offset = 0;
+        }
+        t
+    }
+
+    fn cfb_update(&mut self, c: u8) {
+        self.cfb[self.update_offset] ^= c;
+        self.update_offset += 1;
+        if self.update_offset == self.cfb_len {
+            self.update_offset = 0;
+        }
+    }
+}
+
+fn sha256_hex(data: &[u8], salt: &[u8]) -> String {
+    let mut input = Vec::from(data);
+    input.extend_from_slice(salt);
+    let digest = sha256_digest(&input);
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn hex_to_bytes(s: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len()/2);
+    for i in (0..s.len()).step_by(2) {
+        let byte = u8::from_str_radix(&s[i..i+2], 16).unwrap();
+        out.push(byte);
+    }
+    out
+}
+
+fn derive_key(password: &[u8], salt: &[u8]) -> Vec<u8> {
+    let mut key = sha256_hex(password, salt);
+    for _ in 0..1000 {
+        key = sha256_hex(key.as_bytes(), salt);
+    }
+    hex_to_bytes(&key)
+}
+
+fn cfb_init(state: &mut BlowfishState, seed: &[u8]) {
+    state.cfb.fill(0);
+    state.randbyte_offset = 0;
+    state.update_offset = 0;
+    if !seed.is_empty() {
+        let mi = std::cmp::max(seed.len(), state.cfb_len);
+        for i in 0..mi {
+            let idx = i % state.cfb_len;
+            state.cfb[idx] ^= seed[i % seed.len()];
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_blowfish_init(state: *mut cryptstate_T, key: *const c_char, arg: *mut crypt_arg_T) -> c_int {
+    if state.is_null() || key.is_null() || arg.is_null() { return 0; }
+    let key_slice = unsafe { CStr::from_ptr(key).to_bytes() };
+    let arg = unsafe { &*arg };
+    let salt = unsafe { slice::from_raw_parts(arg.cat_salt, arg.cat_salt_len as usize) };
+    let seed = unsafe { slice::from_raw_parts(arg.cat_seed, arg.cat_seed_len as usize) };
+    let key_bytes = derive_key(key_slice, salt);
+    let cipher = match Blowfish::new_from_slice(&key_bytes) { Ok(c) => c, Err(_) => return 0 };
+    let cfb_len = if unsafe { (*state).method_nr } == CRYPT_M_BF { 64 } else { 8 };
+    let mut st = BlowfishState { cipher, cfb: vec![0u8; cfb_len], cfb_len, randbyte_offset:0, update_offset:0 };
+    cfb_init(&mut st, seed);
+    unsafe { (*state).method_state = Box::into_raw(Box::new(st)) as *mut c_void; }
+    1
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_blowfish_encode(state: *mut cryptstate_T, from: *const u8, len: usize, to: *mut u8, _last: c_int) {
+    if state.is_null() || from.is_null() || to.is_null() { return; }
+    let st = unsafe { &mut *(*state).method_state.cast::<BlowfishState>() };
+    for i in 0..len {
+        let z = unsafe { *from.add(i) };
+        let t = st.randbyte();
+        st.cfb_update(z);
+        unsafe { *to.add(i) = t ^ z; }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_blowfish_decode(state: *mut cryptstate_T, from: *const u8, len: usize, to: *mut u8, _last: c_int) {
+    if state.is_null() || from.is_null() || to.is_null() { return; }
+    let st = unsafe { &mut *(*state).method_state.cast::<BlowfishState>() };
+    for i in 0..len {
+        let t = st.randbyte();
+        let val = unsafe { *from.add(i) } ^ t;
+        st.cfb_update(val);
+        unsafe { *to.add(i) = val; }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_blowfish_encode_inplace(state: *mut cryptstate_T, buf: *mut u8, len: usize, _p2: *mut u8, last: c_int) {
+    crypt_blowfish_encode(state, buf as *const u8, len, buf, last);
+}
+
+#[no_mangle]
+pub extern "C" fn crypt_blowfish_decode_inplace(state: *mut cryptstate_T, buf: *mut u8, len: usize, _p2: *mut u8, last: c_int) {
+    crypt_blowfish_decode(state, buf as *const u8, len, buf, last);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn roundtrip() {
+        let key = CString::new("test").unwrap();
+        let salt = b"12345678";
+        let seed = b"abcdefgh";
+        let mut arg = crypt_arg_T {
+            cat_salt: salt.as_ptr() as *mut u8,
+            cat_salt_len: salt.len() as c_int,
+            cat_seed: seed.as_ptr() as *mut u8,
+            cat_seed_len: seed.len() as c_int,
+            cat_add: std::ptr::null_mut(),
+            cat_add_len: 0,
+            cat_init_from_file: 0,
+        };
+        let mut st_enc = cryptstate_T { method_nr: CRYPT_M_BF2, method_state: std::ptr::null_mut() };
+        assert_eq!(1, crypt_blowfish_init(&mut st_enc, key.as_ptr(), &mut arg));
+        let data = b"hello world";
+        let mut enc = vec![0u8; data.len()];
+        crypt_blowfish_encode(&mut st_enc, data.as_ptr(), data.len(), enc.as_mut_ptr(), 1);
+        let mut st_dec = cryptstate_T { method_nr: CRYPT_M_BF2, method_state: std::ptr::null_mut() };
+        assert_eq!(1, crypt_blowfish_init(&mut st_dec, key.as_ptr(), &mut arg));
+        let mut dec = vec![0u8; data.len()];
+        crypt_blowfish_decode(&mut st_dec, enc.as_ptr(), enc.len(), dec.as_mut_ptr(), 1);
+        assert_eq!(data.to_vec(), dec);
+    }
+}

--- a/rust_sha256/Cargo.toml
+++ b/rust_sha256/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_sha256"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_sha256"
+crate-type = ["staticlib", "rlib"]

--- a/rust_sha256/src/lib.rs
+++ b/rust_sha256/src/lib.rs
@@ -1,0 +1,191 @@
+use std::os::raw::c_uint;
+use std::slice;
+
+#[repr(C)]
+pub struct context_sha256_T {
+    total: [u32; 2],
+    state: [u32; 8],
+    buffer: [u8; 64],
+}
+
+const K256: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+fn sha256_start_rust(ctx: &mut context_sha256_T) {
+    ctx.total = [0, 0];
+    ctx.state = [
+        0x6a09e667,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+}
+
+fn rotr(x: u32, n: u32) -> u32 { (x >> n) | (x << (32 - n)) }
+
+fn sha256_process(ctx: &mut context_sha256_T, data: &[u8; 64]) {
+    let mut w = [0u32; 64];
+    for i in 0..16 {
+        let j = i * 4;
+        w[i] = u32::from_be_bytes([data[j], data[j + 1], data[j + 2], data[j + 3]]);
+    }
+    for t in 16..64 {
+        let s0 = rotr(w[t - 15], 7) ^ rotr(w[t - 15], 18) ^ (w[t - 15] >> 3);
+        let s1 = rotr(w[t - 2], 17) ^ rotr(w[t - 2], 19) ^ (w[t - 2] >> 10);
+        w[t] = w[t - 16]
+            .wrapping_add(s0)
+            .wrapping_add(w[t - 7])
+            .wrapping_add(s1);
+    }
+    let mut a = ctx.state[0];
+    let mut b = ctx.state[1];
+    let mut c = ctx.state[2];
+    let mut d = ctx.state[3];
+    let mut e = ctx.state[4];
+    let mut f = ctx.state[5];
+    let mut g = ctx.state[6];
+    let mut h = ctx.state[7];
+    for i in 0..64 {
+        let s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+        let ch = (e & f) ^ ((!e) & g);
+        let temp1 = h
+            .wrapping_add(s1)
+            .wrapping_add(ch)
+            .wrapping_add(K256[i])
+            .wrapping_add(w[i]);
+        let s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+        let maj = (a & b) ^ (a & c) ^ (b & c);
+        let temp2 = s0.wrapping_add(maj);
+        h = g;
+        g = f;
+        f = e;
+        e = d.wrapping_add(temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = temp1.wrapping_add(temp2);
+    }
+    ctx.state[0] = ctx.state[0].wrapping_add(a);
+    ctx.state[1] = ctx.state[1].wrapping_add(b);
+    ctx.state[2] = ctx.state[2].wrapping_add(c);
+    ctx.state[3] = ctx.state[3].wrapping_add(d);
+    ctx.state[4] = ctx.state[4].wrapping_add(e);
+    ctx.state[5] = ctx.state[5].wrapping_add(f);
+    ctx.state[6] = ctx.state[6].wrapping_add(g);
+    ctx.state[7] = ctx.state[7].wrapping_add(h);
+}
+
+fn sha256_update_rust(ctx: &mut context_sha256_T, input: &[u8]) {
+    if input.is_empty() { return; }
+    let mut left = (ctx.total[0] & 0x3f) as usize;
+    let fill = 64 - left;
+    ctx.total[0] = ctx.total[0].wrapping_add(input.len() as u32);
+    if ctx.total[0] < input.len() as u32 { ctx.total[1] = ctx.total[1].wrapping_add(1); }
+    let mut data = input;
+    if left != 0 && data.len() >= fill {
+        ctx.buffer[left..left+fill].copy_from_slice(&data[..fill]);
+        sha256_process(ctx, unsafe { &*(ctx.buffer.as_ptr() as *const [u8;64]) });
+        data = &data[fill..];
+        left = 0;
+    }
+    while data.len() >= 64 {
+        let mut block = [0u8;64];
+        block.copy_from_slice(&data[..64]);
+        sha256_process(ctx, &block);
+        data = &data[64..];
+    }
+    if !data.is_empty() {
+        ctx.buffer[left..left+data.len()].copy_from_slice(data);
+    }
+}
+
+fn sha256_finish_rust(ctx: &mut context_sha256_T, digest: &mut [u8;32]) {
+    let mut msglen = [0u8;8];
+    let high = (ctx.total[0] >> 29) | (ctx.total[1] << 3);
+    let low = ctx.total[0] << 3;
+    msglen[..4].copy_from_slice(&high.to_be_bytes());
+    msglen[4..].copy_from_slice(&low.to_be_bytes());
+    let last = (ctx.total[0] & 0x3f) as usize;
+    let padn = if last < 56 {56 - last} else {120 - last};
+    sha256_update_rust(ctx, &SHA256_PADDING[..padn]);
+    sha256_update_rust(ctx, &msglen);
+    for (i, chunk) in digest.chunks_mut(4).enumerate() {
+        chunk.copy_from_slice(&ctx.state[i].to_be_bytes());
+    }
+}
+
+static SHA256_PADDING: [u8;64] = [
+    0x80, 0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,
+];
+
+#[no_mangle]
+pub extern "C" fn sha256_start(ctx: *mut context_sha256_T) {
+    if ctx.is_null() { return; }
+    sha256_start_rust(unsafe { &mut *ctx });
+}
+
+#[no_mangle]
+pub extern "C" fn sha256_update(ctx: *mut context_sha256_T, input: *mut u8, length: c_uint) {
+    if ctx.is_null() || input.is_null() || length == 0 { return; }
+    let data = unsafe { slice::from_raw_parts(input, length as usize) };
+    sha256_update_rust(unsafe { &mut *ctx }, data);
+}
+
+#[no_mangle]
+pub extern "C" fn sha256_finish(ctx: *mut context_sha256_T, digest: *mut u8) {
+    if ctx.is_null() || digest.is_null() { return; }
+    let mut out = [0u8;32];
+    sha256_finish_rust(unsafe { &mut *ctx }, &mut out);
+    unsafe { slice::from_raw_parts_mut(digest, 32).copy_from_slice(&out); }
+}
+
+/// Compute SHA-256 digest of arbitrary data and return 32-byte array.
+pub fn sha256_digest(data: &[u8]) -> [u8; 32] {
+    let mut ctx = context_sha256_T { total: [0;2], state: [0;8], buffer: [0;64] };
+    sha256_start_rust(&mut ctx);
+    sha256_update_rust(&mut ctx, data);
+    let mut out = [0u8;32];
+    sha256_finish_rust(&mut ctx, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_abc() {
+        let mut ctx = context_sha256_T { total:[0;2], state:[0;8], buffer:[0;64] };
+        unsafe {
+            sha256_start(&mut ctx);
+            let mut data = b"abc".to_vec();
+            sha256_update(&mut ctx, data.as_mut_ptr(), data.len() as c_uint);
+            let mut out = [0u8;32];
+            sha256_finish(&mut ctx, out.as_mut_ptr());
+            let hex: String = out.iter().map(|b| format!("{:02x}", b)).collect();
+            assert_eq!(hex, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+        }
+    }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1427,6 +1427,12 @@ RUST_SCREEN_DIR = ../rust_screen
 RUST_SCREEN_LIB = $(RUST_SCREEN_DIR)/target/release/librust_screen.a
 RUST_SIGN_DIR = ../rust_sign
 RUST_SIGN_LIB = $(RUST_SIGN_DIR)/target/release/librust_sign.a
+RUST_BLOB_DIR = ../rust_blob
+RUST_BLOB_LIB = $(RUST_BLOB_DIR)/target/release/librust_blob.a
+RUST_SHA256_DIR = ../rust_sha256
+RUST_SHA256_LIB = $(RUST_SHA256_DIR)/target/release/librust_sha256.a
+RUST_BLOWFISH_DIR = ../rust_blowfish
+RUST_BLOWFISH_LIB = $(RUST_BLOWFISH_DIR)/target/release/librust_blowfish.a
 
 # Additional Rust crates used by this configuration
 RUST_CHANGE_DIR = ../rust_change
@@ -1473,6 +1479,9 @@ ALL_LIBS = \
            $(RUST_EVALVARS_LIB) \
            $(RUST_SCREEN_LIB) \
            $(RUST_SIGN_LIB) \
+           $(RUST_BLOB_LIB) \
+           $(RUST_SHA256_LIB) \
+           $(RUST_BLOWFISH_LIB) \
            $(LUA_LIBS) \
            $(PERL_LIBS) \
            $(PYTHON_LIBS) \
@@ -1597,7 +1606,16 @@ $(RUST_SCREEN_LIB):
 	cd $(RUST_SCREEN_DIR) && cargo build --release
 
 $(RUST_SIGN_LIB):
-	cd $(RUST_SIGN_DIR) && cargo build --release
+       cd $(RUST_SIGN_DIR) && cargo build --release
+
+$(RUST_BLOB_LIB):
+       cd $(RUST_BLOB_DIR) && cargo build --release
+
+$(RUST_SHA256_LIB):
+       cd $(RUST_SHA256_DIR) && cargo build --release
+
+$(RUST_BLOWFISH_LIB):
+       cd $(RUST_BLOWFISH_DIR) && cargo build --release
 
 # Additional Rust libraries providing rs_* APIs used across the C codebase
 RUST_ARGLIST_DIR = ../rust_arglist
@@ -2283,7 +2301,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVAL_LIB) $(RUST_EXCMD_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_ALLOC_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVAL_LIB) $(RUST_EXCMD_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB) $(RUST_BLOWFISH_LIB)
 	@$(BUILD_DATE_MSG)
 	@LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) $(OBJ) $(ALL_LIBS)" \


### PR DESCRIPTION
## Summary
- Implement blob operations in new `rust_blob` crate
- Provide SHA-256 algorithm in `rust_sha256` crate with C FFI
- Add Blowfish encryption in `rust_blowfish` crate and integrate new crates into build system

## Testing
- `cargo test -p rust_sha256`
- `cargo test -p rust_blob`
- `cargo test -p rust_blowfish`


------
https://chatgpt.com/codex/tasks/task_e_68b7e44159c88320901c1632571a3a2d