### PR TITLE
Use fs_err for file operations in rust_fileio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1289,7 @@ version = "0.1.0"
 name = "rust_fileio"
 version = "0.1.0"
 dependencies = [
+ "fs-err",
  "rust_path",
  "tempfile",
 ]
@@ -1307,6 +1317,20 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_gui_gtk"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_gtk_x11"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_motif"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",

--- a/rust_fileio/Cargo.toml
+++ b/rust_fileio/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 rust_path = { path = "../rust_path" }
+fs-err = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust_fileio/src/lib.rs
+++ b/rust_fileio/src/lib.rs
@@ -29,19 +29,19 @@ pub extern "C" fn rs_readfile(
         Ok(s) => s,
         Err(_) => return -1,
     };
-    let norm = match normalize_path(path_str) {
-        Some(p) => p,
-        None => return -1,
-    };
+    let norm = normalize_path(path_str).unwrap_or_else(|| path_str.to_string());
 
     match fs::metadata(&norm) {
         Ok(meta) if meta.len() as usize <= MAX_IO_SIZE => (),
         _ => return -1,
     }
 
-    match fs::read(&norm) {
+    match fs_err::read(&norm) {
         Ok(_) => 0,
-        Err(_) => -1,
+        Err(err) => {
+            eprintln!("read error: {err}");
+            -1
+        }
     }
 }
 
@@ -61,17 +61,17 @@ pub extern "C" fn rs_writefile(
         Ok(s) => s,
         Err(_) => return -1,
     };
-    let norm = match normalize_path(path_str) {
-        Some(p) => p,
-        None => return -1,
-    };
+    let norm = normalize_path(path_str).unwrap_or_else(|| path_str.to_string());
     if len > MAX_IO_SIZE {
         return -1;
     }
     let slice = unsafe { std::slice::from_raw_parts(data as *const u8, len) };
-    match fs::write(&norm, slice) {
+    match fs_err::write(&norm, slice) {
         Ok(_) => 0,
-        Err(_) => -1,
+        Err(err) => {
+            eprintln!("write error: {err}");
+            -1
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `fs-err` crate for richer error context
- switch `rs_readfile` and `rs_writefile` to `fs_err` operations and log failures
- fall back to the original path when normalization fails

## Testing
- `cargo test -p rust_fileio`


------
https://chatgpt.com/codex/tasks/task_e_68b81b232a40832097c0df8277d03883