### PR TITLE
Implement zip crypt in rust_crypto_zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,15 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "blowfish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,15 +177,6 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher 0.4.4",
-]
 
 [[package]]
 name = "cbindgen"
@@ -491,16 +473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1e6e5492f8f0830c37f301f6349e0dac8b2466e4fe89eef90e9eef906cd046"
-dependencies = [
- "cipher 0.4.4",
- "crypto-common",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,7 +753,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -1497,9 +1468,6 @@ dependencies = [
 name = "rust_crypto_zip"
 version = "0.1.0"
 dependencies = [
- "aes",
- "cbc",
- "crypto",
  "zip",
 ]
 

--- a/rust_crypto_zip/Cargo.toml
+++ b/rust_crypto_zip/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-crypto = { version = "0.5", features = ["cipher"] }
-aes = "0.8"
-cbc = "0.1"
 zip = "4.6.1"
 
 [lib]

--- a/src/rust_crypto_zip.h
+++ b/src/rust_crypto_zip.h
@@ -4,13 +4,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Encrypt input buffer into output using AES-128-CBC with PKCS#7 padding.
+// Encrypt input buffer into output using the traditional Zip crypto algorithm.
 // Returns number of bytes written to output or 0 on error.
 size_t rs_encrypt(const uint8_t *input, size_t input_len,
                   const uint8_t *key, size_t key_len,
                   uint8_t *output, size_t output_len);
 
-// Decrypt input buffer into output using AES-128-CBC with PKCS#7 padding.
+// Decrypt input buffer into output using the traditional Zip crypto algorithm.
 // Returns number of bytes written to output or 0 on error.
 size_t rs_decrypt(const uint8_t *input, size_t input_len,
                   const uint8_t *key, size_t key_len,


### PR DESCRIPTION
## Summary
- replace AES logic with classic Zip crypto in `rust_crypto_zip`
- expose Zip crypto through FFI and adjust header
- remove unused AES dependencies

## Testing
- `cargo test -p rust_crypto_zip`


------
https://chatgpt.com/codex/tasks/task_e_68b84c124e488320bcbcbc3369eb1b2f