### PR TITLE
Port win_getid to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,6 +1785,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_evalwindow"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rust_evalvars",
+]
+
+[[package]]
 name = "rust_excmds"
 version = "0.1.0"
 dependencies = [
@@ -2758,6 +2766,7 @@ dependencies = [
  "rust_cmdhist",
  "rust_debugger",
  "rust_evalfunc_stubs",
+ "rust_evalwindow",
  "rust_excmds",
  "rust_fold",
  "rust_job",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rust_blob = { path = "rust_blob" }
 rust_sha256 = { path = "rust_sha256" }
 rust_bufwrite = { path = "rust_bufwrite" }
 rust_evalfunc_stubs = { path = "rust_evalfunc_stubs" }
+rust_evalwindow = { path = "rust_evalwindow" }
 regex = "1"
 blowfish = "0.8"
 pbkdf2 = "0.12"

--- a/rust_evalwindow/Cargo.toml
+++ b/rust_evalwindow/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "rust_evalvars"
+name = "rust_evalwindow"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-once_cell = "1"
 libc = "0.2"
+rust_evalvars = { path = "../rust_evalvars" }
 
 [lib]
-name = "rust_evalvars"
+name = "rust_evalwindow"
 crate-type = ["staticlib", "rlib"]

--- a/rust_evalwindow/src/lib.rs
+++ b/rust_evalwindow/src/lib.rs
@@ -1,0 +1,101 @@
+use libc::c_char;
+use rust_evalvars::rs_win_getid;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum Vartype {
+    VAR_UNKNOWN = 0,
+    VAR_ANY,
+    VAR_VOID,
+    VAR_BOOL,
+    VAR_SPECIAL,
+    VAR_NUMBER,
+    VAR_FLOAT,
+    VAR_STRING,
+    VAR_BLOB,
+    VAR_FUNC,
+    VAR_PARTIAL,
+    VAR_LIST,
+    VAR_DICT,
+    VAR_JOB,
+    VAR_CHANNEL,
+    VAR_INSTR,
+    VAR_CLASS,
+    VAR_OBJECT,
+    VAR_TYPEALIAS,
+    VAR_TUPLE,
+}
+
+#[repr(C)]
+pub union ValUnion {
+    pub v_number: i64,
+    pub v_string: *mut c_char,
+}
+
+#[repr(C)]
+pub struct typval_T {
+    pub v_type: Vartype,
+    pub v_lock: c_char,
+    pub vval: ValUnion,
+}
+
+#[no_mangle]
+pub extern "C" fn f_win_getid(argvars: *mut typval_T, rettv: *mut typval_T) {
+    unsafe {
+        let winnr = if (*argvars).v_type as i32 == Vartype::VAR_UNKNOWN as i32 {
+            0
+        } else {
+            (*argvars).vval.v_number as i32
+        };
+        let id = rs_win_getid(winnr);
+        (*rettv).v_type = Vartype::VAR_NUMBER;
+        (*rettv).v_lock = 0;
+        (*rettv).vval.v_number = id as i64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_evalvars::{rs_win_create, rs_win_getid};
+
+    #[test]
+    fn returns_window_id_for_number() {
+        unsafe {
+            rs_win_create();
+            rs_win_create();
+            let mut args = [typval_T {
+                v_type: Vartype::VAR_NUMBER,
+                v_lock: 0,
+                vval: ValUnion { v_number: 2 },
+            }];
+            let mut ret = typval_T {
+                v_type: Vartype::VAR_UNKNOWN,
+                v_lock: 0,
+                vval: ValUnion { v_number: 0 },
+            };
+            f_win_getid(args.as_mut_ptr(), &mut ret);
+            assert_eq!(ret.vval.v_number, rs_win_getid(2) as i64);
+        }
+    }
+
+    #[test]
+    fn defaults_to_current_window() {
+        unsafe {
+            rs_win_create();
+            let mut args = [typval_T {
+                v_type: Vartype::VAR_UNKNOWN,
+                v_lock: 0,
+                vval: ValUnion { v_number: 0 },
+            }];
+            let mut ret = typval_T {
+                v_type: Vartype::VAR_UNKNOWN,
+                v_lock: 0,
+                vval: ValUnion { v_number: 0 },
+            };
+            f_win_getid(args.as_mut_ptr(), &mut ret);
+            assert_eq!(ret.vval.v_number, rs_win_getid(0) as i64);
+        }
+    }
+}

--- a/src/evalwindow.c
+++ b/src/evalwindow.c
@@ -12,18 +12,8 @@
  */
 
 #include "vim.h"
-#include "../rust_evalvars/include/rust_evalvars.h"
 
 #if defined(FEAT_EVAL) || defined(PROTO)
-
-    static int
-win_getid(typval_T *argvars)
-{
-    int winnr = 0;
-    if (argvars[0].v_type != VAR_UNKNOWN)
-        winnr = tv_get_number(&argvars[0]);
-    return rs_win_getid(winnr);
-}
 
 
     static void
@@ -771,21 +761,6 @@ f_win_findbuf(typval_T *argvars, typval_T *rettv)
 
     if (rettv_list_alloc(rettv) == OK)
 	win_findbuf(argvars, rettv->vval.v_list);
-}
-
-/*
- * "win_getid()" function
- */
-    void
-f_win_getid(typval_T *argvars, typval_T *rettv)
-{
-    if (in_vim9script()
-	    && (check_for_opt_number_arg(argvars, 0) == FAIL
-		|| (argvars[0].v_type != VAR_UNKNOWN
-		    && check_for_opt_number_arg(argvars, 1) == FAIL)))
-	return;
-
-    rettv->vval.v_number = win_getid(argvars);
 }
 
 /*


### PR DESCRIPTION
## Summary
- add rust_evalwindow crate implementing `win_getid`
- remove C win_getid and wire up new Rust version
- expose rust_evalvars as rlib and update workspace config

## Testing
- `cargo test -p rust_evalwindow`
- `cargo test -p rust_evalvars`


------
https://chatgpt.com/codex/tasks/task_e_68b8cbc7ec008320888ee163d8b3fb86