### PR TITLE
Remove unused git compat include from xdiff

### DIFF
--- a/src/xdiff/xinclude.h
+++ b/src/xdiff/xinclude.h
@@ -55,10 +55,6 @@
 #endif
 #include <string.h>
 #include <limits.h>
-// This include comes from git, so uncomment it
-#if 0
-#include "git-compat-util.h"
-#endif
 #include "xmacros.h"
 #include "xdiff.h"
 #include "xtypes.h"


### PR DESCRIPTION
## Summary
- drop dead `git-compat-util.h` include and surrounding `#if 0` guard in `xinclude.h`

## Testing
- `make -C src xdiff` *(fails: Makefile:1566: missing separator)*
- `cargo test` *(fails: command not found: cargo)*

------
https://chatgpt.com/codex/tasks/task_e_68b83844eff48320b2c6beb65409c334