### PR TITLE
Bridge C regex entry points to Rust implementation

### DIFF
--- a/src/regexp.c
+++ b/src/regexp.c
@@ -22,6 +22,19 @@ int vim_regexec_prog(regprog_T **prog, int ignore_case, char_u *line, colnr_T co
     return vim_regexec(&rm, line, col);
 }
 
+// Bridge the older C call site to the Rust implementation.  The Rust crate
+// exports `rust_regex_match` which performs the actual matching logic.  This
+// thin wrapper simply forwards the call while taking care of the pointer type
+// conversions required for the C API.
+int rust_regex_match(const char *pat, const char *text, int magic, long timeout_ms);
+
+int
+vim_rust_regex_match_wrapper(char_u *pat, char_u *text, int magic, long timeout_ms)
+{
+    return rust_regex_match((const char *)pat, (const char *)text, magic,
+                            timeout_ms);
+}
+
 #else
 #error "Rust regex engine required"
 #endif

--- a/src/search_rs.h
+++ b/src/search_rs.h
@@ -13,7 +13,10 @@ typedef struct {
     int last_maxcount;
 } searchstat_T;
 
-int rust_search_update_stat(const char *pat, const char *text, searchstat_T *stat);
+// Update search statistics using the Rust implementation.  The function does
+// not produce a return value; results are written directly into `stat`.
+void rust_search_update_stat(const char *pat, const char *text,
+                             searchstat_T *stat);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- expose Rust regex matcher through C wrapper
- document and correct search statistics FFI prototype

## Testing
- `cargo test -p rust_search`
- `cargo test -p rust_regexp`


------
https://chatgpt.com/codex/tasks/task_e_68b8cc03789083209280f0e15e355b3b