### PR TITLE
Remove disabled spell prefix handling

### DIFF
--- a/src/spell.c
+++ b/src/spell.c
@@ -860,9 +860,6 @@ find_word(matchinf_T *mip, int mode)
 			mip->mi_compoff = (int)(p - mip->mi_fword);
 		    }
 		}
-#if 0 // Disabled, see below
-		c = mip->mi_compoff;
-#endif
 		++mip->mi_complen;
 		if (flags & WF_COMPROOT)
 		    ++mip->mi_compextra;
@@ -890,16 +887,6 @@ find_word(matchinf_T *mip, int mode)
 			mip->mi_compoff = wlen;
 			find_word(mip, FIND_KEEPCOMPOUND);
 
-#if 0	    // Disabled, a prefix must not appear halfway a compound word,
-	    // unless the COMPOUNDPERMITFLAG is used and then it can't be a
-	    // postponed prefix.
-			if (!slang->sl_nobreak || mip->mi_result == SP_BAD)
-			{
-			    // Check for following word with prefix.
-			    mip->mi_compoff = c;
-			    find_prefix(mip, FIND_COMPOUND);
-			}
-#endif
 		    }
 
 		    if (!slang->sl_nobreak)


### PR DESCRIPTION
## Summary
- drop obsolete `#if 0` sections from `src/spell.c`
- tidy compound word code by removing dead prefix search logic

## Testing
- `cargo test -p rust_spell`


------
https://chatgpt.com/codex/tasks/task_e_68b8384c7dcc8320980e3cc2126a1449