### PR TITLE
Introduce hardcopy crate and document GUI backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.106",
+ "which 4.4.2",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
@@ -1320,6 +1343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1893,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_hardcopy"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.68.1",
+ "cc",
+]
+
+[[package]]
 name = "rust_hashtab"
 version = "0.1.0"
 dependencies = [
@@ -1982,7 +2019,7 @@ version = "0.1.0"
 name = "rust_option"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "tempfile",
 ]
 
@@ -2755,11 +2792,13 @@ dependencies = [
  "rust_buffer",
  "rust_bufwrite",
  "rust_change",
+ "rust_clipboard",
  "rust_cmdhist",
  "rust_debugger",
  "rust_evalfunc_stubs",
  "rust_excmds",
  "rust_fold",
+ "rust_hardcopy",
  "rust_job",
  "rust_message",
  "rust_os_amiga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rust_blob = { path = "rust_blob" }
 rust_sha256 = { path = "rust_sha256" }
 rust_bufwrite = { path = "rust_bufwrite" }
 rust_evalfunc_stubs = { path = "rust_evalfunc_stubs" }
+rust_hardcopy = { path = "rust_hardcopy" }
 regex = "1"
 blowfish = "0.8"
 pbkdf2 = "0.12"
@@ -49,6 +50,7 @@ default = []
 
 [target.'cfg(windows)'.dependencies]
 rust_os_win32 = { path = "rust_os_win32" }
+rust_clipboard = { path = "rust_clipboard", features = ["windows"] }
 
 [target.'cfg(unix)'.dependencies]
 rust_os_unix = { path = "rust_os_unix" }
@@ -61,6 +63,10 @@ rust_os_qnx = { path = "rust_os_qnx" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rust_wayland = { path = "rust_wayland" }
+rust_clipboard = { path = "rust_clipboard", features = ["wayland"] }
+
+[target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
+rust_clipboard = { path = "rust_clipboard", features = ["x11"] }
 
 [lib]
 name = "vim_channel"

--- a/docs/gui_backends.md
+++ b/docs/gui_backends.md
@@ -1,0 +1,14 @@
+# GUI Backend Overview
+
+This document summarizes the purpose of each legacy GUI source file located in `src`.
+
+- `gui_beval.c` – Implements balloon evaluation tooltips and mouse tracking used by several GUI backends.
+- `gui_gtk_f.c` – Custom GTK+ floating container widget managing children at arbitrary positions.
+- `gui_gtk_x11.c` – GTK+ interface targeting the X11 window system.
+- `gui_motif.c` – Motif toolkit based GUI implementation.
+- `gui_photon.c` – Backend for the QNX Photon windowing system.
+- `gui_xim.c` – X Input Method (XIM) support for multi-byte input on X11/GTK.
+- `gui_xmdlg.c` – Dialog implementation for the Motif GUI variant.
+- `gui_xmebw.c` – External Motif menu and toolbar widget utilities.
+
+Rust rewrites of these backends live in crates named `rust_gui_*` within this repository.  Platform specific code should be kept inside those crates so that the core editor remains portable.

--- a/rust_hardcopy/Cargo.toml
+++ b/rust_hardcopy/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust_hardcopy"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+bindgen = "0.68"
+cc = "1.0"
+
+[lib]
+name = "rust_hardcopy"
+crate-type = ["staticlib", "rlib"]

--- a/rust_hardcopy/build.rs
+++ b/rust_hardcopy/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+    // Generate bindings for the small C helper.
+    let bindings = bindgen::Builder::default()
+        .header("src/c_printer.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .generate()
+        .expect("Unable to generate bindings");
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+
+    // Compile the C helper.
+    cc::Build::new()
+        .file("src/c_printer.c")
+        .compile("c_printer");
+}

--- a/rust_hardcopy/src/c_printer.c
+++ b/rust_hardcopy/src/c_printer.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "c_printer.h"
+
+void c_print_line(const char *s) {
+    if (s) {
+        printf("%s\n", s);
+        fflush(stdout);
+    }
+}

--- a/rust_hardcopy/src/c_printer.h
+++ b/rust_hardcopy/src/c_printer.h
@@ -1,0 +1,6 @@
+#ifndef C_PRINTER_H
+#define C_PRINTER_H
+
+void c_print_line(const char *s);
+
+#endif

--- a/rust_hardcopy/src/lib.rs
+++ b/rust_hardcopy/src/lib.rs
@@ -1,0 +1,34 @@
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+/// Print a line of text via the underlying C helper.
+pub fn print_line(s: &str) {
+    let c_string = CString::new(s).expect("CString::new failed");
+    unsafe {
+        c_print_line(c_string.as_ptr());
+    }
+}
+
+/// C ABI wrapper for printing a line.
+#[no_mangle]
+pub extern "C" fn rs_hardcopy_print_line(ptr: *const c_char) {
+    if ptr.is_null() {
+        return;
+    }
+    let c_str = unsafe { CStr::from_ptr(ptr) };
+    if let Ok(text) = c_str.to_str() {
+        print_line(text);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke() {
+        print_line("test");
+    }
+}


### PR DESCRIPTION
## Summary
- document legacy `gui_*.c` backends and point to Rust equivalents
- add `rust_hardcopy` crate demonstrating bindgen-based FFI
- wire up `rust_clipboard` features per-platform and include `rust_hardcopy`

## Testing
- `cargo test -p rust_hardcopy`
- `cargo test -p rust_clipboard`


------
https://chatgpt.com/codex/tasks/task_e_68b8cc06549483208a38bb87d4053ab5