### PR TITLE
Add rudimentary tuple FFI crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_tuple"
+version = "0.1.0"
+
+[[package]]
 name = "rust_undo"
 version = "0.1.0"
 dependencies = [

--- a/rust_tuple/Cargo.toml
+++ b/rust_tuple/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_tuple"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]

--- a/rust_tuple/src/lib.rs
+++ b/rust_tuple/src/lib.rs
@@ -1,0 +1,73 @@
+use std::os::raw::c_long;
+
+#[repr(C)]
+pub struct rs_tuple {
+    items: Vec<i64>,
+}
+
+#[no_mangle]
+pub extern "C" fn rs_tuple_new(len: usize) -> *mut rs_tuple {
+    let tuple = rs_tuple { items: vec![0; len] };
+    Box::into_raw(Box::new(tuple))
+}
+
+#[no_mangle]
+pub extern "C" fn rs_tuple_set(tuple: *mut rs_tuple, idx: usize, value: c_long) -> bool {
+    if tuple.is_null() {
+        return false;
+    }
+    let t = unsafe { &mut *tuple };
+    if let Some(slot) = t.items.get_mut(idx) {
+        *slot = value as i64;
+        true
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_tuple_get(tuple: *const rs_tuple, idx: usize, value: *mut c_long) -> bool {
+    if tuple.is_null() || value.is_null() {
+        return false;
+    }
+    let t = unsafe { &*tuple };
+    if let Some(&v) = t.items.get(idx) {
+        unsafe { *value = v as c_long; }
+        true
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_tuple_len(tuple: *const rs_tuple) -> usize {
+    if tuple.is_null() {
+        0
+    } else {
+        unsafe { (*tuple).items.len() }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_tuple_free(tuple: *mut rs_tuple) {
+    if tuple.is_null() {
+        return;
+    }
+    unsafe { drop(Box::from_raw(tuple)); }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_set_get() {
+        let t = rs_tuple_new(3);
+        assert_eq!(unsafe { rs_tuple_len(t) }, 3);
+        assert!(unsafe { rs_tuple_set(t, 1, 42) });
+        let mut val: c_long = 0;
+        assert!(unsafe { rs_tuple_get(t, 1, &mut val) });
+        assert_eq!(val, 42);
+        unsafe { rs_tuple_free(t) };
+    }
+}

--- a/src/rust_tuple.h
+++ b/src/rust_tuple.h
@@ -1,0 +1,16 @@
+#ifndef RUST_TUPLE_H
+#define RUST_TUPLE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct rs_tuple rs_tuple;
+
+rs_tuple *rs_tuple_new(size_t len);
+bool rs_tuple_set(rs_tuple *tuple, size_t idx, int64_t value);
+bool rs_tuple_get(const rs_tuple *tuple, size_t idx, int64_t *value);
+size_t rs_tuple_len(const rs_tuple *tuple);
+void rs_tuple_free(rs_tuple *tuple);
+
+#endif // RUST_TUPLE_H

--- a/src/tuple_rs.h
+++ b/src/tuple_rs.h
@@ -1,0 +1,14 @@
+#ifndef TUPLE_RS_H
+#define TUPLE_RS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "rust_tuple.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TUPLE_RS_H


### PR DESCRIPTION
## Summary
- add new `rust_tuple` crate implementing simple tuple struct and FFI helpers
- expose tuple API to C via `rust_tuple.h` and `tuple_rs.h`

## Testing
- `cargo test -p rust_tuple`


------
https://chatgpt.com/codex/tasks/task_e_68b83814ab5c8320b55b40285e71b2ec