### PR TITLE
Add stub GUI backends for Haiku and Photon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,9 @@ version = "0.1.0"
 dependencies = [
  "rust_gui_core",
  "rust_gui_gtk",
+ "rust_gui_haiku",
+ "rust_gui_motif",
+ "rust_gui_photon",
  "rust_gui_w32",
  "rust_gui_x11",
 ]
@@ -1841,7 +1844,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_gui_haiku"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
 name = "rust_gui_motif"
+version = "0.1.0"
+dependencies = [
+ "rust_gui_core",
+]
+
+[[package]]
+name = "rust_gui_photon"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",

--- a/rust_gui/Cargo.toml
+++ b/rust_gui/Cargo.toml
@@ -15,10 +15,20 @@ default = ["x11"]
 x11 = ["rust_gui_x11"]
 gtk = ["rust_gui_gtk"]
 w32 = ["rust_gui_w32"]
+motif = ["rust_gui_motif"]
+haiku = ["rust_gui_haiku"]
+photon = ["rust_gui_photon"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rust_gui_x11 = { path = "../rust_gui_x11", optional = true }
 rust_gui_gtk = { path = "../rust_gui_gtk", optional = true }
+rust_gui_motif = { path = "../rust_gui_motif", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 rust_gui_w32 = { path = "../rust_gui_w32", optional = true }
+
+[target.'cfg(target_os = "haiku")'.dependencies]
+rust_gui_haiku = { path = "../rust_gui_haiku", optional = true }
+
+[target.'cfg(target_os = "qnx")'.dependencies]
+rust_gui_photon = { path = "../rust_gui_photon", optional = true }

--- a/rust_gui/src/lib.rs
+++ b/rust_gui/src/lib.rs
@@ -5,9 +5,19 @@ use rust_gui_core::GuiCore;
 use rust_gui_core::GuiEvent;
 #[cfg(all(target_os = "linux", feature = "gtk"))]
 use rust_gui_gtk::GtkBackend as Backend;
+#[cfg(all(target_os = "linux", feature = "motif"))]
+use rust_gui_motif::MotifBackend as Backend;
 #[cfg(target_os = "windows")]
 use rust_gui_w32::W32Backend as Backend;
-#[cfg(all(target_os = "linux", not(feature = "gtk")))]
+#[cfg(target_os = "haiku")]
+use rust_gui_haiku::HaikuBackend as Backend;
+#[cfg(target_os = "qnx")]
+use rust_gui_photon::PhotonBackend as Backend;
+#[cfg(all(
+    target_os = "linux",
+    not(feature = "gtk"),
+    not(feature = "motif")
+))]
 use rust_gui_x11::X11Backend as Backend;
 
 /// Run the GUI.  This is exposed to the C code via `gui_rust.c`.

--- a/rust_gui_haiku/Cargo.toml
+++ b/rust_gui_haiku/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_gui_haiku"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_gui_core = { path = "../rust_gui_core" }

--- a/rust_gui_haiku/src/lib.rs
+++ b/rust_gui_haiku/src/lib.rs
@@ -1,0 +1,50 @@
+use rust_gui_core::backend::{GuiBackend, GuiEvent};
+use std::collections::VecDeque;
+
+/// Backend implementation for the Haiku windowing system.
+///
+/// This mirrors the structure of other GUI backends by recording
+/// drawing operations and providing a simple queued event model.
+#[derive(Default)]
+pub struct HaikuBackend {
+    /// Text that has been drawn, stored for inspection in tests.
+    pub drawn: Vec<String>,
+    /// Pending GUI events.
+    pub events: VecDeque<GuiEvent>,
+}
+
+impl HaikuBackend {
+    /// Create a new backend instance with empty state.
+    pub fn new() -> Self {
+        Self { drawn: Vec::new(), events: VecDeque::new() }
+    }
+
+    /// Queue an event for later processing.
+    pub fn push_event(&mut self, ev: GuiEvent) {
+        self.events.push_back(ev);
+    }
+}
+
+impl GuiBackend for HaikuBackend {
+    fn draw_text(&mut self, text: &str) {
+        self.drawn.push(text.to_string());
+    }
+
+    fn poll_event(&mut self) -> Option<GuiEvent> {
+        self.events.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_and_draw() {
+        let mut backend = HaikuBackend::new();
+        backend.draw_text("hi");
+        backend.push_event(GuiEvent::Expose);
+        assert_eq!(backend.drawn, vec!["hi".to_string()]);
+        assert_eq!(backend.poll_event(), Some(GuiEvent::Expose));
+    }
+}

--- a/rust_gui_photon/Cargo.toml
+++ b/rust_gui_photon/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_gui_photon"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_gui_core = { path = "../rust_gui_core" }

--- a/rust_gui_photon/src/lib.rs
+++ b/rust_gui_photon/src/lib.rs
@@ -1,0 +1,50 @@
+use rust_gui_core::backend::{GuiBackend, GuiEvent};
+use std::collections::VecDeque;
+
+/// Backend implementation for the QNX Photon GUI system.
+///
+/// Similar to the other backends, this keeps a record of drawing
+/// operations and exposes a queued event interface.
+#[derive(Default)]
+pub struct PhotonBackend {
+    /// Recorded draw operations.
+    pub drawn: Vec<String>,
+    /// Queue of pending events.
+    pub events: VecDeque<GuiEvent>,
+}
+
+impl PhotonBackend {
+    /// Instantiate an empty backend instance.
+    pub fn new() -> Self {
+        Self { drawn: Vec::new(), events: VecDeque::new() }
+    }
+
+    /// Push an event into the internal queue.
+    pub fn push_event(&mut self, ev: GuiEvent) {
+        self.events.push_back(ev);
+    }
+}
+
+impl GuiBackend for PhotonBackend {
+    fn draw_text(&mut self, text: &str) {
+        self.drawn.push(text.to_string());
+    }
+
+    fn poll_event(&mut self) -> Option<GuiEvent> {
+        self.events.pop_front()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_and_draw() {
+        let mut backend = PhotonBackend::new();
+        backend.draw_text("hi");
+        backend.push_event(GuiEvent::Key('q'));
+        assert_eq!(backend.drawn, vec!["hi".to_string()]);
+        assert_eq!(backend.poll_event(), Some(GuiEvent::Key('q')));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `rust_gui_haiku` and `rust_gui_photon` crates
- expose new backends in `rust_gui` with feature flags
- extend `Cargo.toml` to include Haiku, Photon and Motif backends

## Testing
- `cargo test -p rust_gui_haiku`
- `cargo test -p rust_gui_photon`
- `cargo check -p rust_gui` *(warning: unexpected cfg `qnx`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cbc8a27083209e4f39917d18b60f