### PR TITLE
Add Rust crates for filepath, findfile, memfile, viminfo and version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_cmdexpand"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
@@ -1811,6 +1818,14 @@ dependencies = [
  "rust_path",
  "tempfile",
 ]
+
+[[package]]
+name = "rust_filepath"
+version = "0.1.0"
+
+[[package]]
+name = "rust_findfile"
+version = "0.1.0"
 
 [[package]]
 name = "rust_fold"
@@ -1971,6 +1986,10 @@ dependencies = [
  "unicode-normalization",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "rust_memfile"
+version = "0.1.0"
 
 [[package]]
 name = "rust_memline"
@@ -2272,6 +2291,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_version"
+version = "0.1.0"
+
+[[package]]
 name = "rust_vim9"
 version = "0.1.0"
 dependencies = [
@@ -2292,6 +2315,10 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_vim9script"
+version = "0.1.0"
+
+[[package]]
+name = "rust_viminfo"
 version = "0.1.0"
 
 [[package]]

--- a/rust_filepath/Cargo.toml
+++ b/rust_filepath/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_filepath"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_filepath"
+crate-type = ["staticlib", "rlib"]

--- a/rust_filepath/src/lib.rs
+++ b/rust_filepath/src/lib.rs
@@ -1,0 +1,58 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "windows")]
+const PATH_SEPARATORS: &[char] = &['\\', '/'];
+#[cfg(not(target_os = "windows"))]
+const PATH_SEPARATORS: &[char] = &['/'];
+
+pub fn is_path_separator(ch: char) -> bool {
+    PATH_SEPARATORS.contains(&ch)
+}
+
+pub fn join_paths(a: &str, b: &str) -> String {
+    let mut path = PathBuf::from(a);
+    path.push(b);
+    path.to_string_lossy().into_owned()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_is_path_sep(ch: c_int) -> c_int {
+    let ch = std::char::from_u32(ch as u32).unwrap_or('\0');
+    is_path_separator(ch) as c_int
+}
+
+#[no_mangle]
+pub extern "C" fn rs_path_join(a: *const c_char, b: *const c_char) -> *mut c_char {
+    if a.is_null() || b.is_null() {
+        return std::ptr::null_mut();
+    }
+    let a = unsafe { CStr::from_ptr(a) }.to_string_lossy().into_owned();
+    let b = unsafe { CStr::from_ptr(b) }.to_string_lossy().into_owned();
+    let joined = Path::new(&a).join(&b);
+    CString::new(joined.to_string_lossy().into_owned()).unwrap().into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_path_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe { let _ = CString::from_raw(s); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sep() {
+        assert!(is_path_separator(std::path::MAIN_SEPARATOR));
+    }
+
+    #[test]
+    fn join() {
+        let joined = join_paths("a", "b");
+        assert!(joined.ends_with("b"));
+    }
+}

--- a/rust_findfile/Cargo.toml
+++ b/rust_findfile/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_findfile"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_findfile"
+crate-type = ["staticlib", "rlib"]

--- a/rust_findfile/src/lib.rs
+++ b/rust_findfile/src/lib.rs
@@ -1,0 +1,49 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::path::{PathBuf};
+
+#[cfg(target_os = "windows")]
+const PATH_LIST_SEPARATOR: char = ';';
+#[cfg(not(target_os = "windows"))]
+const PATH_LIST_SEPARATOR: char = ':';
+
+pub fn find_file(file: &str, search: &str) -> Option<PathBuf> {
+    for dir in search.split(PATH_LIST_SEPARATOR) {
+        if dir.is_empty() { continue; }
+        let candidate = PathBuf::from(dir).join(file);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[no_mangle]
+pub extern "C" fn rs_findfile(file: *const c_char, search: *const c_char) -> *mut c_char {
+    if file.is_null() || search.is_null() {
+        return std::ptr::null_mut();
+    }
+    let file = unsafe { CStr::from_ptr(file) }.to_string_lossy().into_owned();
+    let search = unsafe { CStr::from_ptr(search) }.to_string_lossy().into_owned();
+    match find_file(&file, &search) {
+        Some(path) => CString::new(path.to_string_lossy().into_owned()).unwrap().into_raw(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_findfile_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe { let _ = CString::from_raw(s); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_found() {
+        assert!(find_file("nonexistent", "").is_none());
+    }
+}

--- a/rust_memfile/Cargo.toml
+++ b/rust_memfile/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_memfile"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_memfile"
+crate-type = ["staticlib", "rlib"]

--- a/rust_memfile/src/lib.rs
+++ b/rust_memfile/src/lib.rs
@@ -1,0 +1,69 @@
+
+#[repr(C)]
+pub struct MemFile {
+    data: Vec<u8>,
+}
+
+impl MemFile {
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+    pub fn write(&mut self, buf: &[u8]) {
+        self.data.extend_from_slice(buf);
+    }
+    pub fn read(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_memfile_new() -> *mut MemFile {
+    Box::into_raw(Box::new(MemFile::new()))
+}
+
+#[no_mangle]
+pub extern "C" fn rs_memfile_write(ptr: *mut MemFile, data: *const u8, len: usize) {
+    if ptr.is_null() || data.is_null() {
+        return;
+    }
+    let mf = unsafe { &mut *ptr };
+    let slice = unsafe { std::slice::from_raw_parts(data, len) };
+    mf.write(slice);
+}
+
+#[no_mangle]
+pub extern "C" fn rs_memfile_read(ptr: *const MemFile, len: *mut usize) -> *const u8 {
+    if ptr.is_null() {
+        return std::ptr::null();
+    }
+    let mf = unsafe { &*ptr };
+    if !len.is_null() {
+        unsafe { *len = mf.data.len(); }
+    }
+    mf.read().as_ptr()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_memfile_free(ptr: *mut MemFile) {
+    if !ptr.is_null() {
+        unsafe { drop(Box::from_raw(ptr)); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let mf = rs_memfile_new();
+        let data = b"hello";
+        rs_memfile_write(mf, data.as_ptr(), data.len());
+        let mut len: usize = 0;
+        let ptr = rs_memfile_read(mf, &mut len as *mut usize);
+        assert_eq!(len, 5);
+        let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+        assert_eq!(slice, data);
+        rs_memfile_free(mf);
+    }
+}

--- a/rust_version/Cargo.toml
+++ b/rust_version/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_version"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_version"
+crate-type = ["staticlib", "rlib"]

--- a/rust_version/src/lib.rs
+++ b/rust_version/src/lib.rs
@@ -1,0 +1,79 @@
+use std::ffi::{CStr};
+use std::fs;
+use std::os::raw::{c_char, c_int};
+use std::path::Path;
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl Version {
+    pub fn to_string(&self) -> String {
+        format!("{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+pub fn read(path: &Path) -> std::io::Result<Version> {
+    let text = fs::read_to_string(path)?;
+    let parts: Vec<_> = text.trim().split('.').collect();
+    let major = parts.get(0).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let patch = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    Ok(Version { major, minor, patch })
+}
+
+pub fn write(path: &Path, v: Version) -> std::io::Result<()> {
+    fs::write(path, v.to_string())
+}
+
+#[no_mangle]
+pub extern "C" fn rs_version_read(path: *const c_char, major: *mut u32, minor: *mut u32, patch: *mut u32) -> c_int {
+    if path.is_null() {
+        return -1;
+    }
+    let path = unsafe { CStr::from_ptr(path) }.to_string_lossy().into_owned();
+    match read(Path::new(&path)) {
+        Ok(v) => {
+            unsafe {
+                if !major.is_null() { *major = v.major; }
+                if !minor.is_null() { *minor = v.minor; }
+                if !patch.is_null() { *patch = v.patch; }
+            }
+            0
+        }
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_version_write(path: *const c_char, major: u32, minor: u32, patch: u32) -> c_int {
+    if path.is_null() {
+        return -1;
+    }
+    let path = unsafe { CStr::from_ptr(path) }.to_string_lossy().into_owned();
+    let v = Version { major, minor, patch };
+    match write(Path::new(&path), v) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn roundtrip() {
+        let dir = env::temp_dir();
+        let file = dir.join("version_test.txt");
+        let v = Version { major: 1, minor: 2, patch: 3 };
+        write(&file, v).unwrap();
+        let r = read(&file).unwrap();
+        assert_eq!(r, v);
+        fs::remove_file(file).unwrap();
+    }
+}

--- a/rust_viminfo/Cargo.toml
+++ b/rust_viminfo/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_viminfo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_viminfo"
+crate-type = ["staticlib", "rlib"]

--- a/rust_viminfo/src/lib.rs
+++ b/rust_viminfo/src/lib.rs
@@ -1,0 +1,72 @@
+use std::ffi::{CStr, CString};
+use std::fs;
+use std::os::raw::{c_char, c_int};
+use std::path::Path;
+
+#[derive(Default)]
+pub struct VimInfo {
+    pub lines: Vec<String>,
+}
+
+pub fn read(path: &Path) -> std::io::Result<VimInfo> {
+    let content = fs::read_to_string(path)?;
+    Ok(VimInfo {
+        lines: content.lines().map(|s| s.to_string()).collect(),
+    })
+}
+
+pub fn write(path: &Path, info: &VimInfo) -> std::io::Result<()> {
+    fs::write(path, info.lines.join("\n"))
+}
+
+#[no_mangle]
+pub extern "C" fn rs_viminfo_read(path: *const c_char) -> *mut c_char {
+    if path.is_null() {
+        return std::ptr::null_mut();
+    }
+    let path = unsafe { CStr::from_ptr(path) }.to_string_lossy().into_owned();
+    match read(Path::new(&path)) {
+        Ok(info) => CString::new(info.lines.join("\n")).unwrap().into_raw(),
+        Err(_) => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_viminfo_write(path: *const c_char, data: *const c_char) -> c_int {
+    if path.is_null() || data.is_null() {
+        return -1;
+    }
+    let path = unsafe { CStr::from_ptr(path) }.to_string_lossy().into_owned();
+    let data = unsafe { CStr::from_ptr(data) }.to_string_lossy();
+    let info = VimInfo {
+        lines: data.lines().map(|s| s.to_string()).collect(),
+    };
+    match write(Path::new(&path), &info) {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_viminfo_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe { let _ = CString::from_raw(s); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn roundtrip() {
+        let dir = env::temp_dir();
+        let file = dir.join("viminfo_test.txt");
+        let info = VimInfo { lines: vec!["alpha".into(), "beta".into()] };
+        write(&file, &info).unwrap();
+        let read_back = read(&file).unwrap();
+        assert_eq!(read_back.lines, info.lines);
+        fs::remove_file(file).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `rust_filepath` with path utilities and FFI exposing path separator checks and join
- Implement `rust_findfile` to search files along platform-specific path lists
- Add `rust_memfile` in-memory file representation with FFI helpers
- Add `rust_viminfo` and `rust_version` crates to read/write their data structures

## Testing
- `cargo test -p rust_filepath -p rust_findfile -p rust_memfile -p rust_viminfo -p rust_version`

------
https://chatgpt.com/codex/tasks/task_e_68b8cf52d6708320a0fa642953bcc02c