### PR TITLE
Remove dead code from hashtab

### DIFF
--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -29,34 +29,10 @@
 
 #include "vim.h"
 
-#if 0
-# define HT_DEBUG	// extra checks for table consistency  and statistics
-
-static long hash_count_lookup = 0;	// count number of hashtab lookups
-static long hash_count_perturb = 0;	// count number of "misses"
-#endif
-
 // Magic value for algorithm that walks through the array.
 #define PERTURB_SHIFT 5
 
 static int hash_may_resize(hashtab_T *ht, int minitems);
-
-#if 0 // currently not used
-/*
- * Create an empty hash table.
- * Returns NULL when out of memory.
- */
-    hashtab_T *
-hash_create(void)
-{
-    hashtab_T *ht;
-
-    ht = ALLOC_ONE(hashtab_T);
-    if (ht != NULL)
-	hash_init(ht);
-    return ht;
-}
-#endif
 
 /*
  * Initialize an empty hash table.
@@ -262,23 +238,6 @@ hash_add_item(
     // When the space gets low may resize the array.
     return hash_may_resize(ht, 0);
 }
-
-#if 0  // not used
-/*
- * Overwrite hashtable item "hi" with "key".  "hi" must point to the item that
- * is to be overwritten.  Thus the number of items in the hashtable doesn't
- * change.
- * Although the key must be identical, the pointer may be different, thus it's
- * set anyway (the key is part of an item with that key).
- * The caller must take care of freeing the old item.
- * "hi" is invalid after this!
- */
-    void
-hash_set(hashitem_T *hi, char_u *key)
-{
-    hi->hi_key = key;
-}
-#endif
 
 /*
  * Remove item "hi" from  hashtable "ht".  "hi" must have been obtained with


### PR DESCRIPTION
## Summary
- drop unused debug counters and helpers from hashtab
- remove obsolete hash table creation and set helpers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8384e26388320b06c1a670c9c394a