### PR TITLE
Clean up unused xdiff regex parameters

### DIFF
--- a/src/xdiff/xdiff.h
+++ b/src/xdiff/xdiff.h
@@ -81,15 +81,9 @@ typedef struct s_mmbuffer {
 typedef struct s_xpparam {
 	unsigned long flags;
 
-	/* -I<regex> */
- #if 0  // unused by Vim
-	regex_t **ignore_regex;
-	size_t ignore_regex_nr;
-#endif
-
-	/* See Documentation/diff-options.txt. */
-	char **anchors;
-	size_t anchors_nr;
+        /* See Documentation/diff-options.txt. */
+        char **anchors;
+        size_t anchors_nr;
 } xpparam_t;
 
 typedef struct s_xdemitcb {


### PR DESCRIPTION
## Summary
- drop unused `ignore_regex` fields from `xpparam_t`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b83836932c8320bd60aed1c4f4dba0