### PR TITLE
Handle diff errors without panicking

### DIFF
--- a/rust_diff/src/lib.rs
+++ b/rust_diff/src/lib.rs
@@ -1,9 +1,29 @@
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void, c_long};
+use std::ffi::{CStr, CString, NulError};
+use std::os::raw::{c_char, c_int, c_long, c_void};
+use std::path::Path;
 use std::process::Command;
 use std::ptr;
 
-use diff::{mmfile_t, mmbuffer_t, xdemitcb_t, xdl_diff};
+use diff::{mmbuffer_t, mmfile_t, xdemitcb_t, xdl_diff};
+
+#[derive(Debug)]
+pub enum DiffError {
+    Io(std::io::Error),
+    Nul(NulError),
+    XdiffFailed,
+}
+
+impl From<std::io::Error> for DiffError {
+    fn from(e: std::io::Error) -> Self {
+        DiffError::Io(e)
+    }
+}
+
+impl From<NulError> for DiffError {
+    fn from(e: NulError) -> Self {
+        DiffError::Nul(e)
+    }
+}
 
 #[repr(C)]
 pub enum DiffMode {
@@ -24,48 +44,75 @@ unsafe extern "C" fn collect(priv_: *mut c_void, mb: *mut mmbuffer_t, nbuf: c_in
     0
 }
 
+fn read_file(path: &CStr) -> Result<Vec<u8>, DiffError> {
+    let s = path.to_string_lossy();
+    let p = Path::new(&*s);
+    Ok(std::fs::read(p)?)
+}
+
+fn rs_diff_files_impl(f1: &CStr, f2: &CStr, mode: DiffMode) -> Result<*mut c_char, DiffError> {
+    match mode {
+        DiffMode::External => {
+            let file1 = f1.to_string_lossy();
+            let file2 = f2.to_string_lossy();
+            let out = Command::new("diff")
+                .arg("-u")
+                .arg(&*file1)
+                .arg(&*file2)
+                .output()?;
+            let cstr = CString::new(String::from_utf8_lossy(&out.stdout).to_string())?;
+            Ok(cstr.into_raw())
+        }
+        DiffMode::Xdiff => {
+            let a = read_file(f1)?;
+            let b = read_file(f2)?;
+            let mf1 = mmfile_t {
+                ptr: a.as_ptr() as *const c_char,
+                size: a.len() as c_long,
+            };
+            let mf2 = mmfile_t {
+                ptr: b.as_ptr() as *const c_char,
+                size: b.len() as c_long,
+            };
+            let mut output = String::new();
+            let mut ecb = xdemitcb_t {
+                priv_: &mut output as *mut _ as *mut c_void,
+                out_hunk: None,
+                out_line: Some(collect),
+            };
+            let res = unsafe { xdl_diff(&mf1, &mf2, ptr::null(), ptr::null(), &mut ecb) };
+            if res != 0 {
+                return Err(DiffError::XdiffFailed);
+            }
+            let cstr = CString::new(output)?;
+            Ok(cstr.into_raw())
+        }
+    }
+}
+
 #[no_mangle]
-pub extern "C" fn rs_diff_files(f1: *const c_char, f2: *const c_char, mode: DiffMode) -> *mut c_char {
+pub extern "C" fn rs_diff_files(
+    f1: *const c_char,
+    f2: *const c_char,
+    mode: DiffMode,
+) -> *mut c_char {
     if f1.is_null() || f2.is_null() {
         return ptr::null_mut();
     }
-    let file1 = unsafe { CStr::from_ptr(f1) }.to_string_lossy().into_owned();
-    let file2 = unsafe { CStr::from_ptr(f2) }.to_string_lossy().into_owned();
-
-    match mode {
-        DiffMode::External => {
-            let output = Command::new("diff").arg("-u").arg(&file1).arg(&file2).output();
-            match output {
-                Ok(out) => CString::new(String::from_utf8_lossy(&out.stdout).to_string()).unwrap().into_raw(),
-                Err(_) => ptr::null_mut(),
-            }
-        }
-        DiffMode::Xdiff => {
-            let a = match std::fs::read(&file1) {
-                Ok(v) => v,
-                Err(_) => return ptr::null_mut(),
-            };
-            let b = match std::fs::read(&file2) {
-                Ok(v) => v,
-                Err(_) => return ptr::null_mut(),
-            };
-            let mf1 = mmfile_t { ptr: a.as_ptr() as *const c_char, size: a.len() as c_long };
-            let mf2 = mmfile_t { ptr: b.as_ptr() as *const c_char, size: b.len() as c_long };
-            let mut output = String::new();
-            let mut ecb = xdemitcb_t { priv_: &mut output as *mut _ as *mut c_void, out_hunk: None, out_line: Some(collect) };
-            let res = unsafe { xdl_diff(&mf1, &mf2, ptr::null(), ptr::null(), &mut ecb) };
-            if res != 0 {
-                return ptr::null_mut();
-            }
-            CString::new(output).unwrap().into_raw()
-        }
+    let file1 = unsafe { CStr::from_ptr(f1) };
+    let file2 = unsafe { CStr::from_ptr(f2) };
+    match rs_diff_files_impl(file1, file2, mode) {
+        Ok(ptr) => ptr,
+        Err(_) => ptr::null_mut(),
     }
 }
 
 #[no_mangle]
 pub extern "C" fn rs_diff_free(ptr: *mut c_char) {
     if !ptr.is_null() {
-        unsafe { drop(CString::from_raw(ptr)); }
+        unsafe {
+            drop(CString::from_raw(ptr));
+        }
     }
 }
 
@@ -78,9 +125,9 @@ pub extern "C" fn rs_diff_update_screen() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::write;
-    use std::ffi::{CStr, CString};
     use std::env::temp_dir;
+    use std::ffi::{CStr, CString};
+    use std::fs::write;
 
     #[test]
     fn external_diff() {


### PR DESCRIPTION
## Summary
- Return `Result` from the diff routine with a custom `DiffError` instead of panicking
- Deduplicate file reads with a new `read_file` helper
- Expose an FFI wrapper that maps Rust errors to null pointers for C callers

## Testing
- `cargo fmt -p rust_diff`
- `cargo test -p rust_diff`


------
https://chatgpt.com/codex/tasks/task_e_68b81ae939948320bb7912e704f8666b