### PR TITLE
Use tokio for async file I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,7 @@ version = "0.1.0"
 dependencies = [
  "rust_path",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1659,6 +1660,7 @@ version = "0.1.0"
 name = "rust_spellsuggest"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "rust_spellfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["net", "time", "macros", "io-util", "rt"] }
+tokio = { version = "1", features = ["net", "time", "macros", "io-util", "rt", "fs"] }
 rust_spell = { path = "rust_spell" }
 diff = { path = "rust/diff" }
 rust_buffer = { path = "rust_buffer" }

--- a/rust_fileio/Cargo.toml
+++ b/rust_fileio/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 rust_path = { path = "../rust_path" }
+tokio = { version = "1", features = ["fs", "macros", "rt"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add `fs` feature to shared tokio runtime
- implement file I/O with `tokio::fs` and block_on wrappers for FFI
- convert fileio tests to `#[tokio::test]`

## Testing
- `cargo test -p rust_fileio`


------
https://chatgpt.com/codex/tasks/task_e_68b826462e448320903201a23ab44e03