### PR TITLE
Remove obsolete printer dialog stub

### DIFF
--- a/src/hardcopy.c
+++ b/src/hardcopy.c
@@ -2340,24 +2340,6 @@ mch_print_init(
     struct prt_ps_encoding_S *p_mbenc_first;
     struct prt_ps_charset_S  *p_mbchar = NULL;
 
-#if 0
-    /*
-     * TODO:
-     * If "forceit" is false: pop up a dialog to select:
-     *	- printer name
-     *	- copies
-     *	- collated/uncollated
-     *	- duplex off/long side/short side
-     *	- paper size
-     *	- portrait/landscape
-     *	- font size
-     *
-     * If "forceit" is true: use the default printer and settings
-     */
-    if (forceit)
-	s_pd.Flags |= PD_RETURNDEFAULT;
-#endif
-
     /*
      * Set up font and encoding.
      */


### PR DESCRIPTION
## Summary
- drop dead `#if 0` placeholder for unimplemented printer dialog logic in `hardcopy.c`

## Testing
- `make -C testdir VIMPROG=/usr/bin/vim test_hardcopy` *(fails: Pattern 'Orientation: Landscape' does not match '%%Orientation: Portrait')*


------
https://chatgpt.com/codex/tasks/task_e_68b83865a4308320925db575f3757704