### PR TITLE
Add Rust crates for charset and platform-specific utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_charset"
+version = "0.1.0"
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
@@ -1313,6 +1317,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_gui_gtk_x11"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_motif"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
 name = "rust_gui_w32"
 version = "0.1.0"
 dependencies = [
@@ -1358,6 +1376,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_iscygpty"
+version = "0.1.0"
+
+[[package]]
 name = "rust_job"
 version = "0.1.0"
 dependencies = [
@@ -1373,6 +1395,10 @@ version = "0.1.0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "rust_locale"
+version = "0.1.0"
 
 [[package]]
 name = "rust_log"
@@ -1444,6 +1470,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_os_mac_conv"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_os_mswin"
+version = "0.1.0"
+
+[[package]]
 name = "rust_os_qnx"
 version = "0.1.0"
 dependencies = [
@@ -1452,6 +1489,14 @@ dependencies = [
 
 [[package]]
 name = "rust_os_unix"
+version = "0.1.0"
+
+[[package]]
+name = "rust_os_w32dll"
+version = "0.1.0"
+
+[[package]]
+name = "rust_os_w32exe"
 version = "0.1.0"
 
 [[package]]

--- a/rust_charset/Cargo.toml
+++ b/rust_charset/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_charset"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_charset"
+crate-type = ["staticlib", "rlib"]

--- a/rust_charset/src/lib.rs
+++ b/rust_charset/src/lib.rs
@@ -1,0 +1,26 @@
+use std::os::raw::c_uint;
+
+/// Convert the lower 4 bits of a number to its hexadecimal character.
+/// Mimics the `nr2hex` helper from `charset.c`.
+#[no_mangle]
+pub extern "C" fn nr2hex(c: c_uint) -> u8 {
+    let n = (c & 0xF) as u8;
+    if n <= 9 {
+        b'0' + n
+    } else {
+        b'a' + (n - 10)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_numbers() {
+        assert_eq!(nr2hex(0), b'0');
+        assert_eq!(nr2hex(9), b'9');
+        assert_eq!(nr2hex(10), b'a');
+        assert_eq!(nr2hex(15), b'f');
+    }
+}

--- a/rust_iscygpty/Cargo.toml
+++ b/rust_iscygpty/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_iscygpty"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_iscygpty"
+crate-type = ["staticlib", "rlib"]

--- a/rust_iscygpty/src/lib.rs
+++ b/rust_iscygpty/src/lib.rs
@@ -1,0 +1,24 @@
+use std::os::raw::c_int;
+
+/// Stub implementation of the C `is_cygpty` check.
+#[no_mangle]
+pub extern "C" fn is_cygpty(_fd: c_int) -> c_int {
+    0
+}
+
+/// Check whether any standard descriptor is a Cygwin pty.
+#[no_mangle]
+pub extern "C" fn is_cygpty_used() -> c_int {
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_zero() {
+        assert_eq!(is_cygpty(0), 0);
+        assert_eq!(is_cygpty_used(), 0);
+    }
+}

--- a/rust_locale/Cargo.toml
+++ b/rust_locale/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_locale"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_locale"
+crate-type = ["staticlib", "rlib"]

--- a/rust_locale/src/lib.rs
+++ b/rust_locale/src/lib.rs
@@ -1,0 +1,33 @@
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+/// Check whether a language code starts with two ASCII alphabetic characters.
+/// Mirrors `is_valid_mess_lang` from `locale.c`.
+#[no_mangle]
+pub extern "C" fn is_valid_mess_lang(lang: *const c_char) -> bool {
+    if lang.is_null() {
+        return false;
+    }
+    let bytes = unsafe { CStr::from_ptr(lang).to_bytes() };
+    if bytes.len() < 2 {
+        return false;
+    }
+    bytes[0].is_ascii_alphabetic() && bytes[1].is_ascii_alphabetic()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn detects_language() {
+        let en = CString::new("en").unwrap();
+        assert!(is_valid_mess_lang(en.as_ptr()));
+
+        let c = CString::new("C").unwrap();
+        assert!(!is_valid_mess_lang(c.as_ptr()));
+
+        assert!(!is_valid_mess_lang(std::ptr::null()));
+    }
+}

--- a/rust_os_mac_conv/Cargo.toml
+++ b/rust_os_mac_conv/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_os_mac_conv"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_os_mac_conv"
+crate-type = ["staticlib", "rlib"]

--- a/rust_os_mac_conv/src/lib.rs
+++ b/rust_os_mac_conv/src/lib.rs
@@ -1,0 +1,54 @@
+#![cfg(target_os = "macos")]
+
+use std::ffi::CStr;
+use std::os::raw::{c_int, c_char};
+use std::ptr;
+
+/// Simplified string conversion used on macOS.
+/// Copies the input bytes and appends a NUL terminator.
+#[no_mangle]
+pub extern "C" fn mac_string_convert(
+    ptr_in: *const c_char,
+    len: c_int,
+    lenp: *mut c_int,
+    _fail_on_error: c_int,
+    _from_enc: c_int,
+    _to_enc: c_int,
+    _unconvlenp: *mut c_int,
+) -> *mut c_char {
+    if ptr_in.is_null() || len < 0 {
+        return ptr::null_mut();
+    }
+    unsafe {
+        if !lenp.is_null() {
+            *lenp = len;
+        }
+        let slice = std::slice::from_raw_parts(ptr_in as *const u8, len as usize);
+        let mut vec = slice.to_vec();
+        vec.push(0);
+        let boxed = vec.into_boxed_slice();
+        Box::into_raw(boxed) as *mut c_char
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::ptr;
+
+    #[test]
+    fn copies_string() {
+        let src = CString::new("abc").unwrap();
+        let mut out_len = 0;
+        let out = unsafe {
+            mac_string_convert(src.as_ptr(), 3, &mut out_len, 0, 0, 0, ptr::null_mut())
+        };
+        assert_eq!(out_len, 3);
+        unsafe {
+            let s = CStr::from_ptr(out).to_str().unwrap();
+            assert_eq!(s, "abc");
+            libc::free(out as *mut _);
+        }
+    }
+}

--- a/rust_os_mswin/Cargo.toml
+++ b/rust_os_mswin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_os_mswin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_os_mswin"
+crate-type = ["staticlib", "rlib"]

--- a/rust_os_mswin/src/lib.rs
+++ b/rust_os_mswin/src/lib.rs
@@ -1,0 +1,22 @@
+#![cfg(windows)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static G_HINST: AtomicUsize = AtomicUsize::new(0);
+
+/// Store the instance handle of the executable or DLL.
+#[no_mangle]
+pub extern "C" fn SaveInst(h_inst: usize) {
+    G_HINST.store(h_inst, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saves_instance() {
+        SaveInst(1234);
+        assert_eq!(G_HINST.load(Ordering::Relaxed), 1234);
+    }
+}

--- a/rust_os_w32dll/Cargo.toml
+++ b/rust_os_w32dll/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_os_w32dll"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_os_w32dll"
+crate-type = ["staticlib", "rlib"]

--- a/rust_os_w32dll/src/lib.rs
+++ b/rust_os_w32dll/src/lib.rs
@@ -1,0 +1,36 @@
+#![cfg(windows)]
+
+use std::os::raw::c_void;
+
+extern "C" {
+    fn SaveInst(h_inst: usize);
+}
+
+/// Minimal `DllMain` that stores the instance handle on process attach.
+#[no_mangle]
+pub unsafe extern "system" fn DllMain(
+    hinst_dll: usize,
+    fdw_reason: u32,
+    _lpv_reserved: *mut c_void,
+) -> i32 {
+    const DLL_PROCESS_ATTACH: u32 = 1;
+    if fdw_reason == DLL_PROCESS_ATTACH {
+        SaveInst(hinst_dll);
+    }
+    1 // TRUE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[no_mangle]
+    extern "C" fn SaveInst(_h: usize) {}
+
+
+    #[test]
+    fn calls_dllmain() {
+        unsafe {
+            assert_eq!(DllMain(0, 1, std::ptr::null_mut()), 1);
+        }
+    }
+}

--- a/rust_os_w32exe/Cargo.toml
+++ b/rust_os_w32exe/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_os_w32exe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_os_w32exe"
+crate-type = ["staticlib", "rlib"]

--- a/rust_os_w32exe/src/lib.rs
+++ b/rust_os_w32exe/src/lib.rs
@@ -1,0 +1,50 @@
+#![cfg(windows)]
+
+use std::os::raw::{c_char, c_int};
+
+extern "C" {
+    fn VimMain(argc: c_int, argv: *mut *mut c_char) -> c_int;
+    fn SaveInst(h_inst: usize);
+}
+
+/// Entry point used by the GUI subsystem on Windows.
+#[no_mangle]
+pub extern "system" fn wWinMain(
+    h_instance: usize,
+    _h_prev: usize,
+    _cmd_line: *mut u16,
+    _cmd_show: c_int,
+) -> c_int {
+    unsafe {
+        SaveInst(h_instance);
+        VimMain(0, std::ptr::null_mut())
+    }
+}
+
+/// Console entry point for Windows.
+#[no_mangle]
+pub extern "C" fn wmain(
+    _argc: c_int,
+    _argv: *mut *mut u16,
+) -> c_int {
+    unsafe {
+        SaveInst(0);
+        VimMain(0, std::ptr::null_mut())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[no_mangle]
+    extern "C" fn VimMain(_argc: c_int, _argv: *mut *mut c_char) -> c_int { 0 }
+    #[no_mangle]
+    extern "C" fn SaveInst(_h: usize) {}
+
+    #[test]
+    fn exercise_entry_points() {
+        assert_eq!(wmain(0, std::ptr::null_mut()), 0);
+        assert_eq!(wWinMain(1, 0, std::ptr::null_mut(), 0), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add `rust_charset` implementing the `nr2hex` helper
- create `rust_locale` for validating message language codes
- stub out OS-specific crates for Windows and macOS functionality

## Testing
- `cargo test -p rust_charset`
- `cargo test -p rust_locale`
- `cargo test -p rust_iscygpty`
- `cargo check -p rust_os_mac_conv --target x86_64-apple-darwin`
- `cargo check -p rust_os_mswin --target x86_64-pc-windows-gnu`
- `cargo check -p rust_os_w32dll --target x86_64-pc-windows-gnu`
- `cargo check -p rust_os_w32exe --target x86_64-pc-windows-gnu`


------
https://chatgpt.com/codex/tasks/task_e_68b81abbe3d88320a9abe3f55499c790