### PR TITLE
Remove Rust feature toggles from dict and list

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -13,10 +13,6 @@
 
 #include "vim.h"
 
-#ifdef FEAT_RUST_DICT
-extern dict_T *rust_dict_new(void);
-extern void rust_dict_free(dict_T *d);
-#endif
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
@@ -32,9 +28,6 @@ static dict_T		*first_dict = NULL;
     dict_T *
 dict_alloc(void)
 {
-#ifdef FEAT_RUST_DICT
-    return rust_dict_new();
-#else
     dict_T *d;
 
     d = ALLOC_CLEAR_ONE(dict_T);
@@ -54,7 +47,6 @@ dict_alloc(void)
     d->dv_refcount = 0;
     d->dv_copyID = 0;
     return d;
-#endif
 }
 
 /*
@@ -170,15 +162,11 @@ dict_free_dict(dict_T *d)
 static void
 dict_free(dict_T *d)
 {
-#ifdef FEAT_RUST_DICT
-    rust_dict_free(d);
-#else
     if (!in_free_unref_items)
     {
         dict_free_contents(d);
         dict_free_dict(d);
     }
-#endif
 }
 
 /*

--- a/src/list.c
+++ b/src/list.c
@@ -13,10 +13,6 @@
 
 #include "vim.h"
 
-#ifdef FEAT_RUST_LIST
-extern list_T *rust_list_new(void);
-extern void rust_list_free(list_T *l);
-#endif
 
 #if defined(FEAT_EVAL) || defined(PROTO)
 
@@ -91,16 +87,12 @@ list_init(list_T *l)
     list_T *
 list_alloc(void)
 {
-#ifdef FEAT_RUST_LIST
-    return rust_list_new();
-#else
     list_T  *l;
 
     l = ALLOC_CLEAR_ONE(list_T);
     if (l != NULL)
         list_init(l);
     return l;
-#endif
 }
 
 /*
@@ -306,15 +298,11 @@ list_free_items(int copyID)
 void
 list_free(list_T *l)
 {
-#ifdef FEAT_RUST_LIST
-    rust_list_free(l);
-#else
     if (in_free_unref_items)
         return;
 
     list_free_contents(l);
     list_free_list(l);
-#endif
 }
 
 /*


### PR DESCRIPTION
## Summary
- drop FEAT_RUST_DICT and FEAT_RUST_LIST conditionals
- always use C implementations for dict and list allocation/free

## Testing
- `make -C src dict.o list.o` *(fails: Makefile:1572: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_68b850dfcf588320a0b6aabbf637034f