### PR TITLE
Add PumItem cleanup helper and RAII wrapper

### DIFF
--- a/src/evalfunc.c
+++ b/src/evalfunc.c
@@ -3690,12 +3690,10 @@ f_balloon_split(typval_T *argvars, typval_T *rettv UNUSED)
 	pumitem_T	*array;
 	int		size = split_message(msg, &array);
 
-	// Skip the first and last item, they are always empty.
-	for (int i = 1; i < size - 1; ++i)
-	    list_append_string(rettv->vval.v_list, array[i].pum_text, -1);
-	while (size > 0)
-	    vim_free(array[--size].pum_text);
-	vim_free(array);
+        // Skip the first and last item, they are always empty.
+        for (int i = 1; i < size - 1; ++i)
+            list_append_string(rettv->vval.v_list, array[i].pum_text, -1);
+        free_pum_items(array, (size_t)size);
     }
 }
 # endif

--- a/src/proto/popupmenu.pro
+++ b/src/proto/popupmenu.pro
@@ -12,6 +12,7 @@ void pum_may_redraw(void);
 int pum_get_height(void);
 void pum_set_event_info(dict_T *dict);
 int split_message(char_u *mesg, pumitem_T **array);
+void free_pum_items(pumitem_T *ptr, size_t count);
 void ui_remove_balloon(void);
 void ui_post_balloon(char_u *mesg, list_T *list);
 void ui_may_remove_balloon(void);


### PR DESCRIPTION
## Summary
- add `free_pum_items` to deallocate strings returned from `split_message`
- introduce `OwnedPumItems` RAII wrapper for automatic cleanup
- update C call site and tests to free popup menu items

## Testing
- `cargo test -p rust_popupmenu`
- `make -C src objects/evalfunc.o` *(fails: Makefile:1565: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b81adb8198832081d4f83db580fca7