### PR TITLE
Define OPAQUE_TOOLBOX_STRUCTS directly

### DIFF
--- a/src/os_mac.h
+++ b/src/os_mac.h
@@ -14,9 +14,7 @@
 // can access the internal structures.
 // (Until fully Carbon compliant)
 // TODO: Can we remove this? (Dany)
-#if 0
-# define OPAQUE_TOOLBOX_STRUCTS 0
-#endif
+#define OPAQUE_TOOLBOX_STRUCTS 0
 
 // Include MAC_OS_X_VERSION_* macros
 #ifdef HAVE_AVAILABILITYMACROS_H


### PR DESCRIPTION
## Summary
- define `OPAQUE_TOOLBOX_STRUCTS` unconditionally in `os_mac.h`

## Testing
- `clang -target x86_64-apple-darwin -fsyntax-only -I src src/os_macosx.m` (fails: 'mach/boolean.h' file not found)
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8385de6ec8320bacf27ad07d3fe65