### PR TITLE
Use similar crate for external diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ name = "rust_diff"
 version = "0.1.0"
 dependencies = [
  "diff",
+ "similar",
 ]
 
 [[package]]
@@ -1307,6 +1308,20 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_gui_gtk"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_gtk_x11"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_motif"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",

--- a/rust_diff/Cargo.toml
+++ b/rust_diff/Cargo.toml
@@ -8,4 +8,5 @@ crate-type = ["staticlib"]
 
 [dependencies]
 diff = { path = "../rust/diff" }
+similar = "2.7"
 


### PR DESCRIPTION
## Summary
- add `similar` crate for diff generation
- generate unified diffs in Rust instead of shelling out to `diff`
- verify diff headers and content in tests

## Testing
- `cargo test -p rust_diff`


------
https://chatgpt.com/codex/tasks/task_e_68b81b15754883209e6e7b0836d79bb5