### PR TITLE
Add safe file and buffer I/O APIs

### DIFF
--- a/src/memline.c
+++ b/src/memline.c
@@ -1,12 +1,6 @@
 #include "vim.h"
 #include <stdbool.h>
-
-extern void *rs_ml_buffer_new(void);
-extern void rs_ml_buffer_free(void *buf);
-extern bool rs_ml_append(void *buf, size_t lnum, const char *line);
-extern bool rs_ml_delete(void *buf, size_t lnum);
-extern bool rs_ml_replace(void *buf, size_t lnum, const char *line);
-extern unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
+#include "rust_memline.h"
 
 static char_u empty_line[] = "";
 
@@ -22,7 +16,7 @@ int ml_open(buf_T *buf)
     // Initialize with one empty line, as Vim expects buffers to have at least
     // one line.
     (void)rs_ml_append((void *)buf->b_ml.ml_mfp, 0, "");
-    buf->b_ml.ml_line_count = 1;
+    buf->b_ml.ml_line_count = (linenr_T)rs_ml_line_count((void *)buf->b_ml.ml_mfp);
     return OK;
 }
 
@@ -38,24 +32,19 @@ void ml_close(buf_T *buf, int del_file UNUSED)
 int ml_append(linenr_T lnum, char_u *line, colnr_T len UNUSED, int newfile UNUSED)
 {
     void *rs_buffer = (void *)curbuf->b_ml.ml_mfp;
-    if (rs_ml_append(rs_buffer, (size_t)lnum, (const char *)line)) {
-        // Vim uses 1-based line numbers; appending after lnum increases count
-        // by 1.
-        ++curbuf->b_ml.ml_line_count;
-        return OK;
-    }
-    return FAIL;
+    if (!rs_ml_append(rs_buffer, (size_t)lnum, (const char *)line))
+        return FAIL;
+    curbuf->b_ml.ml_line_count = (linenr_T)rs_ml_line_count(rs_buffer);
+    return OK;
 }
 
 int ml_delete(linenr_T lnum)
 {
     void *rs_buffer = (void *)curbuf->b_ml.ml_mfp;
-    if (rs_ml_delete(rs_buffer, (size_t)lnum)) {
-        if (curbuf->b_ml.ml_line_count > 0)
-            --curbuf->b_ml.ml_line_count;
-        return OK;
-    }
-    return FAIL;
+    if (!rs_ml_delete(rs_buffer, (size_t)lnum))
+        return FAIL;
+    curbuf->b_ml.ml_line_count = (linenr_T)rs_ml_line_count(rs_buffer);
+    return OK;
 }
 
 int ml_replace(linenr_T lnum, char_u *line, int copy UNUSED)

--- a/src/rust_memline.h
+++ b/src/rust_memline.h
@@ -1,0 +1,23 @@
+#ifndef RUST_MEMLINE_H
+#define RUST_MEMLINE_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *rs_ml_buffer_new(void);
+void rs_ml_buffer_free(void *buf);
+bool rs_ml_append(void *buf, size_t lnum, const char *line);
+bool rs_ml_delete(void *buf, size_t lnum);
+bool rs_ml_replace(void *buf, size_t lnum, const char *line);
+unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
+size_t rs_ml_line_count(void *buf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUST_MEMLINE_H


### PR DESCRIPTION
## Summary
- enforce size limits in Rust file I/O and add tests for oversize reads and writes
- add maximum line length and line-count API to Rust memline implementation
- wire C memline logic through new Rust API and provide header for bindings

## Testing
- `cargo test` in rust_fileio
- `cargo test` in rust_memline

------
https://chatgpt.com/codex/tasks/task_e_68b80e81f16083209a338900f5c0f0c3