### PR TITLE
Move message formatting and output to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +179,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.9.4",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend 0.3.11",
+ "wayland-client 0.31.11",
 ]
 
 [[package]]
@@ -331,10 +366,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "copypasta"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a"
+dependencies = [
+ "clipboard-win",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "smithay-clipboard",
+ "x11-clipboard",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -483,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +696,16 @@ checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
+dependencies = [
+ "rustix 1.0.8",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1066,6 +1155,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1357,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1276,6 +1478,15 @@ name = "quick-xml"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -1465,6 +1676,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_clipboard"
+version = "0.1.0"
+dependencies = [
+ "copypasta",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
@@ -1611,6 +1829,7 @@ version = "0.1.0"
 name = "rust_gui_gtk"
 version = "0.1.0"
 dependencies = [
+ "rust_clipboard",
  "rust_gui_core",
 ]
 
@@ -1632,6 +1851,7 @@ dependencies = [
 name = "rust_gui_w32"
 version = "0.1.0"
 dependencies = [
+ "rust_clipboard",
  "rust_gui_core",
 ]
 
@@ -1640,7 +1860,7 @@ name = "rust_gui_x11"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",
- "x11rb",
+ "x11rb 0.11.1",
 ]
 
 [[package]]
@@ -1740,6 +1960,7 @@ name = "rust_message"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "tempfile",
 ]
 
 [[package]]
@@ -2001,6 +2222,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_ui"
+version = "0.1.0"
+dependencies = [
+ "rust_screen",
+]
+
+[[package]]
 name = "rust_undo"
 version = "0.1.0"
 dependencies = [
@@ -2038,7 +2266,7 @@ version = "0.1.0"
 name = "rust_wayland"
 version = "0.1.0"
 dependencies = [
- "wayland-client",
+ "wayland-client 0.30.2",
 ]
 
 [[package]]
@@ -2246,6 +2474,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.9.4",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror",
+ "wayland-backend 0.3.11",
+ "wayland-client 0.31.11",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner 0.31.7",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-backend 0.3.11",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2596,26 @@ name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "time"
@@ -2591,7 +2875,21 @@ dependencies = [
  "nix 0.26.4",
  "scoped-tls",
  "smallvec",
- "wayland-sys",
+ "wayland-sys 0.30.1",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.0.8",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys 0.31.7",
 ]
 
 [[package]]
@@ -2602,8 +2900,67 @@ checksum = "489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8"
 dependencies = [
  "bitflags 1.3.2",
  "nix 0.26.4",
- "wayland-backend",
- "wayland-scanner",
+ "wayland-backend 0.1.2",
+ "wayland-scanner 0.30.1",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+dependencies = [
+ "bitflags 2.9.4",
+ "rustix 1.0.8",
+ "wayland-backend 0.3.11",
+ "wayland-scanner 0.31.7",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.9.4",
+ "cursor-icon",
+ "wayland-backend 0.3.11",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+dependencies = [
+ "rustix 1.0.8",
+ "wayland-client 0.31.11",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+dependencies = [
+ "bitflags 2.9.4",
+ "wayland-backend 0.3.11",
+ "wayland-client 0.31.11",
+ "wayland-scanner 0.31.7",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.9.4",
+ "wayland-backend 0.3.11",
+ "wayland-client 0.31.11",
+ "wayland-protocols",
+ "wayland-scanner 0.31.7",
 ]
 
 [[package]]
@@ -2613,7 +2970,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.28.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.37.5",
  "quote",
 ]
 
@@ -2625,6 +2993,18 @@ checksum = "96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06"
 dependencies = [
  "dlib",
  "log",
+ "pkg-config",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
  "pkg-config",
 ]
 
@@ -2961,16 +3341,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
+name = "x11-clipboard"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3"
+dependencies = [
+ "libc",
+ "x11rb 0.13.2",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3c79412dd91bae7a7366b8ad1565a85e35dd049affc3a6a2c549e97419617"
 dependencies = [
- "gethostname",
+ "gethostname 0.2.3",
  "nix 0.25.1",
  "winapi",
  "winapi-wsapoll",
- "x11rb-protocol",
+ "x11rb-protocol 0.11.1",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname 1.0.2",
+ "rustix 1.0.8",
+ "x11rb-protocol 0.13.2",
 ]
 
 [[package]]
@@ -2981,6 +3382,24 @@ checksum = "e0b1513b141123073ce54d5bb1d33f801f17508fbd61e02060b1214e96d39c56"
 dependencies = [
  "nix 0.25.1",
 ]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "zeroize"

--- a/rust_message/Cargo.toml
+++ b/rust_message/Cargo.toml
@@ -8,3 +8,6 @@ crate-type = ["staticlib"]
 
 [dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/message.c
+++ b/src/message.c
@@ -3,332 +3,304 @@
 #include <stdio.h>
 #include <string.h>
 
-// Bridge to Rust message queue if available.
+// FFI bridge to Rust message handling
 extern void rs_queue_message(char *msg, int level);
 
-static void vprint_prefixed(const char *prefix, const char *fmt, va_list ap)
+static void
+send_formatted(int level, const char *fmt, va_list ap)
 {
-    if (prefix != NULL) fputs(prefix, stderr);
-    vfprintf(stderr, fmt, ap);
-    fputc('\n', stderr);
+    char buf[2048];
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    rs_queue_message(buf, level);
 }
 
-static void bridge_info(const char *s)
-{
-    if (s) rs_queue_message((char *)s, 0);
-}
-
-static void bridge_warn(const char *s)
-{
-    if (s) rs_queue_message((char *)s, 1);
-}
-
-static void bridge_error(const char *s)
-{
-    if (s) rs_queue_message((char *)s, 2);
-}
-
-int smsg(const char *fmt, ...)
+int
+smsg(const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    char buf[2048];
-    vsnprintf(buf, sizeof(buf), fmt, ap);
-    fputs(buf, stderr);
-    fputc('\n', stderr);
-    bridge_info(buf);
+    send_formatted(0, fmt, ap);
     va_end(ap);
     return 0;
 }
 
-int semsg(const char *fmt, ...)
+int
+semsg(const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    char buf[2048];
-    vsnprintf(buf, sizeof(buf), fmt, ap);
-    fputs("E: ", stderr);
-    fputs(buf, stderr);
-    fputc('\n', stderr);
-    bridge_error(buf);
+    send_formatted(2, fmt, ap);
     va_end(ap);
     return 0;
 }
 
-void siemsg(const char *fmt, ...)
+void
+siemsg(const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    char buf[2048];
-    vsnprintf(buf, sizeof(buf), fmt, ap);
-    fputs("E: ", stderr);
-    fputs(buf, stderr);
-    fputc('\n', stderr);
-    bridge_error(buf);
+    send_formatted(2, fmt, ap);
     va_end(ap);
 }
 
-void emsg(const char_u *msg)
+void
+emsg(const char_u *msg)
 {
-    if (msg == NULL) return;
-    fprintf(stderr, "E: %s\n", (const char *)msg);
-    bridge_error((const char *)msg);
+    if (msg != NULL)
+        rs_queue_message((char *)msg, 2);
 }
 
-void msg_putchar(int c)
+void
+msg_putchar(int c)
 {
-    fputc(c, stderr);
+    char buf[2] = { (char)c, '\0' };
+    rs_queue_message(buf, 0);
 }
 
-void msg_puts(const char *s)
+void
+msg_puts(const char *s)
 {
-    if (s != NULL) {
-        fputs(s, stderr);
-        bridge_info(s);
-    }
+    if (s != NULL)
+        rs_queue_message((char *)s, 0);
 }
 
-void msg_puts_attr(char *s, int attr)
+void
+msg_puts_attr(char *s, int attr)
 {
     (void)attr;
     msg_puts(s);
 }
 
-void msg_puts_title(const char *s)
+void
+msg_puts_title(const char *s)
 {
-    if (s != NULL) {
-        fprintf(stderr, "%s\n", s);
-        bridge_info(s);
-    }
+    if (s != NULL)
+        rs_queue_message((char *)s, 0);
 }
 
-void msg_outtrans(char_u *s)
+void
+msg_outtrans(char_u *s)
 {
-    if (s != NULL) {
-        fputs((const char *)s, stderr);
-        bridge_info((const char *)s);
-    }
+    if (s != NULL)
+        rs_queue_message((char *)s, 0);
 }
 
-void msg_clr_eos(void) {}
-void msg_start(void) {}
-void msg_end(void) {}
+int
+msg_outtrans_attr(char_u *s, int attr)
+{
+    (void)attr;
+    if (s == NULL)
+        return 0;
+    rs_queue_message((char *)s, 0);
+    return (int)strlen((const char *)s);
+}
 
-int message_filtered(char_u *s)
+char *
+msg_outtrans_long_attr(char *s, int attr)
+{
+    (void)attr;
+    if (s != NULL)
+        rs_queue_message(s, 0);
+    return s;
+}
+
+void
+give_warning(char_u *msg, int hl)
+{
+    (void)hl;
+    if (msg != NULL)
+        rs_queue_message((char *)msg, 1);
+}
+
+int
+msg(char_u *s)
+{
+    if (s != NULL)
+        rs_queue_message((char *)s, 0);
+    return 0;
+}
+
+void
+msg_prt_line(char_u *s, int list)
+{
+    (void)list;
+    if (s != NULL)
+        rs_queue_message((char *)s, 0);
+}
+
+void
+verb_msg(char *s)
+{
+    if (s != NULL)
+        rs_queue_message(s, 0);
+}
+
+// Stubs for unused functionality
+void
+msg_clr_eos(void)
+{
+}
+void
+msg_start(void)
+{
+}
+void
+msg_end(void)
+{
+}
+int
+message_filtered(char_u *s)
 {
     (void)s;
     return 0;
 }
-
-void verbose_enter(void) {}
-void verbose_leave(void) {}
-
-void give_warning(char_u *msg, int hl)
+void
+verbose_enter(void)
 {
-    (void)hl;
-    if (msg != NULL) {
-        fprintf(stderr, "W: %s\n", (const char *)msg);
-        bridge_warn((const char *)msg);
-    }
 }
-
-int msg(char_u *s)
+void
+verbose_leave(void)
 {
-    if (s != NULL) {
-        fprintf(stderr, "%s\n", (const char *)s);
-        bridge_info((const char *)s);
-    }
-    return 0;
 }
-
-char *msg_trunc_attr(char *s, int use_history, int attr)
+char *
+msg_trunc_attr(char *s, int use_history, int attr)
 {
     (void)use_history;
     (void)attr;
-    // Reset msg_hist_off as callers expect
     msg_hist_off = FALSE;
     return s;
 }
-
-void set_keep_msg(char_u *p, int attr)
+void
+set_keep_msg(char_u *p, int attr)
 {
     (void)attr;
     keep_msg = p;
 }
-
-void trunc_string(const char *src, char *dst, int maxlen, int dstlen)
+void
+trunc_string(const char *src, char *dst, int maxlen, int dstlen)
 {
     (void)maxlen;
-    if (src == NULL || dst == NULL || dstlen <= 0) return;
-    // Simple copy, ensure NUL-terminated
-    snprintf(dst, (size_t)dstlen, "%s", src);
+    if (src && dst && dstlen > 0)
+        snprintf(dst, (size_t)dstlen, "%s", src);
 }
-
-void verbose_enter_scroll(void) {}
-void verbose_leave_scroll(void) {}
-
-void msg_warn_missing_clipboard(void)
+void
+verbose_enter_scroll(void)
 {
-    fprintf(stderr, "W: missing clipboard support\n");
 }
-
-int msg_outtrans_attr(char_u *s, int attr)
+void
+verbose_leave_scroll(void)
 {
-    (void)attr;
-    if (s == NULL) return 0;
-    fputs((const char *)s, stderr);
-    return (int)strlen((const char *)s);
 }
-
-char *msg_outtrans_long_attr(char *s, int attr)
+void
+msg_warn_missing_clipboard(void)
 {
-    (void)attr;
-    if (s != NULL) fputs(s, stderr);
-    return s;
+    rs_queue_message("missing clipboard support", 1);
 }
-
-void msg_advance(int col)
+int
+msg_outnum(long n)
 {
-    (void)col;
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%ld", n);
+    rs_queue_message(buf, 0);
+    return 0;
 }
-
-void msg_starthere(void) {}
-
-void internal_error(const char *where)
-{
-    if (where) fprintf(stderr, "Internal error: %s\n", where);
-}
-
-int msg_outtrans_len_attr(char_u *s, int len, int attr)
-{
-    (void)attr;
-    if (s == NULL || len <= 0) return 0;
-    fwrite((const char *)s, 1, (size_t)len, stderr);
-    return len;
-}
-
-void msg_attr(char_u *s, int attr)
-{
-    (void)attr;
-    if (s) fputs((const char *)s, stderr);
-}
-
-void msg_outnum(long n)
-{
-    fprintf(stderr, "%ld", n);
-}
-
-void emsg_invreg(int c)
+void
+emsg_invreg(int c)
 {
     char buf[64];
     snprintf(buf, sizeof(buf), "Invalid register: %c", c);
-    emsg((char_u *)buf);
+    rs_queue_message(buf, 2);
 }
-
-void internal_error_no_abort(const char *where)
+void
+internal_error(const char *where)
+{
+    if (where)
+        rs_queue_message((char *)where, 2);
+}
+void
+internal_error_no_abort(const char *where)
 {
     internal_error(where);
 }
-
-void msg_sb_eol(void) {}
-
-void msg_putchar_attr(int c, int attr)
+void
+msg_putchar_attr(int c, int attr)
 {
     (void)attr;
-    fputc(c, stderr);
+    msg_putchar(c);
 }
-
-void iemsg(const char *s)
+void
+iemsg(const char *s)
 {
-    if (s != NULL)
-    {
-        fputs("I: ", stderr);
-        fputs(s, stderr);
-        fputc('\n', stderr);
-        bridge_error(s);
-    }
+    if (s)
+        rs_queue_message((char *)s, 2);
 }
-
-void wait_return(int redraw)
+void
+wait_return(int redraw)
 {
     (void)redraw;
-    // Minimal build: do not block, just note that we would have waited
-    // and mark that we used wait_return.
     did_wait_return = TRUE;
 }
-
-int vim_dialog_yesno(int type, char_u *title, char_u *message, int buttons)
+int
+vim_dialog_yesno(int type, char_u *title, char_u *message, int buttons)
 {
-    (void)type; (void)title; (void)buttons;
-    if (message != NULL)
-    {
-        fputs("? ", stderr);
-        fputs((const char *)message, stderr);
-        fputc('\n', stderr);
-    }
-    // Default to YES to keep flows moving in minimal build.
+    (void)type;
+    (void)title;
+    (void)buttons;
+    if (message)
+        rs_queue_message((char *)message, 0);
     return VIM_YES;
 }
-
-void msg_prt_line(char_u *s, int list)
+void
+ch_logfile(char_u *fname, char_u *mode)
 {
-    (void)list;
-    if (s != NULL)
-    {
-        fputs((const char *)s, stderr);
-        fputc('\n', stderr);
-        bridge_info((const char *)s);
-    }
+    (void)fname;
+    (void)mode;
 }
-
-void ch_logfile(char_u *fname, char_u *mode)
+void
+may_clear_sb_text(void)
 {
-    (void)fname; (void)mode;
-    // No-op in minimal build.
 }
-
-void may_clear_sb_text(void)
+int
+do_dialog(int type,
+          char_u *title,
+          char_u *message,
+          char_u *buttons,
+          int dfltbutton,
+          char_u *textfield,
+          int ex_cmd)
 {
-    // No-op in minimal build.
-}
-
-int do_dialog(int type, char_u *title, char_u *message, char_u *buttons, int dfltbutton, char_u *textfield, int ex_cmd)
-{
-    (void)type; (void)title; (void)buttons; (void)textfield; (void)ex_cmd;
-    if (message != NULL)
-    {
-        fputs((const char *)message, stderr);
-        fputc('\n', stderr);
-    }
+    (void)type;
+    (void)title;
+    (void)buttons;
+    (void)textfield;
+    (void)ex_cmd;
+    if (message)
+        rs_queue_message((char *)message, 0);
     return dfltbutton <= 0 ? 1 : dfltbutton;
 }
-
-void verb_msg(char *s)
+char_u *
+str2special_save(char_u *src, int do_special, int keep_screen_char)
 {
-    if (s != NULL)
-    {
-        fputs(s, stderr);
-        fputc('\n', stderr);
-    }
-}
-
-char_u *str2special_save(char_u *src, int do_special, int keep_screen_char)
-{
-    (void)do_special; (void)keep_screen_char;
-    if (src == NULL) return NULL;
+    (void)do_special;
+    (void)keep_screen_char;
+    if (!src)
+        return NULL;
     size_t len = strlen((const char *)src);
     char_u *p = (char_u *)malloc(len + 1);
-    if (p == NULL) return NULL;
-    memcpy(p, src, len + 1);
+    if (p)
+    {
+        memcpy(p, src, len + 1);
+    }
     return p;
 }
-
-void msg_source(int attr)
+void
+msg_source(int attr)
 {
     (void)attr;
 }
-
-void windgoto(int row, int col)
+void
+windgoto(int row, int col)
 {
-    (void)row; (void)col;
+    (void)row;
+    (void)col;
 }


### PR DESCRIPTION
## Summary
- route C message functions through `rs_queue_message` and remove local output logic
- expand `rs_queue_message` to print prefixed messages and track them
- test message printing and add `tempfile` dev-dependency

## Testing
- `cargo test -p rust_message`
- `make -C src message.o` *(fails: missing separator (did you mean TAB instead of 8 spaces?))*

------
https://chatgpt.com/codex/tasks/task_e_68b851d8eb048320855cc9351e69c1bb