### PR TITLE
Use similar for diff implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,9 @@ dependencies = [
 [[package]]
 name = "diff"
 version = "0.1.0"
+dependencies = [
+ "similar",
+]
 
 [[package]]
 name = "digest"
@@ -1307,6 +1310,20 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_gui_gtk"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_gtk_x11"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_motif"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",

--- a/rust/diff/Cargo.toml
+++ b/rust/diff/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+similar = "2"
 [lib]
 name = "diff"
 path = "src/lib.rs"


### PR DESCRIPTION
## Summary
- replace custom diff algorithm with `similar::TextDiff`
- stream `TextDiff` results to existing FFI callbacks
- add `similar` crate dependency

## Testing
- `cargo test -p diff`


------
https://chatgpt.com/codex/tasks/task_e_68b81b1d2fa8832088a26d3c0ef67ae8