### PR TITLE
Use regex crate for regex engine FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,9 @@ dependencies = [
 [[package]]
 name = "rust_regex_engine"
 version = "0.1.0"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "rust_regexp"

--- a/rust_regex_engine/Cargo.toml
+++ b/rust_regex_engine/Cargo.toml
@@ -7,7 +7,5 @@ edition = "2021"
 name = "rust_regex_engine"
 crate-type = ["staticlib", "rlib"]
 
-# This crate implements a very small regular expression engine that
-# supports only literal matches and a few meta characters.  Therefore we
-# do not depend on an external regex crate.
 [dependencies]
+regex = "1"

--- a/rust_regex_engine/src/lib.rs
+++ b/rust_regex_engine/src/lib.rs
@@ -1,88 +1,14 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_long, c_void};
 
-// A very small regular expression engine.  It only understands a few meta
-// characters and is intended as a placeholder for the full Vim engine.
-// Supported syntax:
-//  - Literals
-//  - '.'      : matches any single character
-//  - '*'      : zero or more of the previous item
-//  - '^'      : anchor at start of the string
-//  - '$'      : anchor at end of the string
-// No capturing groups or character classes are implemented.
+use regex::Regex;
+use regex::RegexBuilder;
+
 // Flag bit 1 enables case-insensitive matching.
 
 #[repr(C)]
 pub struct RegProg {
-    pattern: Vec<u8>,
-    ic: bool,
-}
-
-fn eq_byte(a: u8, b: u8, ic: bool) -> bool {
-    if ic {
-        a.to_ascii_lowercase() == b.to_ascii_lowercase()
-    } else {
-        a == b
-    }
-}
-
-// Try to match `pat` against `text` starting at the first character.  Returns
-// the length of the match when successful.
-fn match_here(pat: &[u8], text: &[u8], ic: bool) -> Option<usize> {
-    if pat.is_empty() {
-        return Some(0);
-    }
-    if pat.len() >= 2 && pat[1] == b'*' {
-        return match_star(pat[0], &pat[2..], text, ic);
-    }
-    match pat[0] {
-        b'$' if pat.len() == 1 => {
-            if text.is_empty() {
-                Some(0)
-            } else {
-                None
-            }
-        }
-        c if !text.is_empty() && (c == b'.' || eq_byte(c, text[0], ic)) => {
-            match_here(&pat[1..], &text[1..], ic).map(|l| l + 1)
-        }
-        _ => None,
-    }
-}
-
-fn match_star(c: u8, pat: &[u8], text: &[u8], ic: bool) -> Option<usize> {
-    let mut i = 0;
-    while i <= text.len() {
-        if let Some(l) = match_here(pat, &text[i..], ic) {
-            return Some(i + l);
-        }
-        if i == text.len() {
-            break;
-        }
-        if c != b'.' && !eq_byte(c, text[i], ic) {
-            break;
-        }
-        i += 1;
-    }
-    None
-}
-
-// Search for a match of `pat` anywhere in `text`.
-fn search(pat: &[u8], text: &[u8], ic: bool) -> Option<(usize, usize)> {
-    if pat.first() == Some(&b'^') {
-        return match_here(&pat[1..], text, ic).map(|l| (0, l));
-    }
-    let mut i = 0;
-    while i <= text.len() {
-        if let Some(l) = match_here(pat, &text[i..], ic) {
-            return Some((i, i + l));
-        }
-        if i == text.len() {
-            break;
-        }
-        i += 1;
-    }
-    None
+    regex: Regex,
 }
 
 #[no_mangle]
@@ -95,28 +21,15 @@ pub extern "C" fn vim_regcomp(pattern: *const c_char, flags: c_int) -> *mut RegP
         Ok(s) => s,
         Err(_) => return std::ptr::null_mut(),
     };
