### PR TITLE
Remove git include from xdiff

### DIFF
--- a/src/xdiff/xinclude.h
+++ b/src/xdiff/xinclude.h
@@ -55,10 +55,6 @@
 #endif
 #include <string.h>
 #include <limits.h>
-// This include comes from git, so uncomment it
-#if 0
-#include "git-compat-util.h"
-#endif
 #include "xmacros.h"
 #include "xdiff.h"
 #include "xtypes.h"


### PR DESCRIPTION
## Summary
- remove unused git-compat-util include from xdiff header

## Testing
- `cargo build -p rust_xdiff`


------
https://chatgpt.com/codex/tasks/task_e_68b8385f03a08320bb7d44af473b065e