### PR TITLE
Start migrating bufwrite logic to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_bufwrite"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_change"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rust_message = { path = "rust_message" }
 rust_blob = { path = "rust_blob" }
 rust_sha256 = { path = "rust_sha256" }
 rust_blowfish = { path = "rust_blowfish" }
+rust_bufwrite = { path = "rust_bufwrite" }
 
 [features]
 default = []

--- a/rust_bufwrite/Cargo.toml
+++ b/rust_bufwrite/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_bufwrite"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+libc = "0.2"

--- a/rust_bufwrite/include/rust_bufwrite.h
+++ b/rust_bufwrite/include/rust_bufwrite.h
@@ -1,0 +1,16 @@
+#ifndef RUST_BUFWRITE_H
+#define RUST_BUFWRITE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int rs_buf_write(int fd, const void *buf, int len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUST_BUFWRITE_H

--- a/rust_bufwrite/src/lib.rs
+++ b/rust_bufwrite/src/lib.rs
@@ -1,0 +1,46 @@
+use libc::{c_int, c_void, size_t, EINTR};
+
+/// Write a buffer to a file descriptor, retrying on EINTR.
+#[no_mangle]
+pub extern "C" fn rs_buf_write(fd: c_int, buf: *const c_void, len: c_int) -> c_int {
+    if fd < 0 || buf.is_null() || len < 0 {
+        return -1;
+    }
+    let mut written: c_int = 0;
+    while written < len {
+        let ptr = unsafe { (buf as *const u8).add(written as usize) } as *const c_void;
+        let res = unsafe { libc::write(fd, ptr, (len - written) as size_t) };
+        if res < 0 {
+            let err = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+            if err == EINTR {
+                continue;
+            }
+            return res as c_int;
+        }
+        written += res as c_int;
+    }
+    written
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{File, read_to_string};
+    use std::os::fd::AsRawFd;
+    use libc::c_void;
+
+    #[test]
+    fn write_and_read_back() {
+        let mut path = std::env::temp_dir();
+        path.push("rs_bufwrite_test.txt");
+        let file = File::create(&path).unwrap();
+        let fd = file.as_raw_fd();
+        let data = b"hello";
+        let res = rs_buf_write(fd, data.as_ptr() as *const c_void, data.len() as c_int);
+        assert_eq!(res, data.len() as c_int);
+        drop(file);
+        let contents = read_to_string(&path).unwrap();
+        assert_eq!(contents, "hello");
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/bufwrite.c
+++ b/src/bufwrite.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "rust_bufwrite.h"
 
 #if defined(HAVE_UTIME) && defined(HAVE_UTIME_H)
 # include <utime.h>		// for struct utimbuf
@@ -506,7 +507,7 @@ buf_write_bytes(struct bw_info *ip)
 								ip->bw_finish);
 	    if (len == 0)
 		return OK;  // Crypt layer is buffering, will flush later.
-	    wlen = write_eintr(ip->bw_fd, outbuf, len);
+            wlen = rs_buf_write(ip->bw_fd, outbuf, len);
 	    vim_free(outbuf);
 	    return (wlen < len) ? FAIL : OK;
 	}
@@ -514,7 +515,7 @@ buf_write_bytes(struct bw_info *ip)
     }
 #endif
 
-    wlen = write_eintr(ip->bw_fd, buf, len);
+    wlen = rs_buf_write(ip->bw_fd, buf, len);
     return (wlen < len) ? FAIL : OK;
 }
 
@@ -2174,7 +2175,7 @@ restore_backup:
 	if (!buf->b_p_fixeol && buf->b_p_eof)
 	{
 	    // write trailing CTRL-Z
-	    (void)write_eintr(write_info.bw_fd, "\x1a", 1);
+            (void)rs_buf_write(write_info.bw_fd, "\x1a", 1);
 	    nchars++;
 	}
 

--- a/src/rust_bufwrite.h
+++ b/src/rust_bufwrite.h
@@ -1,0 +1,6 @@
+#ifndef RUST_BUFWRITE_WRAPPER_H
+#define RUST_BUFWRITE_WRAPPER_H
+
+#include "../rust_bufwrite/include/rust_bufwrite.h"
+
+#endif // RUST_BUFWRITE_WRAPPER_H


### PR DESCRIPTION
## Summary
- add new `rust_bufwrite` crate with `rs_buf_write` FFI
- call into `rs_buf_write` from `bufwrite.c` for writing bytes and trailing CTRL-Z
- wire crate into workspace

## Testing
- `cargo test -p rust_bufwrite`

------
https://chatgpt.com/codex/tasks/task_e_68b817336cc083209d736adddf339a08