### PR TITLE
Integrate Vim9 parser and execution in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,11 +2029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_vim9"
+version = "0.1.0"
+dependencies = [
+ "rust_vim9compile",
+]
+
+[[package]]
 name = "rust_vim9cmds"
 version = "0.1.0"
 dependencies = [
  "rust_eval",
- "rust_vim9compile",
+ "rust_vim9",
 ]
 
 [[package]]

--- a/rust_vim9/Cargo.toml
+++ b/rust_vim9/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_vim9"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "rust_vim9"
+crate-type = ["rlib"]
+
+[dependencies]
+rust_vim9compile = { path = "../rust_vim9compile" }

--- a/rust_vim9/src/lib.rs
+++ b/rust_vim9/src/lib.rs
@@ -1,0 +1,29 @@
+pub use rust_vim9compile::{
+    compile, eval_bool_expr, eval_expr, execute, parse_line, Vim9Instr, Vim9Program, Vim9Type,
+};
+
+/// Execute a Vim9 script consisting of multiple lines.
+/// Each line is parsed, compiled and executed independently.
+/// Returns a vector with the result of each line.
+pub fn execute_script(script: &str) -> Vec<i64> {
+    script
+        .lines()
+        .filter_map(|line| {
+            let ast = parse_line(line)?;
+            let prog = compile(&ast);
+            Some(execute(&prog))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn script_executes_lines() {
+        let script = "1 + 2\n3 + 4\n1 < 2";
+        let result = execute_script(script);
+        assert_eq!(result, vec![3, 7, 1]);
+    }
+}

--- a/rust_vim9/tests/vim9_script.rs
+++ b/rust_vim9/tests/vim9_script.rs
@@ -1,0 +1,8 @@
+use rust_vim9::execute_script;
+
+#[test]
+fn runs_simple_script() {
+    let script = "echo 1 + 2\n3 + 4";
+    let result = execute_script(script);
+    assert_eq!(result, vec![3, 7]);
+}

--- a/rust_vim9cmds/Cargo.toml
+++ b/rust_vim9cmds/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
 rust_eval = { path = "../rust_eval" }
-rust_vim9compile = { path = "../rust_vim9compile" }
+rust_vim9 = { path = "../rust_vim9" }

--- a/rust_vim9cmds/src/lib.rs
+++ b/rust_vim9cmds/src/lib.rs
@@ -2,7 +2,7 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 
 use rust_eval::{typval_T, ValUnion, Vartype};
-use rust_vim9compile::{eval_bool_expr, eval_expr};
+use rust_vim9::{eval_bool_expr, eval_expr};
 
 pub mod cmds {
     use super::*;

--- a/rust_vim9cmds/tests/ffi.rs
+++ b/rust_vim9cmds/tests/ffi.rs
@@ -1,9 +1,7 @@
 use std::ffi::CString;
 
-use rust_vim9cmds::{
-    vim9_eval_bool, vim9_eval_int, vim9_exec_rs, vim9_declare_error_rs,
-};
 use rust_eval::{typval_T, ValUnion, Vartype};
+use rust_vim9cmds::{vim9_declare_error_rs, vim9_eval_bool, vim9_eval_int, vim9_exec_rs};
 
 #[test]
 fn ffi_eval_bool() {
@@ -29,7 +27,9 @@ fn ffi_exec_expression() {
     };
     let ok = vim9_exec_rs(expr.as_ptr(), &mut out as *mut typval_T);
     assert!(ok);
-    unsafe { assert_eq!(out.vval.v_number, 9); }
+    unsafe {
+        assert_eq!(out.vval.v_number, 9);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `rust_vim9` crate exposing Vim9 parser, compiler and executor in Rust
- route `rust_vim9cmds` through unified crate
- add multi-line Vim9 script tests

## Testing
- `cargo test -p rust_vim9 -p rust_vim9cmds -p rust_vim9compile`


------
https://chatgpt.com/codex/tasks/task_e_68b84c122d708320997377c8c7b544c1