### PR TITLE
Remove dead text object cases

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -7207,12 +7207,7 @@ nv_object(
 		flag = current_quote(cap->oap, cap->count1, include,
 								  cap->nchar);
 		break;
-#if 0	// TODO
-	case 'S': // "aS" = a section
-	case 'f': // "af" = a filename
-	case 'u': // "au" = a URL
-#endif
-	default:
+	default: // unsupported text object
 		flag = FAIL;
 		break;
     }


### PR DESCRIPTION
## Summary
- drop unused `#if 0` block for section/filename/URL text objects
- clarify default branch for unsupported text objects

## Testing
- `make -C src normal.o` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b8385d54bc8320b2aa94ff68bafe56