### PR TITLE
Add crypt state free function

### DIFF
--- a/src/crypt.c
+++ b/src/crypt.c
@@ -648,14 +648,21 @@ crypt_free_state(cryptstate_T *state)
 #ifdef FEAT_SODIUM
     if (crypt_method_is_sodium(state->method_nr))
     {
-	sodium_munlock(((sodium_state_T *)state->method_state)->key,
-							 crypto_box_SEEDBYTES);
-	sodium_memzero(state->method_state, sizeof(sodium_state_T));
-	sodium_free(state->method_state);
+        sodium_munlock(((sodium_state_T *)state->method_state)->key,
+                                                         crypto_box_SEEDBYTES);
+        sodium_memzero(state->method_state, sizeof(sodium_state_T));
+        sodium_free(state->method_state);
     }
     else
 #endif
-	vim_free(state->method_state);
+    {
+#ifdef FEAT_RUST_CRYPT
+        if (state->method_nr <= CRYPT_M_BF2)
+            crypt_state_free(state);
+        else
+#endif
+            vim_free(state->method_state);
+    }
     vim_free(state);
 }
 

--- a/src/crypt_rs.h
+++ b/src/crypt_rs.h
@@ -18,6 +18,7 @@ void crypt_blowfish_encode(cryptstate_T *state, char_u *from, size_t len, char_u
 void crypt_blowfish_decode(cryptstate_T *state, char_u *from, size_t len, char_u *to, int last);
 void crypt_blowfish_encode_inplace(cryptstate_T *state, char_u *buf, size_t len, char_u *p2, int last);
 void crypt_blowfish_decode_inplace(cryptstate_T *state, char_u *buf, size_t len, char_u *p2, int last);
+void crypt_state_free(cryptstate_T *state);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- free Rust crypt method state via new `crypt_state_free`
- invoke Rust state free in `crypt_free_state`
- expose state-free function to C headers

## Testing
- `cargo test -p rust_crypto`
- `make -C src` *(fails: Makefile:2702: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b8177c302c8320b2e1a1eb92696ac7