### PR TITLE
Use thiserror for JobError and improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -1826,6 +1827,26 @@ name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "tinytemplate"

--- a/rust_job/Cargo.toml
+++ b/rust_job/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 tokio = { version = "1", features = ["process", "macros", "rt-multi-thread"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = "1"
 
 [lib]
 name = "rust_job"


### PR DESCRIPTION
## Summary
- derive JobError with thiserror and add descriptive messages
- propagate JobError with `?` and log failures in run_job and job_start
- add thiserror dependency

## Testing
- `cargo test -p rust_job`

------
https://chatgpt.com/codex/tasks/task_e_68b8176506b483208f74befe719419a3