### PR TITLE
Remove dead im_is_active assignment

### DIFF
--- a/src/gui_xim.c
+++ b/src/gui_xim.c
@@ -628,12 +628,6 @@ im_preedit_end_cb(GtkIMContext *context UNUSED, gpointer data UNUSED)
 	preedit_start_col = MAXCOL;
     xim_has_preediting = FALSE;
 
-#if 0
-    // Removal of this line suggested by Takuhiro Nishioka.  Fixes that IM was
-    // switched off unintentionally.  We now use preedit_is_active (added by
-    // SungHyun Nam).
-    im_is_active = FALSE;
-#endif
     preedit_is_active = FALSE;
     gui_update_cursor(TRUE, FALSE);
     im_show_info();


### PR DESCRIPTION
## Summary
- remove unused im_is_active assignment after ending XIM preedit

## Testing
- `auto/configure --with-features=huge --enable-gui=gtk3 --enable-xim --srcdir=.` *(fails: no GUI selected; xim has been disabled)*
- `make -j4` *(fails: Makefile:1566: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b83867c30483208e3b674c9a33d090