### PR TITLE
Use NonNull for buffer management

### DIFF
--- a/rust_buffer/src/lib.rs
+++ b/rust_buffer/src/lib.rs
@@ -1,4 +1,5 @@
 use std::os::raw::{c_int, c_long, c_void};
+use std::ptr::NonNull;
 use std::sync::{
     atomic::{AtomicI32, Ordering},
     Mutex, OnceLock,
@@ -13,49 +14,67 @@ pub struct FileBuffer {
     _data: [u8; 0],
 }
 
-// Global storage of allocated buffer pointers.  A simple Vec is sufficient
-// because we only ever store raw pointers and occasionally remove them.
-static BUFFERS: OnceLock<Mutex<Vec<usize>>> = OnceLock::new();
+unsafe impl Send for FileBuffer {}
+unsafe impl Sync for FileBuffer {}
+
+// Global storage of allocated buffer pointers.  We wrap the Mutex in a newtype
+// so that we can provide manual `Send` and `Sync` implementations even though
+// `NonNull<T>` itself does not implement these traits.
+struct BufferList(Mutex<Vec<NonNull<FileBuffer>>>);
+
+unsafe impl Send for BufferList {}
+unsafe impl Sync for BufferList {}
+
+static BUFFERS: OnceLock<BufferList> = OnceLock::new();
 
 // Counter similar to Vim's 'top_file_num', used by get_highest_fnum().
 static TOP_FILE_NUM: AtomicI32 = AtomicI32::new(1);
 
+// Safe wrappers around libc allocation routines using NonNull for safety.
+fn calloc_file_buffer(size: usize) -> Option<NonNull<FileBuffer>> {
+    let ptr = unsafe { libc::calloc(1, size) } as *mut FileBuffer;
+    NonNull::new(ptr)
+}
+
+fn free_file_buffer(ptr: NonNull<FileBuffer>) {
+    unsafe { libc::free(ptr.as_ptr() as *mut c_void) };
+}
+
 #[no_mangle]
 pub extern "C" fn buf_alloc(size: usize) -> *mut FileBuffer {
-    let ptr = unsafe { libc::calloc(1, size) } as *mut FileBuffer;
-    if !ptr.is_null() {
+    if let Some(ptr) = calloc_file_buffer(size) {
         BUFFERS
-            .get_or_init(|| Mutex::new(Vec::new()))
+            .get_or_init(|| BufferList(Mutex::new(Vec::new())))
+            .0
             .lock()
             .unwrap()
-            .push(ptr as *mut c_void as usize);
+            .push(ptr);
+        ptr.as_ptr()
+    } else {
+        std::ptr::null_mut()
     }
-    ptr
 }
 
 #[no_mangle]
 pub extern "C" fn buf_free(buf: *mut FileBuffer) {
-    if buf.is_null() {
+    let Some(ptr) = NonNull::new(buf) else {
         return;
-    }
+    };
     if let Some(m) = BUFFERS.get() {
-        let mut buffers = m.lock().unwrap();
-        if let Some(pos) = buffers
-            .iter()
-            .position(|&p| p == buf as *mut c_void as usize)
-        {
+        let mut buffers = m.0.lock().unwrap();
+        if let Some(pos) = buffers.iter().position(|&p| p == ptr) {
             buffers.remove(pos);
         }
     }
-    unsafe { libc::free(buf as *mut c_void) };
+    free_file_buffer(ptr);
 }
 
 #[no_mangle]
 pub extern "C" fn buf_freeall(_buf: *mut FileBuffer, _flags: c_int) {
     if let Some(m) = BUFFERS.get() {
-        let mut buffers = m.lock().unwrap();
+        let mut buffers = m.0.lock().unwrap();
         for ptr in buffers.drain(..) {
-            unsafe { libc::free(ptr as *mut c_void) };
+            free_file_buffer(ptr);
         }
     }
 }
@@ -86,16 +105,16 @@ fn set_top_file_num(num: i32) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::raw::c_void;
+    use std::ptr::NonNull;
 
     #[test]
     fn alloc_and_free() {
         let p = buf_alloc(16);
         assert!(!p.is_null());
-        let list = BUFFERS.get().unwrap();
-        assert!(list.lock().unwrap().contains(&(p as *mut c_void as usize)));
+        let list = &BUFFERS.get().unwrap().0;
+        assert!(list.lock().unwrap().contains(&NonNull::new(p).unwrap()));
         buf_free(p);
-        assert!(!list.lock().unwrap().contains(&(p as *mut c_void as usize)));
+        assert!(!list.lock().unwrap().contains(&NonNull::new(p).unwrap()));
     }
 
     #[test]
@@ -103,11 +122,11 @@ mod tests {
         let p1 = buf_alloc(8);
         let p2 = buf_alloc(8);
         assert!(!p1.is_null() && !p2.is_null());
-        let list = BUFFERS.get().unwrap();
+        let list = &BUFFERS.get().unwrap().0;
         {
             let guard = list.lock().unwrap();
-            assert!(guard.contains(&(p1 as *mut c_void as usize)));
-            assert!(guard.contains(&(p2 as *mut c_void as usize)));
+            assert!(guard.contains(&NonNull::new(p1).unwrap()));
+            assert!(guard.contains(&NonNull::new(p2).unwrap()));
         }
         buf_freeall(std::ptr::null_mut(), 0);
         assert!(list.lock().unwrap().is_empty());


### PR DESCRIPTION
## Summary
- track allocated buffers with `Vec<NonNull<FileBuffer>>`
- wrap libc allocation with safe `NonNull` helpers
- switch buffer allocation and free routines to use `NonNull`

## Testing
- `cargo test -p rust_buffer`


------
https://chatgpt.com/codex/tasks/task_e_68b8175b3f008320ad53206716ad7f00