### PR TITLE
Enable rust regex engine by default and add benchmarks

### DIFF
--- a/rust_regex_engine/Cargo.toml
+++ b/rust_regex_engine/Cargo.toml
@@ -9,3 +9,10 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 regex = "1"
+
+[dev-dependencies]
+criterion = "0.4"
+
+[[bench]]
+name = "engine"
+harness = false

--- a/rust_regex_engine/benches/engine.rs
+++ b/rust_regex_engine/benches/engine.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::ffi::CString;
+use rust_regex_engine::{vim_regcomp, vim_regexec, vim_regfree, RegMatch};
+
+fn bench_regexec(c: &mut Criterion) {
+    let pat = CString::new("foo.*bar").unwrap();
+    let text = CString::new("foo something bar").unwrap();
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(!prog.is_null());
+    c.bench_function("vim_regexec", |b| {
+        b.iter(|| {
+            let mut rm = RegMatch {
+                regprog: prog,
+                startp: [std::ptr::null(); 10],
+                endp: [std::ptr::null(); 10],
+                rm_matchcol: 0,
+                rm_ic: 0,
+            };
+            assert_eq!(vim_regexec(&mut rm, text.as_ptr(), 0), 1);
+        })
+    });
+    vim_regfree(prog);
+}
+
+criterion_group!(benches, bench_regexec);
+criterion_main!(benches);

--- a/rust_regex_engine/include/rust_regex_engine.h
+++ b/rust_regex_engine/include/rust_regex_engine.h
@@ -8,17 +8,38 @@ extern "C" {
 #endif
 
 typedef struct RegProg RegProg;
-struct regmatch_T;
-struct regmmatch_T;
-struct win_T;
-struct buf_T;
+
+// Lightweight copies of the structures used by Vim's C code.  Keeping the
+// definitions here makes the FFI interface self-contained and allows external
+// consumers to allocate and read these structs without including Vim headers.
+typedef struct {
+    long lnum;
+    int col;
+} Lpos;
+
+typedef struct {
+    RegProg *regprog;
+    const char *startp[10];
+    const char *endp[10];
+    int rm_matchcol;
+    int rm_ic;
+} RegMatch;
+
+typedef struct {
+    RegProg *regprog;
+    Lpos startpos[10];
+    Lpos endpos[10];
+    int rmm_matchcol;
+    int rmm_ic;
+    int rmm_maxcol;
+} RegMMMatch;
 
 RegProg* vim_regcomp(const char *pattern, int flags);
 void vim_regfree(RegProg *prog);
-int vim_regexec(struct regmatch_T *rmp, const char *line, int col);
-int vim_regexec_nl(struct regmatch_T *rmp, const char *line, int col);
-long vim_regexec_multi(struct regmmatch_T *rmp, struct win_T *win,
-                       struct buf_T *buf, long lnum, int col,
+int vim_regexec(RegMatch *rmp, const char *line, int col);
+int vim_regexec_nl(RegMatch *rmp, const char *line, int col);
+long vim_regexec_multi(RegMMMatch *rmp, void *win,
+                       void *buf, long lnum, int col,
                        int *timed_out);
 char* vim_regsub(RegProg *prog, const char *text, const char *sub);
 

--- a/rust_regex_engine/tests/compat.rs
+++ b/rust_regex_engine/tests/compat.rs
@@ -94,6 +94,33 @@ fn regexec_multi_single_line() {
 }
 
 #[test]
+fn regexec_multi_no_match() {
+    let pat = CString::new("qux").unwrap();
+    let line = CString::new("foo").unwrap();
+    let lines = [line.as_ptr()];
+    let prog = vim_regcomp(pat.as_ptr(), 0);
+    assert!(!prog.is_null());
+    let mut rmm = RegMMMatch {
+        regprog: prog,
+        startpos: [Lpos { lnum: 0, col: 0 }; 10],
+        endpos: [Lpos { lnum: 0, col: 0 }; 10],
+        rmm_matchcol: 0,
+        rmm_ic: 0,
+        rmm_maxcol: 0,
+    };
+    let matched = vim_regexec_multi(
+        &mut rmm,
+        std::ptr::null_mut(),
+        lines.as_ptr() as *mut c_void,
+        1,
+        0,
+        std::ptr::null_mut(),
+    );
+    assert_eq!(matched, 0);
+    vim_regfree(prog);
+}
+
+#[test]
 fn invalid_pattern_returns_null() {
     let pat = CString::new("[a-").unwrap();
     let prog = vim_regcomp(pat.as_ptr(), 0);

--- a/src/regexp.h
+++ b/src/regexp.h
@@ -13,6 +13,13 @@
 #ifndef _REGEXP_H
 #define _REGEXP_H
 
+// Default to using the Rust-based regular expression engine unless the caller
+// explicitly disables it.  This mirrors the previous build-system default but
+// makes the preference visible in the headers as well.
+#ifndef USE_RUST_REGEX
+# define USE_RUST_REGEX
+#endif
+
 /*
  * The number of sub-matches is limited to 10.
  * The first one (index 0) is the whole match, referenced with "\0".


### PR DESCRIPTION
## Summary
- default to the Rust-based regex engine in regexp.h
- expose full FFI types for the regex engine
- add criterion benchmark and extra regression test for `vim_regexec_multi`

## Testing
- `cargo test`
- `cargo bench --bench engine`


------
https://chatgpt.com/codex/tasks/task_e_68b8261303208320ae8d00c1cc788c63