### PR TITLE
Add rust_time crate and port vim_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_time"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_undo"
 version = "0.1.0"
 dependencies = [

--- a/rust_time/Cargo.toml
+++ b/rust_time/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_time"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_time"
+crate-type = ["staticlib", "rlib"]

--- a/rust_time/src/lib.rs
+++ b/rust_time/src/lib.rs
@@ -1,0 +1,30 @@
+use libc::{time, time_t};
+
+#[cfg(not(test))]
+extern "C" {
+    static mut time_for_testing: time_t;
+}
+
+#[cfg(test)]
+#[no_mangle]
+pub static mut time_for_testing: time_t = 0;
+
+#[no_mangle]
+pub unsafe extern "C" fn vim_time() -> time_t {
+    if time_for_testing == 0 {
+        time(std::ptr::null_mut())
+    } else {
+        time_for_testing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_non_zero() {
+        let t = unsafe { vim_time() };
+        assert!(t > 0);
+    }
+}

--- a/src/time.c
+++ b/src/time.c
@@ -59,18 +59,9 @@ vim_localtime(
 }
 
 /*
- * Return the current time in seconds.  Calls time(), unless test_settime()
- * was used.
+ * vim_time() has been moved to the Rust implementation in the rust_time
+ * crate.  The C version is no longer needed here.
  */
-    time_T
-vim_time(void)
-{
-# ifdef FEAT_EVAL
-    return time_for_testing == 0 ? time(NULL) : time_for_testing;
-# else
-    return time(NULL);
-# endif
-}
 
 /*
  * Replacement for ctime(), which is not safe to use.


### PR DESCRIPTION
## Summary
- add new `rust_time` crate implementing `vim_time` in Rust using libc
- remove C implementation of `vim_time` and reference Rust crate

## Testing
- `cargo test -p rust_time`

------
https://chatgpt.com/codex/tasks/task_e_68b8381666d48320b4cce89afdec6fb1