### PR TITLE
Move showcmd truncation to Rust

### DIFF
--- a/rust_normal/src/lib.rs
+++ b/rust_normal/src/lib.rs
@@ -1,4 +1,5 @@
-use std::os::raw::c_int;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
 
 #[repr(C)]
 pub struct oparg_T {
@@ -21,12 +22,77 @@ pub extern "C" fn rs_normal_cmd(oap: *mut oparg_T, toplevel: c_int) {
     }
 }
 
+const SHOWCMD_BUFLEN: usize = 41;
+
+#[cfg(not(test))]
+extern "C" {
+    static mut p_sc: c_int;
+    static mut showcmd_buf: [c_char; SHOWCMD_BUFLEN];
+    fn char_avail() -> c_int;
+    fn display_showcmd();
+}
+
+#[cfg(test)]
+#[no_mangle]
+static mut p_sc: c_int = 0;
+#[cfg(test)]
+#[no_mangle]
+static mut showcmd_buf: [c_char; SHOWCMD_BUFLEN] = [0; SHOWCMD_BUFLEN];
+#[cfg(test)]
+#[no_mangle]
+extern "C" fn char_avail() -> c_int { 0 }
+#[cfg(test)]
+#[no_mangle]
+extern "C" fn display_showcmd() {}
+
+#[no_mangle]
+pub extern "C" fn rs_del_from_showcmd(len: c_int) {
+    unsafe {
+        if p_sc == 0 {
+            return;
+        }
+
+        let mut len = len;
+        let old_len =
+            CStr::from_ptr(showcmd_buf.as_ptr()).to_bytes().len() as c_int;
+        if len > old_len {
+            len = old_len;
+        }
+        *showcmd_buf
+            .as_mut_ptr()
+            .add((old_len - len) as usize) = 0;
+
+        if char_avail() == 0 {
+            display_showcmd();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ptr;
 
     #[test]
     fn smoke_test() {
         unsafe { rs_normal_cmd(std::ptr::null_mut(), 0) };
+    }
+
+    #[test]
+    fn del_from_showcmd_basic() {
+        unsafe {
+            p_sc = 1;
+            let initial = b"abcd\0";
+            ptr::copy_nonoverlapping(
+                initial.as_ptr() as *const c_char,
+                showcmd_buf.as_mut_ptr(),
+                initial.len(),
+            );
+            rs_del_from_showcmd(2);
+            let res = CStr::from_ptr(showcmd_buf.as_ptr())
+                .to_str()
+                .unwrap();
+            assert_eq!(res, "ab");
+        }
     }
 }

--- a/src/normal.c
+++ b/src/normal.c
@@ -34,7 +34,7 @@ static int	VIsual_mode_orig = NUL;		// saved Visual mode
 static void	set_vcount_ca(cmdarg_T *cap, int *set_prevcount);
 #endif
 static void	unshift_special(cmdarg_T *cap);
-static void	del_from_showcmd(int);
+// static void	del_from_showcmd(int);
 
 /*
  * nv_*(): functions called to handle Normal and Visual mode commands.
@@ -253,7 +253,7 @@ getcount:
 	    if (c == K_DEL || c == K_KDEL)
 	    {
 		cap->count0 /= 10;
-		del_from_showcmd(4);	// delete the digit and ~@%
+		rs_del_from_showcmd(4);	// delete the digit and ~@%
 	    }
 	    else if (cap->count0 > 99999999L)
 	    {
@@ -507,7 +507,7 @@ normal_cmd_get_more_chars(
 		{
 		    *cp = c;
 		    // Guessing how to update showcmd here...
-		    del_from_showcmd(3);
+		    rs_del_from_showcmd(3);
 		    *need_flushbuf |= add_to_showcmd(*cp);
 		}
 	    }
@@ -1790,26 +1790,6 @@ add_to_showcmd_c(int c)
 {
     if (!add_to_showcmd(c))
 	setcursor();
-}
-
-/*
- * Delete 'len' characters from the end of the shown command.
- */
-    static void
-del_from_showcmd(int len)
-{
-    int	    old_len;
-
-    if (!p_sc)
-	return;
-
-    old_len = (int)STRLEN(showcmd_buf);
-    if (len > old_len)
-	len = old_len;
-    showcmd_buf[old_len - len] = NUL;
-
-    if (!char_avail())
-	display_showcmd();
 }
 
 /*

--- a/src/normal_rs.h
+++ b/src/normal_rs.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 void rs_normal_cmd(oparg_T *oap, int toplevel);
+void rs_del_from_showcmd(int len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- expose `rs_del_from_showcmd` in FFI and call it from normal mode command handling
- implement `rs_del_from_showcmd` in Rust with unit test

## Testing
- `cargo test -p rust_normal`


------
https://chatgpt.com/codex/tasks/task_e_68b8260f1a2c8320b6b63c6be1e61515