### PR TITLE
Use crc32fast for zip CRC calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,7 +1144,7 @@ name = "rust_crypto"
 version = "0.1.0"
 dependencies = [
  "blowfish",
- "once_cell",
+ "crc32fast",
  "ring",
 ]
 

--- a/rust_crypto/Cargo.lock
+++ b/rust_crypto/Cargo.lock
@@ -36,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,12 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,7 +111,7 @@ name = "rust_crypto"
 version = "0.1.0"
 dependencies = [
  "blowfish",
- "once_cell",
+ "crc32fast",
  "ring",
 ]
 

--- a/rust_crypto/Cargo.toml
+++ b/rust_crypto/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 blowfish = "0.8"
 ring = "0.17"
-once_cell = "1.18"
+crc32fast = "1.3"


### PR DESCRIPTION
## Summary
- replace custom CRC32 implementation with `crc32fast` hasher
- update zip-key update logic to use the new hasher and drop old table
- add regression test to ensure CRC results remain unchanged

## Testing
- `cargo test -p rust_crypto`

------
https://chatgpt.com/codex/tasks/task_e_68b817a244f88320a46c8748e230253c