### PR TITLE
Drop obsolete IM state reset in XIM preedit callback

### DIFF
--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -628,12 +628,6 @@ im_preedit_end_cb(GtkIMContext *context UNUSED, gpointer data UNUSED)
 	preedit_start_col = MAXCOL;
     xim_has_preediting = FALSE;
 
-#if 0
-    // Removal of this line suggested by Takuhiro Nishioka.  Fixes that IM was
-    // switched off unintentionally.  We now use preedit_is_active (added by
-    // SungHyun Nam).
-    im_is_active = FALSE;
-#endif
     preedit_is_active = FALSE;
     gui_update_cursor(TRUE, FALSE);
     im_show_info();


### PR DESCRIPTION
## Summary
- remove old `#if 0` block in `im_preedit_end_cb` and rely on `preedit_is_active`

## Testing
- `make -C src` *(fails: Makefile:1566: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.)*


------
https://chatgpt.com/codex/tasks/task_e_68b8383f51888320b3ab8783238b2b9a