### PR TITLE
Add client-server networking and OS API crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_clientserver"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
@@ -1790,6 +1797,13 @@ name = "rust_os_amiga"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust_os_api"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
 ]
 
 [[package]]

--- a/rust_clientserver/Cargo.toml
+++ b/rust_clientserver/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_clientserver"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["net", "io-util", "rt", "macros"] }

--- a/rust_clientserver/src/lib.rs
+++ b/rust_clientserver/src/lib.rs
@@ -1,0 +1,54 @@
+use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::net::SocketAddr;
+
+/// Start a simple asynchronous TCP server that echoes received data.
+pub async fn start_server(addr: &SocketAddr) -> tokio::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    loop {
+        let (mut socket, _) = listener.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            if let Ok(n) = socket.read(&mut buf).await {
+                if n > 0 {
+                    let _ = socket.write_all(&buf[..n]).await;
+                }
+            }
+        });
+    }
+}
+
+/// Connect to the server.
+pub async fn connect(addr: &SocketAddr) -> tokio::io::Result<TcpStream> {
+    TcpStream::connect(addr).await
+}
+
+/// Send a debug command to the connected stream.
+pub async fn send_debug_command(stream: &mut TcpStream, cmd: &str) -> tokio::io::Result<()> {
+    stream.write_all(cmd.as_bytes()).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn basic_flow() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    let n = sock.read(&mut buf).await.unwrap();
+                    sock.write_all(&buf[..n]).await.unwrap();
+                });
+            }
+        });
+        let mut stream = connect(&addr).await.unwrap();
+        send_debug_command(&mut stream, "ping").await.unwrap();
+    }
+}

--- a/rust_os_api/Cargo.toml
+++ b/rust_os_api/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_os_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+crossterm = "0.27"

--- a/rust_os_api/src/lib.rs
+++ b/rust_os_api/src/lib.rs
@@ -1,0 +1,32 @@
+use crossterm::{cursor, terminal, ExecutableCommand};
+
+use std::io::{stdout, Write, Result};
+
+/// Move the cursor to the given position.
+pub fn move_cursor_to(x: u16, y: u16) -> Result<()> {
+    stdout().execute(cursor::MoveTo(x, y))?;
+    Ok(())
+}
+
+/// Clear the entire screen.
+pub fn clear_screen() -> Result<()> {
+    stdout().execute(terminal::Clear(terminal::ClearType::All))?;
+    Ok(())
+}
+
+/// Play a simple beep sound using the BEL character.
+pub fn play_beep() -> std::io::Result<()> {
+    let mut out = stdout();
+    out.write_all(b"\x07")?;
+    out.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn beep_works() {
+        play_beep().unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add `rust_clientserver` crate providing async TCP server/client and debug command helpers
- add `rust_os_api` crate wrapping terminal control and a simple beep

## Testing
- `cargo test -p rust_clientserver`
- `cargo test -p rust_os_api`


------
https://chatgpt.com/codex/tasks/task_e_68b84c1086f083209ba6f4a95d30b878