### PR TITLE
Add stub Rust bufwrite crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_bufwrite"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_change"
 version = "0.1.0"
 dependencies = [

--- a/rust_bufwrite/Cargo.toml
+++ b/rust_bufwrite/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_bufwrite"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_bufwrite"
+crate-type = ["staticlib", "rlib"]

--- a/rust_bufwrite/src/lib.rs
+++ b/rust_bufwrite/src/lib.rs
@@ -1,0 +1,29 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+/// Dummy bufwrite function exposed to C.
+/// Returns 0 on success, -1 on error.
+#[no_mangle]
+pub extern "C" fn bufwrite_dummy(path: *const c_char) -> c_int {
+    if path.is_null() {
+        return -1;
+    }
+    // Convert C string to Rust &str for demonstration purposes.
+    let c_str = unsafe { CStr::from_ptr(path) };
+    match c_str.to_str() {
+        Ok(_s) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn dummy_ok() {
+        let s = CString::new("test").unwrap();
+        assert_eq!(bufwrite_dummy(s.as_ptr()), 0);
+    }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1387,6 +1387,8 @@ SRC_RUST_REGEX_DIR = rust_regex
 SRC_RUST_REGEX_LIB = $(SRC_RUST_REGEX_DIR)/target/release/libvim_rust_regex.a
 RUST_BUFFER_DIR = ../rust_buffer
 RUST_BUFFER_LIB = $(RUST_BUFFER_DIR)/target/release/librust_buffer.a
+RUST_BUFWRITE_DIR = ../rust_bufwrite
+RUST_BUFWRITE_LIB = $(RUST_BUFWRITE_DIR)/target/release/librust_bufwrite.a
 RUST_CHANNEL_DIR = ../rust_channel
 RUST_CHANNEL_LIB = $(RUST_CHANNEL_DIR)/target/release/librust_channel.a
 RUST_GUI_DIR = ../rust_gui
@@ -1468,6 +1470,7 @@ ALL_LIBS = \
            $(RUST_REGEX_LIB) \
            $(SRC_RUST_REGEX_LIB) \
            $(RUST_BUFFER_LIB) \
+           $(RUST_BUFWRITE_LIB) \
            $(RUST_CHANNEL_LIB) \
            $(RUST_GUI_LIB) \
            $(RUST_EVALFUNC_LIB) \
@@ -1559,10 +1562,13 @@ $(SRC_RUST_REGEX_LIB):
 	cd $(SRC_RUST_REGEX_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_BUFFER_LIB):
-	cd $(RUST_BUFFER_DIR) && CARGO_TARGET_DIR=target cargo build --release
+        cd $(RUST_BUFFER_DIR) && CARGO_TARGET_DIR=target cargo build --release
+
+$(RUST_BUFWRITE_LIB):
+        cd $(RUST_BUFWRITE_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_CHANNEL_LIB):
-	cd $(RUST_CHANNEL_DIR) && CARGO_TARGET_DIR=target cargo build --release
+        cd $(RUST_CHANNEL_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_GUI_LIB):
 	cd $(RUST_GUI_DIR) && CARGO_TARGET_DIR=target cargo build --release
@@ -2301,7 +2307,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVAL_LIB) $(RUST_VIM9_LIB) $(RUST_EXCMD_LIB) $(RUST_CMDHIST_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB) $(RUST_BLOWFISH_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_BUFWRITE_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVAL_LIB) $(RUST_VIM9_LIB) $(RUST_EXCMD_LIB) $(RUST_CMDHIST_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB) $(RUST_BLOWFISH_LIB)
 	@$(BUILD_DATE_MSG)
     @LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) objects/*.o $(ALL_LIBS)" \

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #define EXTERN
 #include "vim.h"
 #include "rust_option.h"
+#include "rust_bufwrite.h"
 
 #ifdef __CYGWIN__
 # include <cygwin/version.h>
@@ -107,6 +108,9 @@ main
      * NameBuff.  Thus emsg2() cannot be called!
      */
     mch_early_init();
+
+    // Example call into Rust implementation for buffer writing.
+    (void)bufwrite_dummy("startup.log");
 
 #ifdef MSWIN
     /*

--- a/src/rust_bufwrite.h
+++ b/src/rust_bufwrite.h
@@ -1,0 +1,8 @@
+#ifndef RUST_BUFWRITE_H
+#define RUST_BUFWRITE_H
+
+#include <stddef.h>
+
+int bufwrite_dummy(const char *path);
+
+#endif // RUST_BUFWRITE_H


### PR DESCRIPTION
## Summary
- scaffold rust_bufwrite crate exposing `bufwrite_dummy`
- link new crate in build system and call from `main.c`

## Testing
- `cargo test -p rust_bufwrite`


------
https://chatgpt.com/codex/tasks/task_e_68b81715e3e883208bb4e072d6efbb44