### PR TITLE
Remove obsolete IM deactivation block

### DIFF
--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -627,13 +627,6 @@ im_preedit_end_cb(GtkIMContext *context UNUSED, gpointer data UNUSED)
     if (p_imst == IM_ON_THE_SPOT)
 	preedit_start_col = MAXCOL;
     xim_has_preediting = FALSE;
-
-#if 0
-    // Removal of this line suggested by Takuhiro Nishioka.  Fixes that IM was
-    // switched off unintentionally.  We now use preedit_is_active (added by
-    // SungHyun Nam).
-    im_is_active = FALSE;
-#endif
     preedit_is_active = FALSE;
     gui_update_cursor(TRUE, FALSE);
     im_show_info();


### PR DESCRIPTION
## Summary
- tidy up IM preedit end callback by dropping inactive `#if 0` block
- keep only `preedit_is_active` flag update when preediting finishes

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68b83852317483208e8d704ddda47963