### PR TITLE
refactor(spell): drop unused debug macros

### DIFF
--- a/src/spell.h
+++ b/src/spell.h
@@ -12,23 +12,11 @@
  * rust_spellfile crate.
  */
 
-// Use SPELL_PRINTTREE for debugging: dump the word tree after adding a word.
-// Only use it for small word lists!
-#if 0
-# define SPELL_PRINTTREE
-#endif
-
-// Use SPELL_COMPRESS_ALWAYS for debugging: compress the word tree after
-// adding a word.  Only use it for small word lists!
-#if 0
-# define SPELL_COMPRESS_ALWAYS
-#endif
-
-// Use DEBUG_TRIEWALK to print the changes made in suggest_trie_walk() for a
-// specific word.
-#if 0
-# define DEBUG_TRIEWALK
-#endif
+// Debug helpers can be enabled by defining these macros through a build option
+// or environment variable.
+// #define SPELL_PRINTTREE       // dump the word tree after adding a word
+// #define SPELL_COMPRESS_ALWAYS // compress the word tree after each addition
+// #define DEBUG_TRIEWALK        // trace changes in suggest_trie_walk()
 
 #define MAXWLEN 254		// Assume max. word len is this many bytes.
 				// Some places assume a word length fits in a


### PR DESCRIPTION
## Summary
- remove obsolete `#if 0` debug blocks from `spell.h`
- document how to enable debug helpers via build flags or env vars

## Testing
- `make -C src test` *(fails: missing separator)*
- `make test` *(fails: No rule to make target 'test')*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b838425f548320b8f2540bb4a7e22c