### PR TITLE
Port sort comparator to Rust

### DIFF
--- a/rust_cmdexpand/Cargo.toml
+++ b/rust_cmdexpand/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_cmdexpand"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "rust_cmdexpand"
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+libc = "0.2"

--- a/rust_cmdexpand/src/lib.rs
+++ b/rust_cmdexpand/src/lib.rs
@@ -1,0 +1,61 @@
+use std::os::raw::{c_char, c_int, c_void};
+
+#[no_mangle]
+pub extern "C" fn rs_sort_func_compare(s1: *const c_void, s2: *const c_void) -> c_int {
+    unsafe {
+        let p1 = *(s1 as *const *const c_char);
+        let p2 = *(s2 as *const *const c_char);
+        if *p1 != b'<' as c_char && *p2 == b'<' as c_char {
+            return -1;
+        }
+        if *p1 == b'<' as c_char && *p2 != b'<' as c_char {
+            return 1;
+        }
+        libc::strcmp(p1, p2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn second_snr_returns_negative() {
+        let a = CString::new("abc").unwrap();
+        let b = CString::new("<snr>").unwrap();
+        let res = unsafe {
+            rs_sort_func_compare(
+                &a.as_ptr() as *const _ as *const c_void,
+                &b.as_ptr() as *const _ as *const c_void,
+            )
+        };
+        assert!(res < 0);
+    }
+
+    #[test]
+    fn first_snr_returns_positive() {
+        let a = CString::new("<snr>").unwrap();
+        let b = CString::new("abc").unwrap();
+        let res = unsafe {
+            rs_sort_func_compare(
+                &a.as_ptr() as *const _ as *const c_void,
+                &b.as_ptr() as *const _ as *const c_void,
+            )
+        };
+        assert!(res > 0);
+    }
+
+    #[test]
+    fn compare_uses_strcmp() {
+        let a = CString::new("abc").unwrap();
+        let b = CString::new("abd").unwrap();
+        let res = unsafe {
+            rs_sort_func_compare(
+                &a.as_ptr() as *const _ as *const c_void,
+                &b.as_ptr() as *const _ as *const c_void,
+            )
+        };
+        assert!(res < 0);
+    }
+}

--- a/src/cmdexpand.c
+++ b/src/cmdexpand.c
@@ -15,6 +15,8 @@
 
 // Functions implemented in Rust for key mappings.
 extern const char *rs_map_lookup(const char *lhs);
+// Comparator implemented in Rust for sorting completion matches.
+extern int rs_sort_func_compare(const void *s1, const void *s2);
 
 static int	cmd_showtail;	// Only show path tail in lists ?
 static int	may_expand_pattern = FALSE;
@@ -91,21 +93,6 @@ cmdline_fuzzy_completion_supported(expand_T *xp)
 cmdline_fuzzy_complete(char_u *fuzzystr)
 {
     return vim_strchr(p_wop, WOP_FUZZY) != NULL && *fuzzystr != NUL;
-}
-
-/*
- * sort function for the completion matches.
- * <SNR> functions should be sorted to the end.
- */
-    static int
-sort_func_compare(const void *s1, const void *s2)
-{
-    char_u *p1 = *(char_u **)s1;
-    char_u *p2 = *(char_u **)s2;
-
-    if (*p1 != '<' && *p2 == '<') return -1;
-    if (*p1 == '<' && *p2 != '<') return 1;
-    return STRCMP(p1, p2);
 }
 
 /*
@@ -3713,8 +3700,8 @@ ExpandGenericExt(
     {
 	if (funcsort)
 	    // <SNR> functions should be sorted to the end.
-	    qsort((void *)ga.ga_data, (size_t)ga.ga_len, sizeof(char_u *),
-							   sort_func_compare);
+            qsort((void *)ga.ga_data, (size_t)ga.ga_len, sizeof(char_u *),
+                                                           rs_sort_func_compare);
 	else
 	    sort_strings((char_u **)ga.ga_data + sortStartMatchIdx, ga.ga_len - sortStartMatchIdx);
     }


### PR DESCRIPTION
## Summary
- add new `rust_cmdexpand` crate with Rust implementation of the completion sort comparator
- call into Rust comparator from `cmdexpand.c` instead of the previous C helper
- unit-test sorting behavior in Rust

## Testing
- `cargo test -p rust_cmdexpand`
- `gcc -I src -c src/cmdexpand.c -o /tmp/cmdexpand.o` *(fails: Vim only works with 32 bit int or larger)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cc07f2e08320aee3763dfad9bc35