### PR TITLE
Use retain in buf_free to drop buffer pointer

### DIFF
--- a/rust_buffer/src/lib.rs
+++ b/rust_buffer/src/lib.rs
@@ -62,9 +62,7 @@ pub extern "C" fn buf_free(buf: *mut FileBuffer) {
     };
     if let Some(m) = BUFFERS.get() {
         let mut buffers = m.0.lock().unwrap();
-        if let Some(pos) = buffers.iter().position(|&p| p == ptr) {
-            buffers.remove(pos);
-        }
+        buffers.retain(|&p| p != ptr);
     }
     free_file_buffer(ptr);
 }


### PR DESCRIPTION
## Summary
- Simplify buffer removal logic by using `retain` in `buf_free`

## Testing
- `cargo test -p rust_buffer`


------
https://chatgpt.com/codex/tasks/task_e_68b81ad581b48320b6de912909fb2d7e