### PR TITLE
Move vim_time to Rust using FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_time"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_undo"
 version = "0.1.0"
 dependencies = [

--- a/rust_time/Cargo.toml
+++ b/rust_time/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_time"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_time"
+crate-type = ["staticlib", "rlib"]

--- a/rust_time/src/lib.rs
+++ b/rust_time/src/lib.rs
@@ -1,0 +1,30 @@
+use libc::{time_t, time};
+
+/// Return the current time in seconds.
+/// When Vim is built with testing support, a global `time_for_testing`
+/// value may be used instead of the system time.
+#[no_mangle]
+pub unsafe extern "C" fn rs_vim_time() -> time_t {
+    #[cfg(feature = "feat_eval")]
+    {
+        extern "C" {
+            static mut time_for_testing: time_t;
+        }
+        if time_for_testing != 0 {
+            return time_for_testing;
+        }
+    }
+    time(std::ptr::null_mut())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_time() {
+        // Just ensure the function runs and returns a non-zero value.
+        let t = unsafe { rs_vim_time() };
+        assert!(t > 0);
+    }
+}

--- a/src/time.c
+++ b/src/time.c
@@ -13,6 +13,8 @@
 
 #include "vim.h"
 
+// FFI: implemented in rust_time crate
+extern time_T rs_vim_time(void);
 /*
  * Cache of the current timezone name as retrieved from TZ, or an empty string
  * where unset, up to 64 octets long including trailing null byte.
@@ -59,17 +61,13 @@ vim_localtime(
 }
 
 /*
- * Return the current time in seconds.  Calls time(), unless test_settime()
- * was used.
+ * Return the current time in seconds.  Implementation provided by the
+ * Rust `rust_time` module.
  */
     time_T
 vim_time(void)
 {
-# ifdef FEAT_EVAL
-    return time_for_testing == 0 ? time(NULL) : time_for_testing;
-# else
-    return time(NULL);
-# endif
+    return rs_vim_time();
 }
 
 /*


### PR DESCRIPTION
## Summary
- add new `rust_time` crate with `rs_vim_time` FFI implementation
- delegate `vim_time` in C to Rust module

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b83819f0a883209dff0453ea5a5f4c