### PR TITLE
Move option parsing helpers to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_cmdexpand"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
@@ -2192,6 +2199,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_strings"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_syntax"
 version = "0.1.0"
 
@@ -2244,6 +2258,20 @@ dependencies = [
 
 [[package]]
 name = "rust_time"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_tuple"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_typval"
 version = "0.1.0"
 dependencies = [
  "libc",

--- a/rust_strings/Cargo.toml
+++ b/rust_strings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_strings"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_strings"
+crate-type = ["staticlib", "rlib"]

--- a/rust_strings/src/lib.rs
+++ b/rust_strings/src/lib.rs
@@ -1,0 +1,88 @@
+use libc::{c_char, c_int, c_uchar};
+
+/// Skip to next part of an option argument: skip comma and following spaces.
+#[no_mangle]
+pub unsafe extern "C" fn skip_to_option_part(p: *mut c_uchar) -> *mut c_uchar {
+    let mut q = p;
+    if *q == b',' as c_uchar {
+        q = q.add(1);
+    }
+    while *q == b' ' as c_uchar {
+        q = q.add(1);
+    }
+    q
+}
+
+/// Isolate one part of a string option where parts are separated with
+/// `sep_chars`. The part is copied into `buf` which has length `maxlen`.
+/// `*option` is advanced to the next part and the length is returned.
+#[no_mangle]
+pub unsafe extern "C" fn copy_option_part(
+    option: *mut *mut c_uchar,
+    buf: *mut c_uchar,
+    maxlen: c_int,
+    sep_chars: *const c_char,
+) -> c_int {
+    let mut len: c_int = 0;
+    let mut p = *option;
+
+    if *p == b'.' as c_uchar {
+        *buf.add(len as usize) = *p;
+        len += 1;
+        p = p.add(1);
+    }
+
+    while *p != 0 && libc::strchr(sep_chars, *p as c_int).is_null() {
+        if *p == b'\\' as c_uchar {
+            let next = *p.add(1);
+            if next != 0 && !libc::strchr(sep_chars, next as c_int).is_null() {
+                p = p.add(1);
+            }
+        }
+        if len < maxlen - 1 {
+            *buf.add(len as usize) = *p;
+            len += 1;
+        }
+        p = p.add(1);
+    }
+    *buf.add(len as usize) = 0;
+
+    if *p != 0 && *p != b',' as c_uchar {
+        p = p.add(1);
+    }
+    p = skip_to_option_part(p);
+    *option = p;
+    len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_skip_to_option_part() {
+        let mut s = CString::new(",  test").unwrap();
+        let p = unsafe { skip_to_option_part(s.as_ptr() as *mut c_uchar) };
+        let res = unsafe { std::ffi::CStr::from_ptr(p as *const c_char) };
+        assert_eq!(res.to_str().unwrap(), "test");
+    }
+
+    #[test]
+    fn test_copy_option_part() {
+        let mut opt = CString::new("part1, part2").unwrap();
+        let mut p = opt.as_ptr() as *mut c_uchar;
+        let mut buf = [0u8; 20];
+        let mut option_ptr = p;
+        let len = unsafe {
+            copy_option_part(
+                &mut option_ptr,
+                buf.as_mut_ptr(),
+                buf.len() as c_int,
+                CString::new(",").unwrap().as_ptr(),
+            )
+        };
+        assert_eq!(len, 5);
+        assert_eq!(unsafe { std::ffi::CStr::from_ptr(buf.as_ptr() as *const c_char).to_str().unwrap() }, "part1");
+    }
+}

--- a/rust_tuple/Cargo.toml
+++ b/rust_tuple/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_tuple"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_tuple"
+crate-type = ["staticlib", "rlib"]

--- a/rust_tuple/src/lib.rs
+++ b/rust_tuple/src/lib.rs
@@ -1,0 +1,43 @@
+use libc::{c_int, c_long};
+
+#[repr(C)]
+pub struct garray_T {
+    ga_len: c_int,
+    ga_maxlen: c_int,
+    ga_itemsize: c_int,
+    ga_growsize: c_int,
+    ga_data: *mut libc::c_void,
+}
+
+#[repr(C)]
+pub struct tuple_T {
+    tv_items: garray_T,
+    tv_type: *mut libc::c_void,
+    tv_copytuple: *mut libc::c_void,
+    tv_used_next: *mut tuple_T,
+    tv_used_prev: *mut tuple_T,
+    tv_refcount: c_int,
+    tv_copyID: c_int,
+    tv_lock: libc::c_char,
+}
+
+/// Return the number of items in a tuple.
+#[no_mangle]
+pub unsafe extern "C" fn tuple_len(tuple: *const tuple_T) -> c_long {
+    if tuple.is_null() {
+        0
+    } else {
+        (*tuple).tv_items.ga_len as c_long
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn len_of_null_tuple_is_zero() {
+        let len = unsafe { tuple_len(std::ptr::null()) };
+        assert_eq!(len, 0);
+    }
+}

--- a/rust_typval/Cargo.toml
+++ b/rust_typval/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_typval"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_typval"
+crate-type = ["staticlib", "rlib"]

--- a/rust_typval/src/lib.rs
+++ b/rust_typval/src/lib.rs
@@ -1,0 +1,58 @@
+use libc::{c_char, c_long, c_uchar};
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum vartype_T {
+    VAR_UNKNOWN = 0,
+    VAR_NUMBER = 1,
+    VAR_STRING = 2,
+}
+
+#[repr(C)]
+pub union typval_vval {
+    pub v_number: c_long,
+    pub v_string: *mut c_uchar,
+}
+
+#[repr(C)]
+pub struct typval_T {
+    pub v_type: vartype_T,
+    pub v_lock: c_char,
+    pub vval: typval_vval,
+}
+
+/// Allocate a zeroed typval_T.
+#[no_mangle]
+pub unsafe extern "C" fn alloc_tv() -> *mut typval_T {
+    let tv: *mut typval_T = libc::calloc(1, std::mem::size_of::<typval_T>()) as *mut typval_T;
+    tv
+}
+
+/// Free a typval previously allocated with `alloc_tv`.
+#[no_mangle]
+pub unsafe extern "C" fn free_tv(tv: *mut typval_T) {
+    if tv.is_null() {
+        return;
+    }
+    if (*tv).v_type == vartype_T::VAR_STRING {
+        libc::free((*tv).vval.v_string as *mut _);
+    }
+    libc::free(tv as *mut _);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn alloc_and_free_string_tv() {
+        unsafe {
+            let tv = alloc_tv();
+            (*tv).v_type = vartype_T::VAR_STRING;
+            let s = CString::new("hello").unwrap();
+            (*tv).vval.v_string = libc::strdup(s.as_ptr()) as *mut c_uchar;
+            free_tv(tv);
+        }
+    }
+}

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -28,6 +28,9 @@
 // All user names (for ~user completion as done by shell).
 static garray_T	ga_users;
 
+// FFI: implemented in rust_strings crate
+extern char_u *skip_to_option_part(char_u *p);
+
 /*
  * get_leader_len() returns the length in bytes of the prefix of the given
  * string which introduces a comment.  If this string is not a comment then
@@ -594,19 +597,6 @@ pchar_cursor(int c)
 {
     *(ml_get_buf(curbuf, curwin->w_cursor.lnum, TRUE)
 						  + curwin->w_cursor.col) = c;
-}
-
-/*
- * Skip to next part of an option argument: Skip space and comma.
- */
-    char_u *
-skip_to_option_part(char_u *p)
-{
-    if (*p == ',')
-	++p;
-    while (*p == ' ')
-	++p;
-    return p;
 }
 
 /*

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -16,6 +16,9 @@ static char_u	*username = NULL; // cached result of mch_get_user_name()
 
 static int coladvance2(pos_T *pos, int addspaces, int finetune, colnr_T wcol);
 
+// FFI: implemented in rust_strings crate
+extern int copy_option_part(char_u **option, char_u *buf, int maxlen, char *sep_chars);
+
 /*
  * Return TRUE if in the current mode we need to use virtual.
  */
@@ -728,47 +731,6 @@ set_leftcol(colnr_T leftcol)
 	curwin->w_set_curswant = TRUE;
     redraw_later(UPD_NOT_VALID);
     return retval;
-}
-
-/*
- * Isolate one part of a string option where parts are separated with
- * "sep_chars".
- * The part is copied into "buf[maxlen]".
- * "*option" is advanced to the next part.
- * The length is returned.
- */
-    int
-copy_option_part(
-    char_u	**option,
-    char_u	*buf,
-    int		maxlen,
-    char	*sep_chars)
-{
-    int	    len = 0;
-    char_u  *p = *option;
-
-    // skip '.' at start of option part, for 'suffixes'
-    if (*p == '.')
-	buf[len++] = *p++;
-    while (*p != NUL && vim_strchr((char_u *)sep_chars, *p) == NULL)
-    {
-	/*
-	 * Skip backslash before a separator character and space.
-	 */
-	if (p[0] == '\\' && vim_strchr((char_u *)sep_chars, p[1]) != NULL)
-	    ++p;
-	if (len < maxlen - 1)
-	    buf[len++] = *p;
-	++p;
-    }
-    buf[len] = NUL;
-
-    if (*p != NUL && *p != ',')	// skip non-standard separator
-	++p;
-    p = skip_to_option_part(p);	// p points to next file name
-
-    *option = p;
-    return len;
 }
 
 #if !defined(HAVE_MEMSET) && !defined(PROTO)


### PR DESCRIPTION
## Summary
- add rust_typval, rust_tuple, and rust_strings crates
- implement skip_to_option_part and copy_option_part in Rust
- remove C implementations of these helpers and link to Rust

## Testing
- `cargo test -p rust_strings -p rust_typval -p rust_tuple`


------
https://chatgpt.com/codex/tasks/task_e_68b8cf51979c83209b9990f793755d3b