### PR TITLE
Add clipboard utilities to GUI backend crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ exclude = [
     "rust/terminal",
     "rust_alloc",
     "rust_excmd",
-    "rust_clipboard",
     "rust_float",
     "rust_blowfish",
 ]

--- a/rust_clipboard/src/lib.rs
+++ b/rust_clipboard/src/lib.rs
@@ -31,6 +31,20 @@ fn get_clipboard_text() -> Option<String> {
     ctx.get_contents().ok()
 }
 
+/// Set the clipboard contents to the provided text.
+///
+/// This safe wrapper is intended for use by other Rust crates within the
+/// workspace.  It transparently calls the OS specific implementation selected
+/// above.
+pub fn set_string(text: &str) -> Result<(), ()> {
+    set_clipboard_text(text)
+}
+
+/// Retrieve the current clipboard contents as a `String` if available.
+pub fn get_string() -> Option<String> {
+    get_clipboard_text()
+}
+
 #[no_mangle]
 pub extern "C" fn rs_clipboard_set(data: *const c_char, len: usize) -> c_int {
     if data.is_null() {

--- a/rust_gui_gtk/Cargo.toml
+++ b/rust_gui_gtk/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 rust_gui_core = { path = "../rust_gui_core" }
+rust_clipboard = { path = "../rust_clipboard" }
 

--- a/rust_gui_gtk/src/lib.rs
+++ b/rust_gui_gtk/src/lib.rs
@@ -1,5 +1,6 @@
 use rust_gui_core::backend::{GuiBackend, GuiEvent};
 use std::collections::VecDeque;
+use rust_clipboard;
 
 /// Backend implementation for GTK environments on Unix.
 /// This sample backend records drawing operations and stores events
@@ -34,6 +35,16 @@ impl GuiBackend for GtkBackend {
     }
 }
 
+/// Set the system clipboard text through the GTK backend.
+pub fn clipboard_set(text: &str) -> Result<(), ()> {
+    rust_clipboard::set_string(text)
+}
+
+/// Retrieve text from the system clipboard using the GTK backend.
+pub fn clipboard_get() -> Option<String> {
+    rust_clipboard::get_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -45,5 +56,11 @@ mod tests {
         backend.push_event(GuiEvent::Key('a'));
         assert_eq!(backend.drawn, vec!["hi".to_string()]);
         assert_eq!(backend.poll_event(), Some(GuiEvent::Key('a')));
+    }
+
+    #[test]
+    fn clipboard_roundtrip() {
+        clipboard_set("gtk clipboard").unwrap();
+        assert_eq!(clipboard_get().as_deref(), Some("gtk clipboard"));
     }
 }

--- a/rust_gui_w32/Cargo.toml
+++ b/rust_gui_w32/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 
 [dependencies]
 rust_gui_core = { path = "../rust_gui_core" }
+rust_clipboard = { path = "../rust_clipboard" }
 

--- a/rust_gui_w32/src/lib.rs
+++ b/rust_gui_w32/src/lib.rs
@@ -1,5 +1,6 @@
 use rust_gui_core::backend::{GuiBackend, GuiEvent};
 use std::collections::VecDeque;
+use rust_clipboard;
 
 /// Minimal Windows backend.  Real drawing is delegated to the platform APIs
 /// but for now these methods record actions for testing purposes.
@@ -30,6 +31,16 @@ impl GuiBackend for W32Backend {
     }
 }
 
+/// Set the Windows clipboard contents to `text`.
+pub fn clipboard_set(text: &str) -> Result<(), ()> {
+    rust_clipboard::set_string(text)
+}
+
+/// Retrieve text from the Windows clipboard if available.
+pub fn clipboard_get() -> Option<String> {
+    rust_clipboard::get_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,5 +52,11 @@ mod tests {
         backend.push_event(GuiEvent::Click { x: 1, y: 2 });
         assert_eq!(backend.drawn, vec!["hello".to_string()]);
         assert_eq!(backend.poll_event(), Some(GuiEvent::Click { x: 1, y: 2 }));
+    }
+
+    #[test]
+    fn clipboard_roundtrip() {
+        clipboard_set("w32 clipboard").unwrap();
+        assert_eq!(clipboard_get().as_deref(), Some("w32 clipboard"));
     }
 }


### PR DESCRIPTION
## Summary
- integrate `rust_clipboard` crate into workspace
- expose clipboard helpers in GTK and Windows GUI backends
- add tests for clipboard roundtrips

## Testing
- `cargo test --manifest-path rust_clipboard/Cargo.toml`
- `cargo test --manifest-path rust_gui_gtk/Cargo.toml`
- `cargo test --manifest-path rust_gui_w32/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b84c0fe4c88320bd9bc3b6aa121d7d