### PR TITLE
Add Rust AES crypto helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,13 @@ name = "rust_core"
 version = "0.1.0"
 
 [[package]]
+name = "rust_crypt"
+version = "0.1.0"
+dependencies = [
+ "ring",
+]
+
+[[package]]
 name = "rust_crypto_zip"
 version = "0.1.0"
 dependencies = [

--- a/rust_crypt/Cargo.toml
+++ b/rust_crypt/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_crypt"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+ring = "0.17"

--- a/rust_crypt/src/lib.rs
+++ b/rust_crypt/src/lib.rs
@@ -1,0 +1,97 @@
+use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey, AES_256_GCM};
+use std::slice;
+
+#[no_mangle]
+pub extern "C" fn rust_crypt_encrypt(
+    input: *const u8,
+    input_len: usize,
+    key: *const u8,
+    key_len: usize,
+    output: *mut u8,
+    output_len: usize,
+) -> usize {
+    if input.is_null() || key.is_null() || output.is_null() {
+        return 0;
+    }
+    let data = unsafe { slice::from_raw_parts(input, input_len) };
+    let key_slice = unsafe { slice::from_raw_parts(key, key_len) };
+    if key_slice.len() != 32 {
+        return 0;
+    }
+    let unbound = match UnboundKey::new(&AES_256_GCM, key_slice) {
+        Ok(k) => k,
+        Err(_) => return 0,
+    };
+    let key = LessSafeKey::new(unbound);
+    let nonce_bytes = [0u8; 12];
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+    let mut in_out = data.to_vec();
+    match key.seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out) {
+        Ok(_) => {
+            if in_out.len() > output_len {
+                return 0;
+            }
+            unsafe { std::ptr::copy_nonoverlapping(in_out.as_ptr(), output, in_out.len()); }
+            in_out.len()
+        }
+        Err(_) => 0,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_crypt_decrypt(
+    input: *const u8,
+    input_len: usize,
+    key: *const u8,
+    key_len: usize,
+    output: *mut u8,
+    output_len: usize,
+) -> usize {
+    if input.is_null() || key.is_null() || output.is_null() {
+        return 0;
+    }
+    let mut in_out = unsafe { slice::from_raw_parts(input, input_len).to_vec() };
+    let key_slice = unsafe { slice::from_raw_parts(key, key_len) };
+    if key_slice.len() != 32 {
+        return 0;
+    }
+    let unbound = match UnboundKey::new(&AES_256_GCM, key_slice) {
+        Ok(k) => k,
+        Err(_) => return 0,
+    };
+    let key = LessSafeKey::new(unbound);
+    let nonce_bytes = [0u8; 12];
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+    let plaintext = match key.open_in_place(nonce, Aad::empty(), &mut in_out) {
+        Ok(p) => p,
+        Err(_) => return 0,
+    };
+    if plaintext.len() > output_len {
+        return 0;
+    }
+    unsafe { std::ptr::copy_nonoverlapping(plaintext.as_ptr(), output, plaintext.len()); }
+    plaintext.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip() {
+        let key = [0u8; 32];
+        let msg = b"hello rust";
+        let mut enc = vec![0u8; msg.len() + 16];
+        let enc_len = rust_crypt_encrypt(
+            msg.as_ptr(), msg.len(), key.as_ptr(), key.len(), enc.as_mut_ptr(), enc.len());
+        assert!(enc_len > 0);
+        enc.truncate(enc_len);
+        let mut dec = vec![0u8; msg.len()];
+        let dec_len = rust_crypt_decrypt(
+            enc.as_ptr(), enc.len(), key.as_ptr(), key.len(), dec.as_mut_ptr(), dec.len());
+        assert_eq!(dec_len, msg.len());
+        dec.truncate(dec_len);
+        assert_eq!(msg.to_vec(), dec);
+    }
+}
+

--- a/src/crypt_rs.h
+++ b/src/crypt_rs.h
@@ -2,6 +2,8 @@
 #define CRYPT_RS_H
 
 // structs.h is included via vim.h in C sources; avoid double-including here.
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,6 +13,14 @@ struct cryptmethod_S;
 typedef struct cryptmethod_S cryptmethod_T;
 cryptmethod_T *rust_crypt_methods(void);
 void crypt_state_free(cryptstate_T *state);
+
+// AES-256-GCM convenience wrappers implemented in Rust.
+size_t rust_crypt_encrypt(const uint8_t *input, size_t input_len,
+                          const uint8_t *key, size_t key_len,
+                          uint8_t *output, size_t output_len);
+size_t rust_crypt_decrypt(const uint8_t *input, size_t input_len,
+                          const uint8_t *key, size_t key_len,
+                          uint8_t *output, size_t output_len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add `rust_crypt` crate implementing AES-256-GCM helpers using `ring`
- extend `crypt_rs.h` with prototypes for the new Rust encryption functions

## Testing
- `cargo test -p rust_crypt`

------
https://chatgpt.com/codex/tasks/task_e_68b8d4129b048320a1ba7ce07851ec07