### PR TITLE
refactor: drop disabled throw test block

### DIFF
--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -52,15 +52,12 @@ static char	*get_end_emsg(cstack_T *cstack);
  * is an error exception.)  -  The macros can be defined as expressions checking
  * for a variable that is allowed to be changed during execution of a script.
  */
-#if 0
-// Expressions used for testing during the development phase.
-# define THROW_ON_ERROR		(!eval_to_number("$VIMNOERRTHROW"))
-# define THROW_ON_INTERRUPT	(!eval_to_number("$VIMNOINTTHROW"))
-# define THROW_TEST
-#else
-// Values used for the Vim release.
+// Values used for the Vim release.  For testing macros see test_throw.h.
+#ifndef THROW_ON_ERROR
 # define THROW_ON_ERROR		TRUE
 # define THROW_ON_ERROR_TRUE
+#endif
+#ifndef THROW_ON_INTERRUPT
 # define THROW_ON_INTERRUPT	TRUE
 # define THROW_ON_INTERRUPT_TRUE
 #endif

--- a/src/test_throw.h
+++ b/src/test_throw.h
@@ -1,0 +1,17 @@
+/* vi:set ts=8 sts=4 sw=4 noet:
+ *
+ * VIM - Vi IMproved    by Bram Moolenaar
+ *
+ * Do ":help uganda"  in Vim to read copying and usage conditions.
+ * Do ":help credits" in Vim to see a list of people who contributed.
+ */
+
+#ifndef TEST_THROW_H
+#define TEST_THROW_H
+
+// Expressions used for testing during the development phase.
+# define THROW_ON_ERROR		(!eval_to_number("$VIMNOERRTHROW"))
+# define THROW_ON_INTERRUPT	(!eval_to_number("$VIMNOINTTHROW"))
+# define THROW_TEST
+
+#endif // TEST_THROW_H


### PR DESCRIPTION
## Summary
- remove unused `#if 0` throw-on-error block and keep release defaults
- provide `test_throw.h` with macros for development testing

## Testing
- `cargo test -p rust_eval`

------
https://chatgpt.com/codex/tasks/task_e_68b8383a0adc8320886b5f0c143b90a6