### PR TITLE
Add Rust file search and viminfo I/O with FFI

### DIFF
--- a/src/fileio_rs.h
+++ b/src/fileio_rs.h
@@ -4,12 +4,21 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-int readfile(const char *fname, const char *sfname, long from, long lines_to_skip,
-             long lines_to_read, void *eap, int flags);
-int writefile(const char *fname, const char *data, size_t len, int flags);
+    int readfile(const char *fname,
+                 const char *sfname,
+                 long from,
+                 long lines_to_skip,
+                 long lines_to_read,
+                 void *eap,
+                 int flags);
+    int writefile(const char *fname, const char *data, size_t len, int flags);
+    char *rs_findfile(const char *name, const char *path);
+    char *rs_read_viminfo(const char *path);
+    int rs_write_viminfo(const char *path, const char *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add `rs_findfile`, `rs_read_viminfo`, and `rs_write_viminfo` to rust_fileio
- expose new functions to C via `fileio_rs.h`
- exercise file search and viminfo roundtrip in tests

## Testing
- `cargo test -p rust_fileio`


------
https://chatgpt.com/codex/tasks/task_e_68b84c0ac25c832097917c87419cf43e