### PR TITLE
Add Rust cindent module with FFI and benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,13 @@ name = "rust_charset"
 version = "0.1.0"
 
 [[package]]
+name = "rust_cindent"
+version = "0.1.0"
+dependencies = [
+ "criterion 0.5.1",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [

--- a/rust_cindent/Cargo.toml
+++ b/rust_cindent/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust_cindent"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "indent"
+harness = false

--- a/rust_cindent/benches/indent.rs
+++ b/rust_cindent/benches/indent.rs
@@ -1,0 +1,9 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use rust_cindent::rs_compute_indent;
+
+fn bench_compute_indent(c: &mut Criterion) {
+    c.bench_function("compute_indent", |b| b.iter(|| rs_compute_indent(10)));
+}
+
+criterion_group!(benches, bench_compute_indent);
+criterion_main!(benches);

--- a/rust_cindent/src/lib.rs
+++ b/rust_cindent/src/lib.rs
@@ -1,0 +1,27 @@
+use std::os::raw::c_int;
+
+#[no_mangle]
+pub extern "C" fn rs_compute_indent(level: c_int) -> c_int {
+    if level < 0 {
+        0
+    } else {
+        level * 2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_indent_basic() {
+        assert_eq!(rs_compute_indent(0), 0);
+        assert_eq!(rs_compute_indent(1), 2);
+        assert_eq!(rs_compute_indent(4), 8);
+    }
+
+    #[test]
+    fn compute_indent_negative() {
+        assert_eq!(rs_compute_indent(-3), 0);
+    }
+}

--- a/src/cindent_rs.h
+++ b/src/cindent_rs.h
@@ -1,0 +1,14 @@
+#ifndef CINDENT_RS_H
+#define CINDENT_RS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int rs_compute_indent(int level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CINDENT_RS_H */


### PR DESCRIPTION
## Summary
- introduce `rust_cindent` crate with basic `rs_compute_indent` function
- expose C interface via `src/cindent_rs.h`
- add unit tests and Criterion benchmark for indentation

## Testing
- `cargo test -p rust_cindent`
- `cargo bench -p rust_cindent`

------
https://chatgpt.com/codex/tasks/task_e_68b838140e6483209f3bcc1dea478b78