### PR TITLE
Add stub Rust modules for highlight and related features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_cmdexpand"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_cmdhist"
 version = "0.1.0"
 dependencies = [
@@ -1912,6 +1919,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_highlight"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "rust_indent"
 version = "0.1.0"
 dependencies = [
@@ -1920,6 +1935,13 @@ dependencies = [
 
 [[package]]
 name = "rust_input"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_insexpand"
 version = "0.1.0"
 dependencies = [
  "libc",
@@ -1937,6 +1959,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "rust_linematch"
+version = "0.1.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1962,6 +1991,20 @@ name = "rust_map"
 version = "0.1.0"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "rust_mark"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_match"
+version = "0.1.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2222,6 +2265,13 @@ version = "0.1.0"
 
 [[package]]
 name = "rust_text"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "rust_textformat"
 version = "0.1.0"
 dependencies = [
  "libc",
@@ -2797,7 +2847,12 @@ dependencies = [
  "rust_evalwindow",
  "rust_excmds",
  "rust_fold",
+ "rust_highlight",
+ "rust_insexpand",
  "rust_job",
+ "rust_linematch",
+ "rust_mark",
+ "rust_match",
  "rust_message",
  "rust_os_amiga",
  "rust_os_qnx",
@@ -2808,6 +2863,7 @@ dependencies = [
  "rust_python",
  "rust_sha256",
  "rust_spell",
+ "rust_textformat",
  "rust_wayland",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ rust_sha256 = { path = "rust_sha256" }
 rust_bufwrite = { path = "rust_bufwrite" }
 rust_evalfunc_stubs = { path = "rust_evalfunc_stubs" }
 rust_evalwindow = { path = "rust_evalwindow" }
+rust_highlight = { path = "rust_highlight" }
+rust_insexpand = { path = "rust_insexpand" }
+rust_match = { path = "rust_match" }
+rust_linematch = { path = "rust_linematch" }
+rust_mark = { path = "rust_mark" }
+rust_textformat = { path = "rust_textformat" }
 regex = "1"
 blowfish = "0.8"
 pbkdf2 = "0.12"

--- a/rust_highlight/Cargo.toml
+++ b/rust_highlight/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust_highlight"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+once_cell = "1"
+libc = "0.2"
+
+[lib]
+name = "rust_highlight"
+crate-type = ["staticlib", "rlib"]

--- a/rust_highlight/src/lib.rs
+++ b/rust_highlight/src/lib.rs
@@ -1,0 +1,53 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::sync::Mutex;
+
+static GROUPS: Lazy<Mutex<HashMap<String, String>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Define a highlight group identified by name with a simple attribute string.
+#[no_mangle]
+pub extern "C" fn rs_highlight_define(name: *const c_char, attrs: *const c_char) {
+    let Ok(name) = unsafe { CStr::from_ptr(name) }.to_str().map(|s| s.to_owned()) else {
+        return;
+    };
+    let Ok(attrs) = unsafe { CStr::from_ptr(attrs) }.to_str().map(|s| s.to_owned()) else {
+        return;
+    };
+    GROUPS.lock().unwrap().insert(name, attrs);
+}
+
+/// Query attributes for a highlight group.
+/// Returns a newly allocated C string which must be freed by the caller using
+/// `libc::free`.
+#[no_mangle]
+pub extern "C" fn rs_highlight_get(name: *const c_char) -> *mut c_char {
+    let Ok(name) = unsafe { CStr::from_ptr(name) }.to_str().map(|s| s.to_owned()) else {
+        return std::ptr::null_mut();
+    };
+    let Some(attrs) = GROUPS.lock().unwrap().get(&name).cloned() else {
+        return std::ptr::null_mut();
+    };
+    let cstring = match CString::new(attrs) {
+        Ok(c) => c,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    cstring.into_raw()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn define_and_get() {
+        let name = CString::new("MyGroup").unwrap();
+        let attrs = CString::new("fg=red,bg=blue").unwrap();
+        rs_highlight_define(name.as_ptr(), attrs.as_ptr());
+        let res_ptr = rs_highlight_get(name.as_ptr());
+        let res = unsafe { CString::from_raw(res_ptr) };
+        assert_eq!(res.to_str().unwrap(), "fg=red,bg=blue");
+    }
+}

--- a/rust_insexpand/Cargo.toml
+++ b/rust_insexpand/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_insexpand"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_insexpand"
+crate-type = ["staticlib", "rlib"]

--- a/rust_insexpand/src/lib.rs
+++ b/rust_insexpand/src/lib.rs
@@ -1,0 +1,24 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_insexpand_example(input: *const c_char) -> c_int {
+    if input.is_null() {
+        return -1;
+    }
+    let s = unsafe { CStr::from_ptr(input) };
+    s.to_bytes().len() as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn example_works() {
+        let input = CString::new("abc").unwrap();
+        let len = rs_insexpand_example(input.as_ptr());
+        assert_eq!(len, 3);
+    }
+}

--- a/rust_linematch/Cargo.toml
+++ b/rust_linematch/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_linematch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_linematch"
+crate-type = ["staticlib", "rlib"]

--- a/rust_linematch/src/lib.rs
+++ b/rust_linematch/src/lib.rs
@@ -1,0 +1,24 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_linematch_example(input: *const c_char) -> c_int {
+    if input.is_null() {
+        return -1;
+    }
+    let s = unsafe { CStr::from_ptr(input) };
+    s.to_bytes().len() as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn example_works() {
+        let input = CString::new("abc").unwrap();
+        let len = rs_linematch_example(input.as_ptr());
+        assert_eq!(len, 3);
+    }
+}

--- a/rust_mark/Cargo.toml
+++ b/rust_mark/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_mark"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_mark"
+crate-type = ["staticlib", "rlib"]

--- a/rust_mark/src/lib.rs
+++ b/rust_mark/src/lib.rs
@@ -1,0 +1,24 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_mark_example(input: *const c_char) -> c_int {
+    if input.is_null() {
+        return -1;
+    }
+    let s = unsafe { CStr::from_ptr(input) };
+    s.to_bytes().len() as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn example_works() {
+        let input = CString::new("abc").unwrap();
+        let len = rs_mark_example(input.as_ptr());
+        assert_eq!(len, 3);
+    }
+}

--- a/rust_match/Cargo.toml
+++ b/rust_match/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_match"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_match"
+crate-type = ["staticlib", "rlib"]

--- a/rust_match/src/lib.rs
+++ b/rust_match/src/lib.rs
@@ -1,0 +1,24 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_match_example(input: *const c_char) -> c_int {
+    if input.is_null() {
+        return -1;
+    }
+    let s = unsafe { CStr::from_ptr(input) };
+    s.to_bytes().len() as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn example_works() {
+        let input = CString::new("abc").unwrap();
+        let len = rs_match_example(input.as_ptr());
+        assert_eq!(len, 3);
+    }
+}

--- a/rust_textformat/Cargo.toml
+++ b/rust_textformat/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_textformat"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_textformat"
+crate-type = ["staticlib", "rlib"]

--- a/rust_textformat/src/lib.rs
+++ b/rust_textformat/src/lib.rs
@@ -1,0 +1,24 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_textformat_example(input: *const c_char) -> c_int {
+    if input.is_null() {
+        return -1;
+    }
+    let s = unsafe { CStr::from_ptr(input) };
+    s.to_bytes().len() as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn example_works() {
+        let input = CString::new("abc").unwrap();
+        let len = rs_textformat_example(input.as_ptr());
+        assert_eq!(len, 3);
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder Rust crates for highlight, insexpand, match, linematch, mark, and textformat
- expose simple C-callable helper functions in each crate
- wire new crates into the Cargo workspace

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8cf47af9c832081e5582b48b1bd81