### PR TITLE
Remove flags argument from may_get_cmd_block

### DIFF
--- a/src/autocmd.c
+++ b/src/autocmd.c
@@ -1063,7 +1063,9 @@ do_autocmd(exarg_T *eap, char_u *arg_in, int forceit)
 	{
 	    if (eap != NULL)
 		// Read a {} block if it follows.
-		cmd = may_get_cmd_block(eap, cmd, &tofree, &flags);
+		cmd = may_get_cmd_block(eap, cmd, &tofree);
+                if (tofree != NULL)
+                    flags |= UC_VIM9;
 
 	    cmd = expand_sfile(cmd);
 	    if (cmd == NULL)	    // some error

--- a/src/proto/usercmd.pro
+++ b/src/proto/usercmd.pro
@@ -13,7 +13,7 @@ char_u *cmdcomplete_type_to_str(int expand, char_u *compl_arg);
 int cmdcomplete_str_to_type(char_u *complete_str);
 char *uc_fun_cmd(void);
 int parse_compl_arg(char_u *value, int vallen, int *complp, long *argt, char_u **compl_arg);
-char_u *may_get_cmd_block(exarg_T *eap, char_u *p, char_u **tofree, int *flags);
+char_u *may_get_cmd_block(exarg_T *eap, char_u *p, char_u **tofree);
 void ex_command(exarg_T *eap);
 void ex_comclear(exarg_T *eap);
 void uc_clear(garray_T *gap);

--- a/src/usercmd.c
+++ b/src/usercmd.c
@@ -1205,7 +1205,7 @@ fail:
  * Used for ":command" and ":autocmd".
  */
     char_u *
-may_get_cmd_block(exarg_T *eap, char_u *p, char_u **tofree, int *flags)
+may_get_cmd_block(exarg_T *eap, char_u *p, char_u **tofree)
 {
     char_u *retp = p;
 
@@ -1241,7 +1241,6 @@ may_get_cmd_block(exarg_T *eap, char_u *p, char_u **tofree, int *flags)
 	vim_free(line);
 	retp = *tofree = ga_concat_strings(&ga, "\n");
 	ga_clear_strings(&ga);
-	*flags |= UC_VIM9;
     }
     return retp;
 }
@@ -1322,7 +1321,9 @@ ex_command(exarg_T *eap)
     {
 	char_u *tofree = NULL;
 
-	p = may_get_cmd_block(eap, p, &tofree, &flags);
+	p = may_get_cmd_block(eap, p, &tofree);
+        if (tofree != NULL)
+            flags |= UC_VIM9;
 
 	uc_add_command(name, end - name, p, argt, def, flags, compl, compl_arg,
 						  addr_type_arg, eap->forceit);

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -2337,13 +2337,12 @@ compile_exec(char_u *line_arg, exarg_T *eap, cctx_T *cctx)
 	    if (*p == '{')
 	    {
 		exarg_T ea;
-		int	flags = 0;  // unused
-		int	start_lnum = SOURCING_LNUM;
+		int     start_lnum = SOURCING_LNUM;
 
 		CLEAR_FIELD(ea);
 		ea.arg = eap->arg;
 		fill_exarg_from_cctx(&ea, cctx);
-		(void)may_get_cmd_block(&ea, p, &tofree, &flags);
+		(void)may_get_cmd_block(&ea, p, &tofree);
 		if (tofree != NULL)
 		{
 		    *p = NUL;


### PR DESCRIPTION
## Summary
- drop unused `flags` variable from `vim9cmds.c`
- simplify `may_get_cmd_block` by removing unused flags parameter and update callers

## Testing
- `make -C src test` *(fails: missing separator)*
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8383461788320866c734811071ae8