### PR TITLE
Use AsyncFd for pty echo loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_gui_gtk_x11"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_motif"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
 name = "rust_gui_w32"
 version = "0.1.0"
 dependencies = [

--- a/rust_pty/Cargo.toml
+++ b/rust_pty/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nix = { version = "0.27", features = ["term"] }
+nix = { version = "0.27", features = ["term", "fs"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "io-util"] }

--- a/rust_pty/src/lib.rs
+++ b/rust_pty/src/lib.rs
@@ -1,20 +1,82 @@
+use nix::errno::Errno;
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::{openpty, OpenptyResult};
-use std::io;
-use tokio::task;
 use nix::unistd::{read, write};
+use std::io;
+use std::os::unix::io::{AsRawFd, OwnedFd};
+use tokio::io::unix::AsyncFd;
 
 /// Open a new pseudo terminal using `nix`.
 pub fn open() -> io::Result<OpenptyResult> {
     openpty(None, None).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
 }
 
-/// Echo data back on the file descriptor using blocking reads wrapped in `tokio`.
-pub async fn echo_loop(fd: i32) -> io::Result<()> {
+/// Echo data back on the file descriptor using non-blocking I/O with `AsyncFd`.
+pub async fn echo_loop(fd: OwnedFd) -> io::Result<()> {
+    fn nix_to_io(err: nix::Error) -> io::Error {
+        io::Error::new(io::ErrorKind::Other, err)
+    }
+
+    let flags =
+        OFlag::from_bits_truncate(fcntl(fd.as_raw_fd(), FcntlArg::F_GETFL).map_err(nix_to_io)?);
+    let mut new_flags = flags;
+    new_flags.insert(OFlag::O_NONBLOCK);
+    fcntl(fd.as_raw_fd(), FcntlArg::F_SETFL(new_flags)).map_err(nix_to_io)?;
+
+    let async_fd = AsyncFd::new(fd)?;
     let mut buf = [0u8; 1024];
     loop {
-        let n = task::spawn_blocking(move || read(fd, &mut buf)).await.unwrap()?;
-        if n == 0 { break; }
-        task::spawn_blocking(move || write(fd, &buf[..n])).await.unwrap()?;
+        let mut read_guard = async_fd.readable().await?;
+        match read(async_fd.as_raw_fd(), &mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                read_guard.clear_ready();
+                let mut written = 0;
+                while written < n {
+                    let mut write_guard = async_fd.writable().await?;
+                    match write(async_fd.as_raw_fd(), &buf[written..n]) {
+                        Ok(m) => {
+                            written += m;
+                            write_guard.clear_ready();
+                        }
+                        Err(e) if e == Errno::EWOULDBLOCK => {
+                            write_guard.clear_ready();
+                            continue;
+                        }
+                        Err(e) => return Err(nix_to_io(e)),
+                    }
+                }
+            }
+            Err(e) if e == Errno::EWOULDBLOCK => {
+                read_guard.clear_ready();
+                continue;
+            }
+            Err(e) => return Err(nix_to_io(e)),
+        }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::pty::OpenptyResult;
+    use nix::unistd::{read, write};
+    use std::os::unix::io::AsRawFd;
+    use tokio::task;
+
+    #[tokio::test]
+    async fn echo_loop_echoes_input() {
+        let OpenptyResult { master, slave } = open().unwrap();
+        let handle = task::spawn(async move { echo_loop(slave).await.unwrap() });
+
+        let msg = b"ping";
+        write(master.as_raw_fd(), msg).unwrap();
+        let mut buf = [0u8; 4];
+        let n = read(master.as_raw_fd(), &mut buf).unwrap();
+        assert_eq!(&buf[..n], msg);
+
+        drop(master);
+        handle.await.unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- switch pty echo loop to non-blocking AsyncFd
- enable nix `fs` feature and reuse buffer without moves
- add read/write test for the echo loop

## Testing
- `cargo test -p rust_pty`


------
https://chatgpt.com/codex/tasks/task_e_68b81aed5b188320bcd62bfe979c1686