### PR TITLE
Implement Rust-backed syntax rule evaluation

### DIFF
--- a/rust_syntax/include/rust_syntax.h
+++ b/rust_syntax/include/rust_syntax.h
@@ -1,0 +1,20 @@
+#ifndef RUST_SYNTAX_H
+#define RUST_SYNTAX_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void rs_syntax_start(void *wp, long lnum);
+void rs_syn_update(int startofline);
+int rs_eval_line(const char *line);
+void rs_add_rule(int id, const char *pattern);
+void rs_clear_rules(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUST_SYNTAX_H

--- a/rust_syntax/src/lib.rs
+++ b/rust_syntax/src/lib.rs
@@ -1,5 +1,5 @@
-use std::ffi::c_void;
-use std::os::raw::c_short;
+use std::ffi::{c_void, CStr};
+use std::os::raw::{c_char, c_short};
 use std::sync::Mutex;
 
 /// State tracking for syntax highlighting.
@@ -10,6 +10,28 @@ use std::sync::Mutex;
 /// mirrors the relevant parts so that `syntax_start()` and `syn_update_ends()`
 /// can be implemented on the Rust side while exposing a C-compatible API.
 #[derive(Clone, Copy, Debug, Default)]
+pub struct Lpos {
+    pub lnum: i64,
+    pub col: i32,
+}
+
+#[derive(Clone, Debug)]
+pub struct SyntaxRule {
+    pub id: i32,
+    pub pattern: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct StateItem {
+    pub id: i32,
+    pub m_end: Lpos,
+    pub h_start: Lpos,
+    pub h_end: Lpos,
+    pub ends: bool,
+    pub flags: i64,
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct SyntaxState {
     /// Window pointer provided by the C caller; opaque to Rust.
     pub window: *mut c_void,
@@ -29,6 +51,10 @@ pub struct SyntaxState {
     pub next_list: *mut c_short,
     /// Flags for the next group list.
     pub next_flags: i32,
+    /// Registered matching rules.
+    pub rules: Vec<SyntaxRule>,
+    /// Active state items after rule evaluation.
+    pub stack: Vec<StateItem>,
 }
 
 // Raw pointers are opaque handles; sharing them across threads is safe as they
@@ -47,6 +73,8 @@ static SYNTAX_STATE: Mutex<SyntaxState> = Mutex::new(SyntaxState {
     finished: false,
     next_list: std::ptr::null_mut(),
     next_flags: 0,
+    rules: Vec::new(),
+    stack: Vec::new(),
 });
 
 /// Start syntax parsing for line `lnum` in window `wp`.
@@ -62,6 +90,7 @@ pub extern "C" fn rs_syntax_start(wp: *mut c_void, lnum: i64) {
     state.finished = false;
     state.next_list = std::ptr::null_mut();
     state.next_flags = 0;
+    state.stack.clear();
 }
 
 /// Update the parser position.  When `startofline` is non-zero the parser moves
@@ -82,9 +111,58 @@ pub extern "C" fn rs_syn_update(startofline: i32) {
     }
 }
 
+/// Register a simple match rule with ID `id` and textual `pattern`.
+#[no_mangle]
+pub extern "C" fn rs_add_rule(id: i32, pattern: *const c_char) {
+    let cstr = unsafe { CStr::from_ptr(pattern) };
+    if let Ok(pat) = cstr.to_str() {
+        let mut state = SYNTAX_STATE.lock().unwrap();
+        state.rules.push(SyntaxRule { id, pattern: pat.to_string() });
+    }
+}
+
+/// Clear all registered rules and active state items.
+#[no_mangle]
+pub extern "C" fn rs_clear_rules() {
+    let mut state = SYNTAX_STATE.lock().unwrap();
+    state.rules.clear();
+    state.stack.clear();
+}
+
+/// Evaluate registered rules against `line`.  Returns the ID of the first
+/// matching rule or 0 when no rule matches.
+#[no_mangle]
+pub extern "C" fn rs_eval_line(line: *const c_char) -> i32 {
+    let cstr = unsafe { CStr::from_ptr(line) };
+    let line = match cstr.to_str() {
+        Ok(l) => l,
+        Err(_) => return 0,
+    };
+    let mut state = SYNTAX_STATE.lock().unwrap();
+    let lnum = state.lnum;
+    let rules = state.rules.clone();
+    for rule in rules {
+        if let Some(pos) = line.find(&rule.pattern) {
+            let start = pos as i32;
+            let end = start + rule.pattern.len() as i32;
+            state.stack.push(StateItem {
+                id: rule.id,
+                m_end: Lpos { lnum, col: end },
+                h_start: Lpos { lnum, col: start },
+                h_end: Lpos { lnum, col: end },
+                ends: true,
+                flags: 0,
+            });
+            state.col = end;
+            return rule.id;
+        }
+    }
+    0
+}
+
 /// Helper used by unit tests to inspect the current state.
 fn get_state() -> SyntaxState {
-    *SYNTAX_STATE.lock().unwrap()
+    SYNTAX_STATE.lock().unwrap().clone()
 }
 
 #[cfg(test)]
@@ -93,6 +171,7 @@ mod tests {
 
     #[test]
     fn start_and_update_progression() {
+        rs_clear_rules();
         rs_syntax_start(std::ptr::null_mut(), 10);
         let s = get_state();
         assert_eq!(s.lnum, 10);
@@ -112,10 +191,37 @@ mod tests {
 
     #[test]
     fn finished_flag() {
+        rs_clear_rules();
         rs_syntax_start(std::ptr::null_mut(), 1);
         assert!(!get_state().finished);
         rs_syn_update(1);
         let s = get_state();
         assert!(s.finished);
+    }
+
+    #[test]
+    fn regression_major_syntax_rules() {
+        use std::ffi::CString;
+
+        rs_clear_rules();
+        let c_kw = CString::new("int").unwrap();
+        rs_add_rule(1, c_kw.as_ptr());
+        let rust_kw = CString::new("fn").unwrap();
+        rs_add_rule(2, rust_kw.as_ptr());
+        let py_kw = CString::new("def").unwrap();
+        rs_add_rule(3, py_kw.as_ptr());
+
+        rs_syntax_start(std::ptr::null_mut(), 1);
+
+        let c_line = CString::new("int main() { return 0; }").unwrap();
+        assert_eq!(rs_eval_line(c_line.as_ptr()), 1);
+        rs_syn_update(1);
+
+        let rust_line = CString::new("fn main() {}").unwrap();
+        assert_eq!(rs_eval_line(rust_line.as_ptr()), 2);
+        rs_syn_update(1);
+
+        let py_line = CString::new("def main(): pass").unwrap();
+        assert_eq!(rs_eval_line(py_line.as_ptr()), 3);
     }
 }

--- a/src/rust_syntax.h
+++ b/src/rust_syntax.h
@@ -1,9 +1,0 @@
-#ifndef RUST_SYNTAX_H
-#define RUST_SYNTAX_H
-
-#include <stdint.h>
-
-void rs_syntax_start(void *wp, long lnum);
-void rs_syn_update(int startofline);
-
-#endif // RUST_SYNTAX_H

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -12,6 +12,7 @@
  */
 
 #include "vim.h"
+#include "../rust_syntax/include/rust_syntax.h"
 
 #if defined(FEAT_SYN_HL) || defined(PROTO)
 
@@ -368,6 +369,7 @@ syntax_start(win_T *wp, linenr_T lnum)
 #ifdef FEAT_CONCEAL
     current_sub_char = NUL;
 #endif
+    rs_syntax_start((void *)wp, lnum);
 
     /*
      * After switching buffers, invalidate current_state.
@@ -929,6 +931,10 @@ syn_update_ends(int startofline)
     stateitem_T	*cur_si;
     int		i;
     int		seen_keepend;
+
+    rs_syn_update(startofline);
+    char_u *line = ml_get_buf(syn_buf, current_lnum, FALSE);
+    rs_eval_line((const char *)line);
 
     if (startofline)
     {


### PR DESCRIPTION
## Summary
- Add Rust data structures and FFI for syntax rule management and evaluation
- Expose new syntax API via header and wire C code to call into Rust
- Add regression tests covering basic C/Rust/Python syntax patterns

## Testing
- `cargo test -p rust_syntax`


------
https://chatgpt.com/codex/tasks/task_e_68b8261579008320a3906983540b94ae