### PR TITLE
Use Rust evaluator for Vim variables

### DIFF
--- a/rust_eval/tests/variables.rs
+++ b/rust_eval/tests/variables.rs
@@ -1,0 +1,13 @@
+use std::ffi::CString;
+
+use rust_eval::{eval_variable_rs, set_variable_rs, typval_T, Vartype, ValUnion};
+
+#[test]
+fn variable_roundtrip() {
+    let name = CString::new("x").unwrap();
+    let val = typval_T { v_type: Vartype::VAR_NUMBER, v_lock: 0, vval: ValUnion { v_number: 7 } };
+    assert!(set_variable_rs(name.as_ptr(), &val));
+    let mut out = typval_T { v_type: Vartype::VAR_UNKNOWN, v_lock: 0, vval: ValUnion { v_number: 0 } };
+    assert!(eval_variable_rs(name.as_ptr(), &mut out));
+    unsafe { assert_eq!(out.vval.v_number, 7); }
+}


### PR DESCRIPTION
## Summary
- forward `set_vim_var_nr`/`get_vim_var_nr` and string helpers to Rust via `set_variable_rs`/`eval_variable_rs`
- exercise variable FFI in a new integration test

## Testing
- `cd rust_eval && cargo test`
- `cd rust_evalvars && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8260ddda0832083a91ca651cbf5b3