### PR TITLE
Add GTK/XIM FFI crates and Windows API wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,32 @@ dependencies = [
 
 [[package]]
 name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.25",
+ "criterion-plot",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
@@ -1397,6 +1423,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_gui_gtk_f"
+version = "0.1.0"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "rust_gui_gtk_x11"
 version = "0.1.0"
 dependencies = [
@@ -1415,6 +1448,7 @@ name = "rust_gui_w32"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -1423,6 +1457,13 @@ version = "0.1.0"
 dependencies = [
  "rust_gui_core",
  "x11rb",
+]
+
+[[package]]
+name = "rust_gui_xim"
+version = "0.1.0"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -1588,7 +1629,7 @@ version = "0.1.0"
 name = "rust_os_win32"
 version = "0.1.0"
 dependencies = [
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1650,6 +1691,7 @@ dependencies = [
 name = "rust_regex_engine"
 version = "0.1.0"
 dependencies = [
+ "criterion 0.4.0",
  "regex",
 ]
 
@@ -1657,7 +1699,7 @@ dependencies = [
 name = "rust_regexp"
 version = "0.1.0"
 dependencies = [
- "criterion",
+ "criterion 0.5.1",
  "regex",
 ]
 
@@ -1707,11 +1749,12 @@ dependencies = [
 [[package]]
 name = "rust_spellfile"
 version = "0.1.0"
+
 [[package]]
 name = "rust_spellsuggest"
 version = "0.1.0"
 dependencies = [
- "criterion",
+ "criterion 0.5.1",
  "rust_spellfile",
 ]
 
@@ -2180,6 +2223,7 @@ name = "vim_channel"
 version = "0.1.0"
 dependencies = [
  "diff",
+ "regex",
  "rust_alloc",
  "rust_blob",
  "rust_blowfish",
@@ -2409,6 +2453,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows"

--- a/rust_gui_gtk_f/Cargo.toml
+++ b/rust_gui_gtk_f/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_gui_gtk_f"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libloading = "0.8"

--- a/rust_gui_gtk_f/src/lib.rs
+++ b/rust_gui_gtk_f/src/lib.rs
@@ -1,0 +1,34 @@
+use libloading::Library;
+use std::ffi::{c_char, c_int};
+
+/// Initialize GTK using a dynamically loaded `gtk_init_check` call.
+///
+/// Passing null pointers for argc/argv matches the C API's allowance for
+/// optional arguments.  Returns `true` on success and `false` otherwise.
+pub fn gtk_init_check() -> bool {
+    unsafe {
+        let lib = match Library::new("libgtk-3.so.0") {
+            Ok(lib) => lib,
+            Err(_) => return false,
+        };
+        let func: libloading::Symbol<
+            unsafe extern "C" fn(*mut c_int, *mut *mut *mut c_char) -> i32,
+        > = match lib.get(b"gtk_init_check\0") {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+        // Call `gtk_init_check(NULL, NULL)`; non-zero indicates success.
+        func(std::ptr::null_mut(), std::ptr::null_mut()) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_gtk() {
+        // Should not panic even if GTK is unavailable.
+        let _ = gtk_init_check();
+    }
+}

--- a/rust_gui_w32/Cargo.toml
+++ b/rust_gui_w32/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 rust_gui_core = { path = "../rust_gui_core" }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.48", features = ["Win32_System_SystemInformation"] }
+

--- a/rust_gui_w32/src/lib.rs
+++ b/rust_gui_w32/src/lib.rs
@@ -1,6 +1,9 @@
 use rust_gui_core::backend::{GuiBackend, GuiEvent};
 use std::collections::VecDeque;
 
+#[cfg(windows)]
+use windows::Win32::System::SystemInformation::GetTickCount;
+
 /// Minimal Windows backend.  Real drawing is delegated to the platform APIs
 /// but for now these methods record actions for testing purposes.
 #[derive(Default)]
@@ -17,6 +20,21 @@ impl W32Backend {
     /// Queue an event so it can later be retrieved by `poll_event`.
     pub fn push_event(&mut self, ev: GuiEvent) {
         self.events.push_back(ev);
+    }
+}
+
+/// Wrap the Win32 `GetTickCount` API through the `windows` crate.
+///
+/// On non-Windows platforms this returns `0` so that the function can be
+/// compiled and tested without depending on the actual Windows API.
+pub fn get_tick_count() -> u32 {
+    #[cfg(windows)]
+    unsafe {
+        GetTickCount()
+    }
+    #[cfg(not(windows))]
+    {
+        0
     }
 }
 
@@ -41,5 +59,11 @@ mod tests {
         backend.push_event(GuiEvent::Click { x: 1, y: 2 });
         assert_eq!(backend.drawn, vec!["hello".to_string()]);
         assert_eq!(backend.poll_event(), Some(GuiEvent::Click { x: 1, y: 2 }));
+    }
+
+    #[test]
+    fn tick_count() {
+        // Ensure calling through the windows crate wrapper works on all targets.
+        let _ = get_tick_count();
     }
 }

--- a/rust_gui_xim/Cargo.toml
+++ b/rust_gui_xim/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_gui_xim"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libloading = "0.8"

--- a/rust_gui_xim/src/lib.rs
+++ b/rust_gui_xim/src/lib.rs
@@ -1,0 +1,32 @@
+use libloading::Library;
+use std::ffi::c_void;
+
+/// Attempt to open the X Input Method (XIM) using dynamic loading.
+///
+/// On systems without X11 this will simply return `false` without
+/// attempting to load any libraries.
+pub fn open_xim() -> bool {
+    unsafe {
+        let lib = match Library::new("libX11.so.6") {
+            Ok(lib) => lib,
+            Err(_) => return false,
+        };
+        // We only verify that the `XOpenIM` symbol exists; calling it would
+        // require a valid X11 display and input method setup which is not
+        // available in the test environment.
+        let result = lib.get::<unsafe extern "C" fn() -> *mut c_void>(b"XOpenIM\0");
+        result.is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_xim() {
+        // This test mainly ensures the dynamic loading path executes
+        // without crashing on platforms lacking X11.
+        let _ = open_xim();
+    }
+}


### PR DESCRIPTION
## Summary
- add `rust_gui_gtk_f` crate to initialize GTK via dynamic loading
- add `rust_gui_xim` crate to detect XIM availability using libloading
- wrap Win32 `GetTickCount` with `windows` crate in `rust_gui_w32`

## Testing
- `cargo test -p rust_gui_xim`
- `cargo test -p rust_gui_gtk_f`
- `cargo test -p rust_gui_w32`


------
https://chatgpt.com/codex/tasks/task_e_68b82ab75d10832088e35b5540557152