### PR TITLE
Add Rust crypto/zip implementation with C wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +48,15 @@ name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "atty"
@@ -115,13 +135,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.3.0",
  "opaque-debug",
 ]
 
@@ -144,10 +173,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "cbindgen"
@@ -157,7 +204,7 @@ checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
  "clap 3.2.25",
  "heck",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "proc-macro2",
  "quote",
@@ -175,6 +222,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -230,6 +279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,7 +308,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "strsim",
  "termcolor",
  "textwrap",
@@ -290,12 +349,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -417,6 +491,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf1e6e5492f8f0830c37f301f6349e0dac8b2466e4fe89eef90e9eef906cd046"
+dependencies = [
+ "cipher 0.4.4",
+ "crypto-common",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +508,32 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -479,6 +589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +615,17 @@ name = "find-msvc-tools"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "libz-rs-sys",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "generic-array"
@@ -572,6 +699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,7 +756,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -631,6 +774,16 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -690,6 +843,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +894,35 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "liblzma"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bf66f4598dc77ff96677c8e763655494f00ff9c1cf79e2eb5bb07bc31f807d"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -882,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1205,18 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
 
 [[package]]
 name = "prettyplease"
@@ -1268,6 +1484,16 @@ name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "rust_crypto_zip"
+version = "0.1.0"
+dependencies = [
+ "aes",
+ "cbc",
+ "crypto",
+ "zip",
 ]
 
 [[package]]
@@ -1919,6 +2145,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2201,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -2070,6 +2313,25 @@ name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "tinytemplate"
@@ -2698,4 +2960,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
 dependencies = [
  "nix 0.25.1",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.3",
+ "hmac",
+ "indexmap 2.11.0",
+ "liblzma",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/rust_crypto_zip/Cargo.toml
+++ b/rust_crypto_zip/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust_crypto_zip"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+crypto = { version = "0.5", features = ["cipher"] }
+aes = "0.8"
+cbc = "0.1"
+zip = "4.6.1"
+
+[lib]
+name = "rust_crypto_zip"
+crate-type = ["staticlib", "rlib"]

--- a/rust_crypto_zip/src/lib.rs
+++ b/rust_crypto_zip/src/lib.rs
@@ -1,0 +1,208 @@
+use std::io::{Cursor, Read, Write};
+use std::slice;
+
+use aes::Aes128;
+use cbc::{Decryptor, Encryptor};
+use crypto::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use zip::{read::ZipArchive, write::FileOptions, CompressionMethod, ZipWriter};
+
+// Internal helper for AES-128-CBC encryption.
+fn aes_encrypt(data: &[u8], key: &[u8]) -> Option<Vec<u8>> {
+    if key.len() != 16 {
+        return None;
+    }
+    let iv = [0u8; 16];
+    let mut out = vec![0u8; data.len() + 16];
+    let cipher = Encryptor::<Aes128>::new(key.into(), &iv.into());
+    let n = cipher
+        .encrypt_padded_b2b_mut::<Pkcs7>(data, &mut out)
+        .ok()?
+        .len();
+    out.truncate(n);
+    Some(out)
+}
+
+// Internal helper for AES-128-CBC decryption.
+fn aes_decrypt(data: &[u8], key: &[u8]) -> Option<Vec<u8>> {
+    if key.len() != 16 {
+        return None;
+    }
+    let iv = [0u8; 16];
+    let mut out = vec![0u8; data.len()];
+    let cipher = Decryptor::<Aes128>::new(key.into(), &iv.into());
+    let n = cipher
+        .decrypt_padded_b2b_mut::<Pkcs7>(data, &mut out)
+        .ok()?
+        .len();
+    out.truncate(n);
+    Some(out)
+}
+
+// Compress data into a single-file ZIP archive.
+fn zip_compress(data: &[u8]) -> Option<Vec<u8>> {
+    let mut cursor = Cursor::new(Vec::new());
+    {
+        let mut writer = ZipWriter::new(&mut cursor);
+        let options = FileOptions::<()>::default().compression_method(CompressionMethod::Deflated);
+        writer.start_file("data", options).ok()?;
+        writer.write_all(data).ok()?;
+        writer.finish().ok()?;
+    }
+    Some(cursor.into_inner())
+}
+
+// Decompress a single-file ZIP archive.
+fn zip_decompress(data: &[u8]) -> Option<Vec<u8>> {
+    let cursor = Cursor::new(data);
+    let mut archive = ZipArchive::new(cursor).ok()?;
+    let mut file = archive.by_index(0).ok()?;
+    let mut out = Vec::new();
+    file.read_to_end(&mut out).ok()?;
+    Some(out)
+}
+
+// FFI: encrypt buffer using AES-128-CBC with PKCS#7 padding.
+#[no_mangle]
+pub extern "C" fn rs_encrypt(
+    input: *const u8,
+    input_len: usize,
+    key: *const u8,
+    key_len: usize,
+    output: *mut u8,
+    output_len: usize,
+) -> usize {
+    if input.is_null() || key.is_null() || output.is_null() {
+        return 0;
+    }
+    let input = unsafe { slice::from_raw_parts(input, input_len) };
+    let key = unsafe { slice::from_raw_parts(key, key_len) };
+    let out_slice = unsafe { slice::from_raw_parts_mut(output, output_len) };
+    if let Some(enc) = aes_encrypt(input, key) {
+        if enc.len() > out_slice.len() {
+            return 0;
+        }
+        out_slice[..enc.len()].copy_from_slice(&enc);
+        enc.len()
+    } else {
+        0
+    }
+}
+
+// FFI: decrypt buffer using AES-128-CBC with PKCS#7 padding.
+#[no_mangle]
+pub extern "C" fn rs_decrypt(
+    input: *const u8,
+    input_len: usize,
+    key: *const u8,
+    key_len: usize,
+    output: *mut u8,
+    output_len: usize,
+) -> usize {
+    if input.is_null() || key.is_null() || output.is_null() {
+        return 0;
+    }
+    let input = unsafe { slice::from_raw_parts(input, input_len) };
+    let key = unsafe { slice::from_raw_parts(key, key_len) };
+    let out_slice = unsafe { slice::from_raw_parts_mut(output, output_len) };
+    if let Some(dec) = aes_decrypt(input, key) {
+        if dec.len() > out_slice.len() {
+            return 0;
+        }
+        out_slice[..dec.len()].copy_from_slice(&dec);
+        dec.len()
+    } else {
+        0
+    }
+}
+
+// FFI: compress data into ZIP format.
+#[no_mangle]
+pub extern "C" fn rs_zip_compress(
+    input: *const u8,
+    input_len: usize,
+    output: *mut u8,
+    output_len: usize,
+) -> usize {
+    if input.is_null() || output.is_null() {
+        return 0;
+    }
+    let input = unsafe { slice::from_raw_parts(input, input_len) };
+    let out_slice = unsafe { slice::from_raw_parts_mut(output, output_len) };
+    if let Some(comp) = zip_compress(input) {
+        if comp.len() > out_slice.len() {
+            return 0;
+        }
+        out_slice[..comp.len()].copy_from_slice(&comp);
+        comp.len()
+    } else {
+        0
+    }
+}
+
+// FFI: decompress ZIP data.
+#[no_mangle]
+pub extern "C" fn rs_zip_decompress(
+    input: *const u8,
+    input_len: usize,
+    output: *mut u8,
+    output_len: usize,
+) -> usize {
+    if input.is_null() || output.is_null() {
+        return 0;
+    }
+    let input = unsafe { slice::from_raw_parts(input, input_len) };
+    let out_slice = unsafe { slice::from_raw_parts_mut(output, output_len) };
+    if let Some(decomp) = zip_decompress(input) {
+        if decomp.len() > out_slice.len() {
+            return 0;
+        }
+        out_slice[..decomp.len()].copy_from_slice(&decomp);
+        decomp.len()
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_roundtrip() {
+        let data = b"hello rust";
+        let key = [0x11u8; 16];
+        let mut enc_buf = vec![0u8; data.len() + 16];
+        let enc_len = rs_encrypt(
+            data.as_ptr(),
+            data.len(),
+            key.as_ptr(),
+            key.len(),
+            enc_buf.as_mut_ptr(),
+            enc_buf.len(),
+        );
+        assert!(enc_len > 0);
+        let mut dec_buf = vec![0u8; enc_len];
+        let dec_len = rs_decrypt(
+            enc_buf.as_ptr(),
+            enc_len,
+            key.as_ptr(),
+            key.len(),
+            dec_buf.as_mut_ptr(),
+            dec_buf.len(),
+        );
+        assert_eq!(dec_len, data.len());
+        assert_eq!(&dec_buf[..dec_len], data);
+    }
+
+    #[test]
+    fn zip_roundtrip() {
+        let data = b"zip me";
+        let mut comp = vec![0u8; 512];
+        let clen = rs_zip_compress(data.as_ptr(), data.len(), comp.as_mut_ptr(), comp.len());
+        assert!(clen > 0);
+        let mut decomp = vec![0u8; 512];
+        let dlen = rs_zip_decompress(comp.as_ptr(), clen, decomp.as_mut_ptr(), decomp.len());
+        assert_eq!(dlen, data.len());
+        assert_eq!(&decomp[..dlen], data);
+    }
+}

--- a/src/crypt_zip_rs.c
+++ b/src/crypt_zip_rs.c
@@ -1,0 +1,30 @@
+#include "rust_crypto_zip.h"
+
+// C wrappers around the Rust FFI functions to maintain
+// compatibility with existing C code during migration.
+
+size_t crypt_rust_encrypt(const uint8_t *data, size_t len,
+                          const uint8_t *key, size_t key_len,
+                          uint8_t *out, size_t out_len)
+{
+    return rs_encrypt(data, len, key, key_len, out, out_len);
+}
+
+size_t crypt_rust_decrypt(const uint8_t *data, size_t len,
+                          const uint8_t *key, size_t key_len,
+                          uint8_t *out, size_t out_len)
+{
+    return rs_decrypt(data, len, key, key_len, out, out_len);
+}
+
+size_t zip_rust_compress(const uint8_t *data, size_t len,
+                         uint8_t *out, size_t out_len)
+{
+    return rs_zip_compress(data, len, out, out_len);
+}
+
+size_t zip_rust_decompress(const uint8_t *data, size_t len,
+                           uint8_t *out, size_t out_len)
+{
+    return rs_zip_decompress(data, len, out, out_len);
+}

--- a/src/rust_crypto_zip.h
+++ b/src/rust_crypto_zip.h
@@ -1,0 +1,29 @@
+#ifndef RUST_CRYPTO_ZIP_H
+#define RUST_CRYPTO_ZIP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Encrypt input buffer into output using AES-128-CBC with PKCS#7 padding.
+// Returns number of bytes written to output or 0 on error.
+size_t rs_encrypt(const uint8_t *input, size_t input_len,
+                  const uint8_t *key, size_t key_len,
+                  uint8_t *output, size_t output_len);
+
+// Decrypt input buffer into output using AES-128-CBC with PKCS#7 padding.
+// Returns number of bytes written to output or 0 on error.
+size_t rs_decrypt(const uint8_t *input, size_t input_len,
+                  const uint8_t *key, size_t key_len,
+                  uint8_t *output, size_t output_len);
+
+// Compress input buffer into output as a single-file ZIP archive.
+// Returns number of bytes written to output or 0 on error.
+size_t rs_zip_compress(const uint8_t *input, size_t input_len,
+                       uint8_t *output, size_t output_len);
+
+// Decompress a single-file ZIP archive from input into output.
+// Returns number of bytes written to output or 0 on error.
+size_t rs_zip_decompress(const uint8_t *input, size_t input_len,
+                         uint8_t *output, size_t output_len);
+
+#endif // RUST_CRYPTO_ZIP_H


### PR DESCRIPTION
## Summary
- Implement AES-128-CBC encryption and ZIP compression in new `rust_crypto_zip` crate
- Expose Rust routines to C via FFI with matching wrapper functions
- Provide C header and helper module for parallel use during migration

## Testing
- `cargo test -p rust_crypto_zip`

------
https://chatgpt.com/codex/tasks/task_e_68b8381eb23c832080f3d5d85705a334