### PR TITLE
Port version generation to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_version"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "rust_vim9cmds"
 version = "0.1.0"
 dependencies = [

--- a/rust_version/Cargo.toml
+++ b/rust_version/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust_version"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[lib]
+name = "rust_version"
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+once_cell = "1"
+
+[build-dependencies]

--- a/rust_version/build.rs
+++ b/rust_version/build.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+fn main() {
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+    let build_date = Command::new("date")
+        .args(["-u", "+%Y-%m-%d %H:%M:%S"])
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=BUILD_DATE={}", build_date);
+}

--- a/rust_version/include/rust_version.h
+++ b/rust_version/include/rust_version.h
@@ -1,0 +1,15 @@
+#ifndef RUST_VERSION_H
+#define RUST_VERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *rust_short_version(void);
+const char *rust_long_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUST_VERSION_H

--- a/rust_version/src/lib.rs
+++ b/rust_version/src/lib.rs
@@ -1,0 +1,25 @@
+use once_cell::sync::Lazy;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+static SHORT_VERSION: Lazy<CString> = Lazy::new(|| {
+    let ver = env!("CARGO_PKG_VERSION");
+    let git = env!("GIT_HASH");
+    CString::new(format!("{} ({})", ver, git)).unwrap()
+});
+
+static LONG_VERSION: Lazy<CString> = Lazy::new(|| {
+    let ver = env!("CARGO_PKG_VERSION");
+    let date = env!("BUILD_DATE");
+    CString::new(format!("Vim {} built {}", ver, date)).unwrap()
+});
+
+#[no_mangle]
+pub extern "C" fn rust_short_version() -> *const c_char {
+    SHORT_VERSION.as_ptr()
+}
+
+#[no_mangle]
+pub extern "C" fn rust_long_version() -> *const c_char {
+    LONG_VERSION.as_ptr()
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1444,6 +1444,8 @@ RUST_SHA256_DIR = ../rust_sha256
 RUST_SHA256_LIB = $(RUST_SHA256_DIR)/target/release/librust_sha256.a
 RUST_XCMDSRV_DIR = ../rust_xcmdsrv
 RUST_XCMDSRV_LIB = $(RUST_XCMDSRV_DIR)/target/release/librust_xcmdsrv.a
+RUST_VERSION_DIR = ../rust_version
+RUST_VERSION_LIB = $(RUST_VERSION_DIR)/target/release/librust_version.a
 
 # Additional Rust crates used by this configuration
 RUST_CHANGE_DIR = ../rust_change
@@ -1456,6 +1458,7 @@ EXTRA_IPATHS += -I$(RUST_ARABIC_DIR)/include
 EXTRA_IPATHS += -I$(RUST_BEVAL_DIR)/include
 EXTRA_IPATHS += -I$(RUST_VIM9_DIR)/include
 EXTRA_IPATHS += -I$(RUST_TAG_DIR)/include
+EXTRA_IPATHS += -I$(RUST_VERSION_DIR)/include
 
 # Note: MZSCHEME_LIBS must come before LIBS, because LIBS adds -lm which is
 # needed by racket.
@@ -1499,12 +1502,13 @@ ALL_LIBS = \
            $(RUST_EVALVARS_LIB) \
            $(RUST_SCREEN_LIB) \
            $(RUST_SIGN_LIB) \
-           $(RUST_BLOB_LIB) \
-           $(RUST_SHA256_LIB) \
-           $(RUST_XCMDSRV_LIB) \
-           $(LUA_LIBS) \
-           $(PERL_LIBS) \
-           $(PYTHON_LIBS) \
+            $(RUST_BLOB_LIB) \
+            $(RUST_SHA256_LIB) \
+            $(RUST_XCMDSRV_LIB) \
+            $(RUST_VERSION_LIB) \
+            $(LUA_LIBS) \
+            $(PERL_LIBS) \
+            $(PYTHON_LIBS) \
            $(PYTHON3_LIBS) \
            $(TCL_LIBS) \
 	   $(RUBY_LIBS) \
@@ -1651,6 +1655,9 @@ $(RUST_SHA256_LIB):
 
 $(RUST_XCMDSRV_LIB):
        cd $(RUST_XCMDSRV_DIR) && CARGO_TARGET_DIR=target cargo build --release
+
+$(RUST_VERSION_LIB):
+	cd $(RUST_VERSION_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 # Additional Rust libraries providing rs_* APIs used across the C codebase
 RUST_ARGLIST_DIR = ../rust_arglist
@@ -2311,7 +2318,7 @@ CCC = $(CCC_NF) $(ALL_CFLAGS)
 
 # Link the target for normal use or debugging.
 # A shell script is used to try linking without unnecessary libraries.
-$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_BUFWRITE_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVALFUNC_STUBS_LIB) $(RUST_EVAL_LIB) $(RUST_VIM9_LIB) $(RUST_EXCMD_LIB) $(RUST_CMDHIST_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_TAG_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB)
+$(VIMTARGET): auto/config.mk $(OBJ) objects/version.o $(RUST_MEM_LIB) $(RUST_REGEX_LIB) $(SRC_RUST_REGEX_LIB) $(RUST_BUFFER_LIB) $(RUST_BUFWRITE_LIB) $(RUST_CHANNEL_LIB) $(RUST_GUI_LIB) $(RUST_EVALFUNC_LIB) $(RUST_EVALFUNC_STUBS_LIB) $(RUST_EVAL_LIB) $(RUST_VIM9_LIB) $(RUST_EXCMD_LIB) $(RUST_CMDHIST_LIB) $(RUST_ARABIC_LIB) $(RUST_BEVAL_LIB) $(RUST_TAG_LIB) $(RUST_ALLOC_LIB) $(RUST_BLOB_LIB) $(RUST_SHA256_LIB) $(RUST_VERSION_LIB)
 	@$(BUILD_DATE_MSG)
     @LINK="$(PURIFY) $(SHRPENV) $(CClink) $(ALL_LIB_DIRS) $(LDFLAGS) \
 		-o $(VIMTARGET) objects/*.o $(ALL_LIBS)" \

--- a/src/version.c
+++ b/src/version.c
@@ -24,70 +24,20 @@
  */
 
 #include "version.h"
+#include "../rust_version/include/rust_version.h"
 
-char		*Version = VIM_VERSION_SHORT;
-static char	*mediumVersion = VIM_VERSION_MEDIUM;
-
-#if defined(HAVE_DATE_TIME) || defined(PROTO)
-# if (defined(VMS) && defined(VAXC)) || defined(PROTO)
-char	longVersion[sizeof(VIM_VERSION_LONG_DATE) + sizeof(__DATE__)
-						      + sizeof(__TIME__) + 3];
+char            *Version = NULL;
+static char     *mediumVersion = VIM_VERSION_MEDIUM;
+char            *longVersion = NULL;
 
     void
 init_longVersion(void)
 {
-    /*
-     * Construct the long version string.  Necessary because
-     * VAX C can't concatenate strings in the preprocessor.
-     */
-    strcpy(longVersion, VIM_VERSION_LONG_DATE);
-#ifdef BUILD_DATE
-    strcat(longVersion, BUILD_DATE);
-#else
-    strcat(longVersion, __DATE__);
-    strcat(longVersion, " ");
-    strcat(longVersion, __TIME__);
-#endif
-    strcat(longVersion, ")");
-}
-
-# else
-char	*longVersion = NULL;
-
-    void
-init_longVersion(void)
-{
-    if (longVersion != NULL)
-	return;
-
-#ifdef BUILD_DATE
-    char *date_time = BUILD_DATE;
-#else
-    char *date_time = __DATE__ " " __TIME__;
-#endif
-    char *msg = _("%s (%s, compiled %s)");
-    size_t len = strlen(msg)
-	+ strlen(VIM_VERSION_LONG_ONLY)
-	+ strlen(VIM_VERSION_DATE_ONLY)
-	+ strlen(date_time);
-
-    longVersion = alloc(len);
+    if (Version == NULL)
+        Version = (char *)rust_short_version();
     if (longVersion == NULL)
-	longVersion = VIM_VERSION_LONG;
-    else
-	vim_snprintf(longVersion, len, msg,
-		VIM_VERSION_LONG_ONLY, VIM_VERSION_DATE_ONLY, date_time);
+        longVersion = (char *)rust_long_version();
 }
-# endif
-#else
-char	*longVersion = VIM_VERSION_LONG;
-
-    void
-init_longVersion(void)
-{
-    // nothing to do
-}
-#endif
 
 static char *(features[]) =
 {


### PR DESCRIPTION
## Summary
- generate build-time version strings in new `rust_version` crate
- call Rust version helpers from C version module
- link `rust_version` in build system

## Testing
- `cargo test -p rust_version`


------
https://chatgpt.com/codex/tasks/task_e_68b84c13ccb483208793bf9aad6f3663