### PR TITLE
Remove stub text object cases

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -7207,11 +7207,6 @@ nv_object(
 		flag = current_quote(cap->oap, cap->count1, include,
 								  cap->nchar);
 		break;
-#if 0	// TODO
-	case 'S': // "aS" = a section
-	case 'f': // "af" = a filename
-	case 'u': // "au" = a URL
-#endif
 	default:
 		flag = FAIL;
 		break;


### PR DESCRIPTION
## Summary
- remove unused `#if 0` block for unimplemented section/filename/URL text objects

## Testing
- `cargo test -p rust_normal`


------
https://chatgpt.com/codex/tasks/task_e_68b8383df8488320895400edb7d9869e