### PR TITLE
Add placeholder rust_cindent crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,13 @@ name = "rust_charset"
 version = "0.1.0"
 
 [[package]]
+name = "rust_cindent"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [

--- a/rust_cindent/Cargo.toml
+++ b/rust_cindent/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_cindent"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_cindent"
+crate-type = ["staticlib", "rlib"]

--- a/rust_cindent/src/lib.rs
+++ b/rust_cindent/src/lib.rs
@@ -1,0 +1,39 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+/// A very simplified indentation computation.
+/// Counts unmatched '{' and '}' to determine indentation level.
+#[no_mangle]
+pub extern "C" fn rs_cindent(line: *const c_char) -> c_int {
+    if line.is_null() {
+        return 0;
+    }
+    let c_str = unsafe { CStr::from_ptr(line) };
+    let mut level = 0;
+    for ch in c_str.to_bytes() {
+        match *ch as char {
+            '{' => level += 1,
+            '}' => if level > 0 { level -= 1; },
+            _ => {}
+        }
+    }
+    level as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn simple_braces() {
+        let line = CString::new("if (x) {").unwrap();
+        assert_eq!(rs_cindent(line.as_ptr()), 1);
+    }
+
+    #[test]
+    fn closing_brace() {
+        let line = CString::new("}").unwrap();
+        assert_eq!(rs_cindent(line.as_ptr()), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- start porting C indentation logic by introducing a rust_cindent crate
- provide simple brace-count indentation function

## Testing
- `cargo test -p rust_cindent`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b837c1ccdc83208d6b11416787c7cf