-    // Reject patterns containing constructs we do not understand.
-    let bytes = pattern_str.as_bytes();
-    let mut prev_was_atom = false;
-    for &b in bytes {
-        match b {
-            b'.' | b'^' | b'$' => prev_was_atom = true,
-            b'*' => {
-                if !prev_was_atom {
-                    return std::ptr::null_mut();
-                }
-                prev_was_atom = false;
-            }
-            b'[' | b']' | b'(' | b')' | b'+' | b'?' | b'{' | b'}' | b'|' | b'\\' => {
-                return std::ptr::null_mut();
-            }
-            _ => prev_was_atom = true,
-        }
+    let mut builder = RegexBuilder::new(pattern_str);
+    if (flags & 1) != 0 {
+        builder.case_insensitive(true);
     }
-    Box::into_raw(Box::new(RegProg {
-        pattern: bytes.to_vec(),
-        ic: (flags & 1) != 0,
-    }))
+    let regex = match builder.build() {
+        Ok(r) => r,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    Box::into_raw(Box::new(RegProg { regex }))
 }
 
 #[no_mangle]
@@ -161,20 +74,27 @@ fn regexec_internal(rmp: *mut RegMatch, line: *const c_char, col: c_int) -> c_in
         return 0;
     }
     let prog = unsafe { &*prog_ptr };
