### PR TITLE
Track buffer free count in Rust

### DIFF
--- a/rust_buffer/include/rust_buffer.h
+++ b/rust_buffer/include/rust_buffer.h
@@ -9,6 +9,8 @@ void buf_freeall(void *buf, int flags);
 
 int calc_percentage(long part, long whole);
 int get_highest_fnum(void);
+int get_buf_free_count(void);
+void inc_buf_free_count(void);
 
 int get_top_file_num(void);
 void set_top_file_num(int num);


### PR DESCRIPTION
## Summary
- move `buf_free_count` tracking into the `rust_buffer` crate
- expose FFI for getting and incrementing the counter
- update C buffer code to use the Rust functions

## Testing
- `cargo test -p rust_buffer`


------
https://chatgpt.com/codex/tasks/task_e_68b8357ce8f48320b2c7a5d46176d9bc