### PR TITLE
feat(tag): add Rust tag search and stack FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ version = "0.1.0"
 name = "rust_spellsuggest"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "rust_spellfile",
 ]
 
@@ -1671,6 +1672,7 @@ name = "rust_tag"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "once_cell",
  "tempfile",
 ]
 

--- a/rust_tag/Cargo.toml
+++ b/rust_tag/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
+once_cell = "1"
 
 [lib]
 name = "rust_tag"

--- a/rust_tag/include/rust_tag.h
+++ b/rust_tag/include/rust_tag.h
@@ -1,5 +1,7 @@
-#ifndef TAG_RS_H
-#define TAG_RS_H
+#ifndef RUST_TAG_H
+#define RUST_TAG_H
+
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -7,9 +9,12 @@ extern "C" {
 
 int rust_find_tags(const char *pat, int *num_matches, char ***matchesp,
                    int flags, int mincount, const char *buf_ffname);
+void rust_tagstack_push(const char *tag);
+char *rust_tagstack_pop(void);
+int rust_tagstack_len(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // TAG_RS_H
+#endif // RUST_TAG_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -1416,6 +1416,8 @@ RUST_AUTOCMD_DIR = ../rust_autocmd
 RUST_AUTOCMD_LIB = $(RUST_AUTOCMD_DIR)/target/release/librust_autocmd.a
 RUST_SEARCH_DIR = ../rust_search
 RUST_SEARCH_LIB = $(RUST_SEARCH_DIR)/target/release/librust_search.a
+RUST_TAG_DIR = ../rust_tag
+RUST_TAG_LIB = $(RUST_TAG_DIR)/target/release/librust_tag.a
 RUST_USERFUNC_DIR = ../rust_userfunc
 RUST_USERFUNC_LIB = $(RUST_USERFUNC_DIR)/target/release/librust_userfunc.a
 RUST_ALLOC_DIR = ../rust_alloc
@@ -1451,6 +1453,7 @@ RUST_CMDHIST_LIB = $(RUST_CMDHIST_DIR)/target/release/librust_cmdhist.a
 EXTRA_IPATHS += -I$(RUST_ARABIC_DIR)/include
 EXTRA_IPATHS += -I$(RUST_BEVAL_DIR)/include
 EXTRA_IPATHS += -I$(RUST_VIM9_DIR)/include
+EXTRA_IPATHS += -I$(RUST_TAG_DIR)/include
 
 # Note: MZSCHEME_LIBS must come before LIBS, because LIBS adds -lm which is
 # needed by racket.
@@ -1483,8 +1486,9 @@ ALL_LIBS = \
            $(RUST_MBYTE_LIB) \
            $(RUST_AUTOCMD_LIB) \
            $(RUST_SEARCH_LIB) \
+           $(RUST_TAG_LIB) \
            $(RUST_USERFUNC_LIB) \
-           $(RUST_ALLOC_LIB) \
+            $(RUST_ALLOC_LIB) \
            $(RUST_WINDOW_LIB) \
            $(RUST_UNDO_LIB) \
            $(RUST_DRAWSCREEN_LIB) \
@@ -1601,10 +1605,13 @@ $(RUST_AUTOCMD_LIB):
 	cd $(RUST_AUTOCMD_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_SEARCH_LIB):
-	cd $(RUST_SEARCH_DIR) && CARGO_TARGET_DIR=target cargo build --release
+       cd $(RUST_SEARCH_DIR) && CARGO_TARGET_DIR=target cargo build --release
+
+$(RUST_TAG_LIB):
+       cd $(RUST_TAG_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_USERFUNC_LIB):
-	cd $(RUST_USERFUNC_DIR) && CARGO_TARGET_DIR=target cargo build --release
+       cd $(RUST_USERFUNC_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_ALLOC_LIB):
 	cd $(RUST_ALLOC_DIR) && CARGO_TARGET_DIR=target cargo build --release
@@ -2307,7 +2314,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_BUFWRITE_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVAL_LIB) $(RUST_VIM9_LIB) $(RUST_EXCMD_LIB) $(RUST_CMDHIST_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB) $(RUST_BLOWFISH_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_BUFWRITE_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVAL_LIB) $(RUST_VIM9_LIB) $(RUST_EXCMD_LIB) $(RUST_CMDHIST_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_TAG_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB) $(RUST_BLOWFISH_LIB)
 	@$(BUILD_DATE_MSG)
     @LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) objects/*.o $(ALL_LIBS)" \

--- a/src/feature.h
+++ b/src/feature.h
@@ -85,6 +85,9 @@
 // Enable the Rust implementation of quickfix by default.
 #define USE_RUST_QUICKFIX
 
+// Use the Rust implementation for tag searching and tag stack handling.
+#define USE_RUST_TAG
+
 // Syntax highlighting helpers are always provided by the Rust implementation.
 
 // Minimal build: disable terminal feature to avoid pulling terminal/job deps

--- a/src/tag.c
+++ b/src/tag.c
@@ -13,6 +13,10 @@
 
 #include "vim.h"
 
+#ifdef USE_RUST_TAG
+# include "rust_tag.h"
+#endif
+
 /*
  * Structure to hold pointers to various items in a tag line.
  */
@@ -3054,6 +3058,20 @@ findtags_copy_matches(findtags_state_T *st, char_u ***matchesp)
  * TAG_CSCOPE	  use cscope results for tags
  * TAG_NO_TAGFUNC do not call the 'tagfunc' function
  */
+#ifdef USE_RUST_TAG
+int find_tags(
+    char_u      *pat,
+    int         *num_matches,
+    char_u      ***matchesp,
+    int         flags,
+    int         mincount,
+    char_u      *buf_ffname)
+{
+    return rust_find_tags((const char *)pat, num_matches,
+                          (char ***)matchesp, flags, mincount,
+                          (const char *)buf_ffname);
+}
+#else
     int
 find_tags(
     char_u	*pat,			// pattern to search for
@@ -3258,6 +3276,7 @@ findtag_end:
     return retval;
 }
 
+#endif // USE_RUST_TAG
 static garray_T tag_fnames = GA_EMPTY;
 
 /*


### PR DESCRIPTION
## Summary
- implement tag stack push/pop logic in Rust
- expose rust_find_tags and tag stack functions via new header
- switch C tag search to Rust implementation and hook up build system

## Testing
- `cargo test -p rust_tag`


------
https://chatgpt.com/codex/tasks/task_e_68b82617f0f88320a18befa798919cb8