### PR TITLE
Remove unused autocmd helpers

### DIFF
--- a/src/rust_autocmd.h
+++ b/src/rust_autocmd.h
@@ -3,8 +3,6 @@
 
 #include "vim.h"
 
-void rust_autocmd_clear(void);
-int rust_autocmd_add(int event, const char *pat, const char *cmd, int once, int nested);
 int rust_autocmd_do(int event, const char *name);
 
 #endif // RUST_AUTOCMD_H


### PR DESCRIPTION
## Summary
- drop `rust_autocmd_clear` and `rust_autocmd_add` declarations
- remove corresponding Rust implementations

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b8cf7839208320aca7a79f5d033b73