### PR TITLE
Use pbkdf2 for blowfish key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -541,6 +542,21 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -870,6 +886,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,8 +1165,11 @@ name = "rust_blowfish"
 version = "0.1.0"
 dependencies = [
  "blowfish",
+ "hex",
+ "hmac",
  "libc",
- "rust_sha256",
+ "pbkdf2",
+ "sha2",
 ]
 
 [[package]]
@@ -1307,6 +1336,20 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_gui_gtk"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_gtk_x11"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_motif"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",
@@ -1844,6 +1887,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/rust_blowfish/Cargo.toml
+++ b/rust_blowfish/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 [dependencies]
 libc = "0.2"
 blowfish = "0.8"
-rust_sha256 = { path = "../rust_sha256" }
+pbkdf2 = "0.12"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 [lib]
 name = "rust_blowfish"


### PR DESCRIPTION
## Summary
- derive Blowfish key using `pbkdf2` and switch to `hex` for encoding/decoding
- add pbkdf2, hmac, sha2 and hex crate dependencies

## Testing
- `cargo test -p rust_blowfish`


------
https://chatgpt.com/codex/tasks/task_e_68b81b12ccc08320b15d2ae4da1d1ac7