-    let line_bytes = unsafe { CStr::from_ptr(line).to_bytes() };
-    if (col as usize) > line_bytes.len() {
+    let line_str = match unsafe { CStr::from_ptr(line).to_str() } {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    if (col as usize) > line_str.len() {
         return 0;
     }
-    let slice = &line_bytes[(col as usize)..];
-    if let Some((s, e)) = search(&prog.pattern, slice, prog.ic) {
+    let slice = &line_str[(col as usize)..];
+    if let Some(caps) = prog.regex.captures(slice) {
         let m = unsafe { &mut *rmp };
         for i in 0..10 {
             m.startp[i] = std::ptr::null();
             m.endp[i] = std::ptr::null();
         }
-        unsafe {
-            m.startp[0] = line.add(col as usize + s);
-            m.endp[0] = line.add(col as usize + e);
+        for (i, cap) in caps.iter().enumerate().take(10) {
+            if let Some(mat) = cap {
+                unsafe {
+                    m.startp[i] = line.add(col as usize + mat.start());
+                    m.endp[i] = line.add(col as usize + mat.end());
+                }
+            }
         }
         return 1;
     }
@@ -225,14 +145,20 @@ pub extern "C" fn vim_regexec_multi(
                 m.startpos[i] = Lpos { lnum: 0, col: 0 };
                 m.endpos[i] = Lpos { lnum: 0, col: 0 };
             }
-            m.startpos[0] = Lpos {
-                lnum,
-                col: rm.startp[0].offset_from(line_ptr) as c_int,
-            };
-            m.endpos[0] = Lpos {
-                lnum,
-                col: rm.endp[0].offset_from(line_ptr) as c_int,
-            };
+            for i in 0..10 {
+                if !rm.startp[i].is_null() {
+                    m.startpos[i] = Lpos {
+                        lnum,
+                        col: rm.startp[i].offset_from(line_ptr) as c_int,
+                    };
+                }
+                if !rm.endp[i].is_null() {
+                    m.endpos[i] = Lpos {
+                        lnum,
+                        col: rm.endp[i].offset_from(line_ptr) as c_int,
+                    };
+                }
+            }
             m.rmm_matchcol = col;
             return lnum;
         }
@@ -250,16 +176,14 @@ pub extern "C" fn vim_regsub(
         return std::ptr::null_mut();
     }
     let prog = unsafe { &*prog };
-    let text_str = unsafe { CStr::from_ptr(text).to_bytes() };
-    let sub_str = unsafe { CStr::from_ptr(sub).to_bytes() };
-    if let Some((s, e)) = search(&prog.pattern, text_str, prog.ic) {
-        let mut result = Vec::new();
-        result.extend_from_slice(&text_str[..s]);
-        result.extend_from_slice(sub_str);
-        result.extend_from_slice(&text_str[e..]);
-        CString::new(result).unwrap().into_raw()
-    } else {
-        // No match -> return original text
-        CString::new(text_str).unwrap().into_raw()
-    }
+    let text_str = match unsafe { CStr::from_ptr(text).to_str() } {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let sub_str = match unsafe { CStr::from_ptr(sub).to_str() } {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let result = prog.regex.replace(text_str, sub_str);
+    CString::new(result.into_owned()).unwrap().into_raw()
 }

--- a/rust_regex_engine/tests/compat.rs
+++ b/rust_regex_engine/tests/compat.rs
@@ -9,59 +9,58 @@ use std::os::raw::c_void;
 fn basic_match_and_exec_nl() {
     let pat = CString::new("foo").unwrap();
     let text = CString::new("foo bar").unwrap();
-    unsafe {
-        let prog = vim_regcomp(pat.as_ptr(), 0);
-        assert!(!prog.is_null());
-        let mut rm = RegMatch {
-            regprog: prog,
-            startp: [std::ptr::null(); 10],
-            endp: [std::ptr::null(); 10],
-            rm_matchcol: 0,
-            rm_ic: 0,
-        };
-        assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
-        assert_eq!(vim_regexec_nl(&mut rm, text.as_ptr(), 0), 1);
-        vim_regfree(prog);
-    }
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(!prog.is_null());
+    let mut rm = RegMatch {
+        regprog: prog,
+        startp: [std::ptr::null(); 10],
+        endp: [std::ptr::null(); 10],
+        rm_matchcol: 0,
+        rm_ic: 0,
+    };
+    assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
+    assert_eq!(vim_regexec_nl(&mut rm, text.as_ptr(), 0), 1);
+    vim_regfree(prog);
 }
 
 #[test]
 fn substitution_and_flags() {
     let pat = CString::new("foo").unwrap();
     let text = CString::new("Foo bar").unwrap();
+    // enable case-insensitive match using flag bit 1
+    let prog = vim_regcomp(pat.as_ptr(), 1);
+    assert!(!prog.is_null());
+    let sub = CString::new("baz").unwrap();
+    let replaced = vim_regsub(prog, text.as_ptr(), sub.as_ptr());
+    let c_str = unsafe { CStr::from_ptr(replaced) };
+    assert_eq!(c_str.to_str().unwrap(), "baz bar");
     unsafe {
-        // enable case-insensitive match using flag bit 1
-        let prog = vim_regcomp(pat.as_ptr(), 1);
-        assert!(!prog.is_null());
-        let sub = CString::new("baz").unwrap();
-        let replaced = vim_regsub(prog, text.as_ptr(), sub.as_ptr());
-        let c_str = CStr::from_ptr(replaced);
-        assert_eq!(c_str.to_str().unwrap(), "baz bar");
-        vim_regfree(prog);
-    }
+        let _ = CString::from_raw(replaced);
+    }; // free result
+    vim_regfree(prog);
 }
 
 #[test]
 fn capture_offsets() {
-    // Use a pattern with a '.' meta character and ensure offsets for the
-    // whole match are filled in.
-    let pat = CString::new("a.c").unwrap();
+    // Use a pattern with a capturing group and ensure offsets for the
+    // whole match and the first group are filled in.
+    let pat = CString::new("(a.)c").unwrap();
     let text = CString::new("zabc").unwrap();
-    unsafe {
-        let prog = vim_regcomp(pat.as_ptr(), 0);
-        assert!(!prog.is_null());
-        let mut rm = RegMatch {
-            regprog: prog,
-            startp: [std::ptr::null(); 10],
-            endp: [std::ptr::null(); 10],
-            rm_matchcol: 0,
-            rm_ic: 0,
-        };
-        assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
-        assert!(!rm.startp[0].is_null());
-        assert!(!rm.endp[0].is_null());
-        vim_regfree(prog);
-    }
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(!prog.is_null());
+    let mut rm = RegMatch {
+        regprog: prog,
+        startp: [std::ptr::null(); 10],
+        endp: [std::ptr::null(); 10],
+        rm_matchcol: 0,
+        rm_ic: 0,
+    };
+    assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
+    assert!(!rm.startp[0].is_null());
+    assert!(!rm.endp[0].is_null());
+    assert!(!rm.startp[1].is_null());
+    assert!(!rm.endp[1].is_null());
+    vim_regfree(prog);
 }
 
 #[test]
@@ -70,56 +69,50 @@ fn regexec_multi_single_line() {
     let line1 = CString::new("foo").unwrap();
     let line2 = CString::new("bar baz").unwrap();
     let lines = [line1.as_ptr(), line2.as_ptr()];
-    unsafe {
-        let prog = vim_regcomp(pat.as_ptr(), 0);
-        assert!(!prog.is_null());
-        let mut rmm = RegMMMatch {
-            regprog: prog,
-            startpos: [Lpos { lnum: 0, col: 0 }; 10],
-            endpos: [Lpos { lnum: 0, col: 0 }; 10],
-            rmm_matchcol: 0,
-            rmm_ic: 0,
-            rmm_maxcol: 0,
-        };
-        let matched = vim_regexec_multi(
-            &mut rmm,
-            std::ptr::null_mut(),
-            lines.as_ptr() as *mut c_void,
-            2,
-            0,
-            std::ptr::null_mut(),
-        );
-        assert_eq!(matched, 2);
-        assert_eq!(rmm.startpos[0].lnum, 2);
-        assert_eq!(rmm.startpos[0].col, 0);
-        vim_regfree(prog);
-    }
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(!prog.is_null());
+    let mut rmm = RegMMMatch {
+        regprog: prog,
+        startpos: [Lpos { lnum: 0, col: 0 }; 10],
+        endpos: [Lpos { lnum: 0, col: 0 }; 10],
+        rmm_matchcol: 0,
+        rmm_ic: 0,
+        rmm_maxcol: 0,
+    };
+    let matched = vim_regexec_multi(
+        &mut rmm,
+        std::ptr::null_mut(),
+        lines.as_ptr() as *mut c_void,
+        2,
+        0,
+        std::ptr::null_mut(),
+    );
+    assert_eq!(matched, 2);
+    assert_eq!(rmm.startpos[0].lnum, 2);
+    assert_eq!(rmm.startpos[0].col, 0);
+    vim_regfree(prog);
 }
 
 #[test]
 fn invalid_pattern_returns_null() {
     let pat = CString::new("[a-").unwrap();
-    unsafe {
-        let prog = vim_regcomp(pat.as_ptr(), 0);
-        assert!(prog.is_null());
-    }
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(prog.is_null());
 }
 
 #[test]
 fn non_match_returns_zero() {
     let pat = CString::new("foo").unwrap();
     let text = CString::new("bar").unwrap();
-    unsafe {
-        let prog = vim_regcomp(pat.as_ptr(), 0);
-        assert!(!prog.is_null());
-        let mut rm = RegMatch {
-            regprog: prog,
-            startp: [std::ptr::null(); 10],
-            endp: [std::ptr::null(); 10],
-            rm_matchcol: 0,
-            rm_ic: 0,
-        };
-        assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 0);
-        vim_regfree(prog);
-    }
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(!prog.is_null());
+    let mut rm = RegMatch {
+        regprog: prog,
+        startp: [std::ptr::null(); 10],
+        endp: [std::ptr::null(); 10],
+        rm_matchcol: 0,
+        rm_ic: 0,
+    };
+    assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 0);
+    vim_regfree(prog);
 }


### PR DESCRIPTION
## Summary
- replace custom regex engine with the `regex` crate
- expose regex-based compile, execute, and substitute functions over FFI
- expand tests for capturing groups and adjust to safe calls

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b8179de1688320aeb5510564ae305e