### PR TITLE
Adjust buffer flushing in tee tool

### DIFF
--- a/src/tee/src/main.rs
+++ b/src/tee/src/main.rs
@@ -43,11 +43,14 @@ fn run(args: Args) -> io::Result<()> {
             break;
         }
         out_writer.write_all(&buffer[..n])?;
-        out_writer.flush()?;
         for writer in &mut file_writers {
             writer.write_all(&buffer[..n])?;
-            writer.flush()?;
         }
+    }
+    // Ensure any buffered data is written out before exiting.
+    out_writer.flush()?;
+    for writer in &mut file_writers {
+        writer.flush()?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Avoid per-iteration flushes in tee's write loop for stdout and file outputs
- Flush all writers once after completing the copy loop

## Testing
- `cargo test` *(fails: current package believes it's in a workspace when it's not)*

------
https://chatgpt.com/codex/tasks/task_e_68b81788aad88320bd7e6330d581305a