### PR TITLE
Remove disabled THROW_TEST blocks from ex_eval

### DIFF
--- a/src/ex_eval.c
+++ b/src/ex_eval.c
@@ -52,18 +52,11 @@ static char	*get_end_emsg(cstack_T *cstack);
  * is an error exception.)  -  The macros can be defined as expressions checking
  * for a variable that is allowed to be changed during execution of a script.
  */
-#if 0
-// Expressions used for testing during the development phase.
-# define THROW_ON_ERROR		(!eval_to_number("$VIMNOERRTHROW"))
-# define THROW_ON_INTERRUPT	(!eval_to_number("$VIMNOINTTHROW"))
-# define THROW_TEST
-#else
 // Values used for the Vim release.
 # define THROW_ON_ERROR		TRUE
 # define THROW_ON_ERROR_TRUE
 # define THROW_ON_INTERRUPT	TRUE
 # define THROW_ON_INTERRUPT_TRUE
-#endif
 
 /*
  * When several errors appear in a row, setting "force_abort" is delayed until
@@ -223,18 +216,6 @@ cause_errthrow(
 	discard_current_exception();
     }
 
-#ifdef THROW_TEST
-    if (!THROW_ON_ERROR)
-    {
-	/*
-	 * Print error message immediately without searching for a matching
-	 * catch clause; just finally clauses are executed before the script
-	 * is terminated.
-	 */
-	return FALSE;
-    }
-    else
-#endif
     {
 	/*
 	 * Prepare the throw of an error exception, so that everything will
@@ -381,19 +362,6 @@ do_intthrow(cstack_T *cstack)
     if (!got_int || (trylevel == 0 && !did_throw))
 	return FALSE;
 
-#ifdef THROW_TEST	// avoid warning for condition always true
-    if (!THROW_ON_INTERRUPT)
-    {
-	/*
-	 * The interrupt aborts everything except for executing finally clauses.
-	 * Discard any user or error or interrupt exception currently being
-	 * thrown.
-	 */
-	if (did_throw)
-	    discard_current_exception();
-    }
-    else
-#endif
     {
 	/*
 	 * Throw an interrupt exception, so that everything will be aborted
@@ -1699,22 +1667,6 @@ do_throw(cstack_T *cstack)
 	cstack->cs_flags[idx] &= ~CSF_ACTIVE;
 	cstack->cs_exception[idx] = current_exception;
     }
-#if 0
-    // TODO: Add optimization below.  Not yet done because of interface
-    // problems to eval.c and ex_cmds2.c. (Servatius)
-    else
-    {
-	/*
-	 * There are no catch clauses to check or finally clauses to execute.
-	 * End the current script or function.  The exception will be rethrown
-	 * in the caller.
-	 */
-	if (getline_equal(eap->getline, eap->cookie, get_func_line))
-	    current_funccal->returned = TRUE;
-	elseif (eap->get_func_line == getsourceline)
-	    ((struct source_cookie *)eap->cookie)->finished = TRUE;
-    }
-#endif
 
     did_throw = TRUE;
 }


### PR DESCRIPTION
## Summary
- Drop `#if 0` test macros around `THROW_ON_*` and keep only release definitions.
- Remove obsolete, disabled optimization block in `ex_eval.c`.
- Eliminate remaining `THROW_TEST` conditional code.

## Testing
- `make -j4` *(fails: Makefile:1566: missing separator)*
- `gcc -c src/ex_eval.c -I src` *(fails: missing system headers and generated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b8385881c483208eeed43e067602b0