### PR TITLE
Port spell trie lookup and suggestions to Rust

### DIFF
--- a/rust_spell/include/rust_spell.h
+++ b/rust_spell/include/rust_spell.h
@@ -7,6 +7,7 @@
 
 int captype(const unsigned char *word, const unsigned char *end);
 bool rs_spell_load_dict(const char *path);
+bool rs_spell_check(const char *word);
 char **rs_spell_suggest(const char *word, size_t max, size_t *len);
 void rs_spell_free_suggestions(char **ptr, size_t len);
 

--- a/rust_spell/src/lib.rs
+++ b/rust_spell/src/lib.rs
@@ -37,6 +37,21 @@ pub extern "C" fn rs_spell_load_dict(path: *const c_char) -> bool {
 }
 
 #[no_mangle]
+pub extern "C" fn rs_spell_check(word: *const c_char) -> bool {
+    if word.is_null() {
+        return false;
+    }
+    let cstr = unsafe { CStr::from_ptr(word) };
+    let Ok(w) = cstr.to_str() else {
+        return false;
+    };
+    match trie() {
+        Ok(trie_guard) => trie_guard.contains(w),
+        Err(_) => false,
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn rs_spell_suggest(
     word: *const c_char,
     max: usize,

--- a/rust_spell/tests/ffi.rs
+++ b/rust_spell/tests/ffi.rs
@@ -1,0 +1,33 @@
+use rust_spell::{
+    rs_spell_check, rs_spell_free_suggestions, rs_spell_load_dict, rs_spell_suggest,
+};
+use std::ffi::{CStr, CString};
+
+#[test]
+fn load_check_and_suggest() {
+    let mut path = std::env::temp_dir();
+    path.push("dict_test.txt");
+    std::fs::write(&path, b"apple\napply\nbanana\n").unwrap();
+
+    let cpath = CString::new(path.to_str().unwrap()).unwrap();
+    assert!(rs_spell_load_dict(cpath.as_ptr()));
+
+    let word = CString::new("apple").unwrap();
+    assert!(rs_spell_check(word.as_ptr()));
+    let missing = CString::new("appl").unwrap();
+    assert!(!rs_spell_check(missing.as_ptr()));
+
+    let sugg_word = CString::new("appl").unwrap();
+    let mut len: usize = 0;
+    let ptr = rs_spell_suggest(sugg_word.as_ptr(), 5, &mut len as *mut usize);
+    assert!(!ptr.is_null());
+    assert!(len >= 2);
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    let mut res: Vec<String> = slice
+        .iter()
+        .map(|&p| unsafe { CStr::from_ptr(p).to_string_lossy().into_owned() })
+        .collect();
+    rs_spell_free_suggestions(ptr, len);
+    res.sort();
+    assert_eq!(res, vec!["apple", "apply"]);
+}

--- a/rust_spellfile/src/lib.rs
+++ b/rust_spellfile/src/lib.rs
@@ -26,6 +26,17 @@ impl Trie {
         node.is_word = true;
     }
 
+    pub fn contains(&self, word: &str) -> bool {
+        let mut node = &self.root;
+        for ch in word.chars() {
+            match node.children.get(&ch) {
+                Some(n) => node = n,
+                None => return false,
+            }
+        }
+        node.is_word
+    }
+
     fn collect(node: &Node, prefix: &mut String, out: &mut Vec<String>) {
         if node.is_word {
             out.push(prefix.clone());

--- a/rust_spellsuggest/src/lib.rs
+++ b/rust_spellsuggest/src/lib.rs
@@ -42,6 +42,17 @@ pub fn suggest(trie: &Trie, word: &str, max: usize) -> Vec<String> {
             q.push_back((node, prefix.clone(), idx + 1, edits + 1));
         }
 
+        if edits < 1 && idx + 1 < chars.len() {
+            if let Some(next_node) = node.children.get(&chars[idx + 1]) {
+                if let Some(after) = next_node.children.get(&chars[idx]) {
+                    let mut new_pref = prefix.clone();
+                    new_pref.push(chars[idx + 1]);
+                    new_pref.push(chars[idx]);
+                    q.push_back((after, new_pref, idx + 2, edits + 1));
+                }
+            }
+        }
+
         for (ch, child) in &node.children {
             let mut new_pref = prefix.clone();
             new_pref.push(*ch);

--- a/src/spell.c
+++ b/src/spell.c
@@ -70,7 +70,7 @@
 
 #if defined(FEAT_SPELL) || defined(PROTO)
 
-#include "rust_spell.h"
+#include "../rust_spell/include/rust_spell.h"
 #include <time.h>
 
 #define REGION_ALL 0xff		// word valid in all regions


### PR DESCRIPTION
## Summary
- expose spell FFI in rust_spell/include with new rs_spell_check
- add Trie::contains and transposition-aware suggestions in Rust
- verify dictionary loading and suggestions via C-style integration test

## Testing
- `cargo test -p rust_spellfile`
- `cargo test -p rust_spellsuggest`
- `cargo test -p rust_spell`


------
https://chatgpt.com/codex/tasks/task_e_68b826175d048320990ce63c0a0d950d