### PR TITLE
Introduce Rust UI rendering layer

### DIFF
--- a/rust_ui/Cargo.toml
+++ b/rust_ui/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_ui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_screen = { path = "../rust_screen" }

--- a/rust_ui/src/lib.rs
+++ b/rust_ui/src/lib.rs
@@ -1,0 +1,82 @@
+use rust_screen::ScreenBuffer;
+
+/// Trait implemented by rendering backends.
+pub trait Renderer {
+    fn draw_line(&mut self, row: usize, text: &str, attrs: &[u8]);
+}
+
+/// Renderer that prints to stdout, useful for CLI mode.
+pub struct CliRenderer;
+
+impl Renderer for CliRenderer {
+    fn draw_line(&mut self, row: usize, text: &str, _attrs: &[u8]) {
+        println!("{row}: {text}");
+    }
+}
+
+/// High level UI abstraction over [`ScreenBuffer`].
+pub struct Ui<R: Renderer> {
+    screen: ScreenBuffer,
+    pub renderer: R,
+}
+
+impl<R: Renderer> Ui<R> {
+    pub fn new(width: usize, height: usize, renderer: R) -> Self {
+        Self {
+            screen: ScreenBuffer::new(width, height),
+            renderer,
+        }
+    }
+
+    pub fn draw_text(&mut self, row: usize, col: usize, text: &str, attr: u8) {
+        self.screen.draw_text(row, col, text, attr);
+    }
+
+    pub fn highlight(&mut self, row: usize, col: usize, len: usize, attr: u8) {
+        self.screen.highlight_range(row, col, len, attr);
+    }
+
+    pub fn format_text(&self, text: &str, width: usize) -> String {
+        ScreenBuffer::format_text(text, width)
+    }
+
+    pub fn flush(&mut self) {
+        for diff in self.screen.flush_diff() {
+            self.renderer.draw_line(diff.row, &diff.text, &diff.attrs);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct CollectRenderer(pub Vec<String>);
+
+    impl Renderer for CollectRenderer {
+        fn draw_line(&mut self, _row: usize, text: &str, _attrs: &[u8]) {
+            self.0.push(text.to_string());
+        }
+    }
+
+    #[test]
+    fn cli_and_gui_render() {
+        let mut ui_cli = Ui::new(10, 2, CollectRenderer(Vec::new()));
+        ui_cli.draw_text(0, 0, "hi", 1);
+        ui_cli.flush();
+        assert_eq!(ui_cli.renderer.0[0].trim_end(), "hi");
+
+        let mut ui_gui = Ui::new(5, 1, CollectRenderer(Vec::new()));
+        ui_gui.draw_text(0, 0, "ab", 1);
+        ui_gui.highlight(0, 0, 2, 2);
+        ui_gui.flush();
+        assert_eq!(ui_gui.renderer.0[0], "ab   ");
+    }
+
+    #[test]
+    fn formatting() {
+        let ui = Ui::new(5, 1, CollectRenderer(Vec::new()));
+        assert_eq!(ui.format_text("abc", 5), "abc  ");
+        assert_eq!(ui.format_text("abcdef", 3), "abc");
+    }
+}

--- a/src/screen.c
+++ b/src/screen.c
@@ -2044,7 +2044,7 @@ screen_char(unsigned off, int row, int col)
             save_buf[0] = ScreenLines[off];
             save_buf[1] = NUL;
         }
-        rs_screen_draw_text(rs_screen_buf, row, col, (char *)save_buf, (uint8_t)attr);
+        rs_screen_draw_formatted(rs_screen_buf, row, col, (char *)save_buf, 1, (uint8_t)attr);
     }
 
     screen_cur_col++;

--- a/src/screen_rs.h
+++ b/src/screen_rs.h
@@ -12,6 +12,7 @@ typedef struct ScreenBuffer ScreenBuffer;
 ScreenBuffer *rs_screen_new(int width, int height);
 void rs_screen_free(ScreenBuffer *buf);
 void rs_screen_draw_text(ScreenBuffer *buf, int row, int col, const char *text, uint8_t attr);
+void rs_screen_draw_formatted(ScreenBuffer *buf, int row, int col, const char *text, int width, uint8_t attr);
 void rs_screen_clear_line(ScreenBuffer *buf, int row, uint8_t attr);
 void rs_screen_clear(ScreenBuffer *buf, uint8_t attr);
 void rs_screen_highlight(ScreenBuffer *buf, int row, int col, int len, uint8_t attr);


### PR DESCRIPTION
## Summary
- add text formatting helpers and formatted drawing in `rust_screen`
- implement new `rust_ui` crate with generic rendering API
- route screen updates through formatted draw call in C code

## Testing
- `cargo test -p rust_screen`
- `cargo test -p rust_ui`


------
https://chatgpt.com/codex/tasks/task_e_68b84c0ee48083209aee96157748833b