### PR TITLE
Remove unused spell debug macro stubs

### DIFF
--- a/src/spell.h
+++ b/src/spell.h
@@ -12,23 +12,6 @@
  * rust_spellfile crate.
  */
 
-// Use SPELL_PRINTTREE for debugging: dump the word tree after adding a word.
-// Only use it for small word lists!
-#if 0
-# define SPELL_PRINTTREE
-#endif
-
-// Use SPELL_COMPRESS_ALWAYS for debugging: compress the word tree after
-// adding a word.  Only use it for small word lists!
-#if 0
-# define SPELL_COMPRESS_ALWAYS
-#endif
-
-// Use DEBUG_TRIEWALK to print the changes made in suggest_trie_walk() for a
-// specific word.
-#if 0
-# define DEBUG_TRIEWALK
-#endif
 
 #define MAXWLEN 254		// Assume max. word len is this many bytes.
 				// Some places assume a word length fits in a


### PR DESCRIPTION
## Summary
- drop dead `#if 0` blocks defining `SPELL_PRINTTREE`, `SPELL_COMPRESS_ALWAYS`, and `DEBUG_TRIEWALK`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b8384ddc2883209459359254f5ea33