### PR TITLE
Add drawline helper and Windows GUI stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_drawline"
+version = "0.1.0"
+
+[[package]]
 name = "rust_drawscreen"
 version = "0.1.0"
 dependencies = [
@@ -2277,6 +2281,9 @@ dependencies = [
 [[package]]
 name = "rust_gui_core"
 version = "0.1.0"
+dependencies = [
+ "rust_drawline",
+]
 
 [[package]]
 name = "rust_gui_gtk"
@@ -2284,6 +2291,7 @@ version = "0.1.0"
 dependencies = [
  "gtk",
  "rust_clipboard",
+ "rust_drawline",
  "rust_gui_core",
 ]
 
@@ -2321,6 +2329,7 @@ version = "0.1.0"
 dependencies = [
  "rust_clipboard",
  "rust_gui_core",
+ "rust_gui_xpm",
 ]
 
 [[package]]
@@ -2338,6 +2347,10 @@ version = "0.1.0"
 dependencies = [
  "rust_gui_core",
 ]
+
+[[package]]
+name = "rust_gui_xpm"
+version = "0.1.0"
 
 [[package]]
 name = "rust_hashtab"

--- a/rust_clipboard/Cargo.toml
+++ b/rust_clipboard/Cargo.toml
@@ -4,13 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-copypasta = { version = "0.10", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+copypasta = { version = "0.10" }
 
 [features]
 default = []
-windows = ["copypasta"]
-x11 = ["copypasta"]
-wayland = ["copypasta"]
 
 [lib]
 name = "rust_clipboard"

--- a/rust_clipboard/src/lib.rs
+++ b/rust_clipboard/src/lib.rs
@@ -2,30 +2,39 @@ use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::sync::{Mutex, OnceLock};
 
-#[cfg(any(feature = "x11", feature = "wayland", feature = "windows"))]
+#[cfg(target_os = "windows")]
 use copypasta::{ClipboardContext, ClipboardProvider};
 
-#[cfg(not(any(feature = "x11", feature = "wayland", feature = "windows")))]
+#[cfg(not(target_os = "windows"))]
 static MEMORY: OnceLock<Mutex<String>> = OnceLock::new();
 
-#[cfg(not(any(feature = "x11", feature = "wayland", feature = "windows")))]
+#[cfg(not(target_os = "windows"))]
 fn set_clipboard_text(s: &str) -> Result<(), ()> {
-    *MEMORY.get_or_init(|| Mutex::new(String::new())).lock().unwrap() = s.to_string();
+    *MEMORY
+        .get_or_init(|| Mutex::new(String::new()))
+        .lock()
+        .unwrap() = s.to_string();
     Ok(())
 }
 
-#[cfg(not(any(feature = "x11", feature = "wayland", feature = "windows")))]
+#[cfg(not(target_os = "windows"))]
 fn get_clipboard_text() -> Option<String> {
-    Some(MEMORY.get_or_init(|| Mutex::new(String::new())).lock().unwrap().clone())
+    Some(
+        MEMORY
+            .get_or_init(|| Mutex::new(String::new()))
+            .lock()
+            .unwrap()
+            .clone(),
+    )
 }
 
-#[cfg(any(feature = "x11", feature = "wayland", feature = "windows"))]
+#[cfg(target_os = "windows")]
 fn set_clipboard_text(s: &str) -> Result<(), ()> {
     let mut ctx = ClipboardContext::new().map_err(|_| ())?;
     ctx.set_contents(s.to_string()).map_err(|_| ())
 }
 
-#[cfg(any(feature = "x11", feature = "wayland", feature = "windows"))]
+#[cfg(target_os = "windows")]
 fn get_clipboard_text() -> Option<String> {
     let mut ctx = ClipboardContext::new().ok()?;
     ctx.get_contents().ok()
@@ -55,7 +64,11 @@ pub extern "C" fn rs_clipboard_set(data: *const c_char, len: usize) -> c_int {
         Ok(s) => s,
         Err(_) => return -1,
     };
-    if set_clipboard_text(text).is_ok() { 0 } else { -1 }
+    if set_clipboard_text(text).is_ok() {
+        0
+    } else {
+        -1
+    }
 }
 
 #[no_mangle]
@@ -72,7 +85,9 @@ pub extern "C" fn rs_clipboard_get(len: *mut usize) -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn rs_clipboard_free(ptr: *mut c_char, _len: usize) {
     if !ptr.is_null() {
-        unsafe { let _ = CString::from_raw(ptr); }
+        unsafe {
+            let _ = CString::from_raw(ptr);
+        }
     }
 }
 

--- a/rust_drawline/Cargo.toml
+++ b/rust_drawline/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_drawline"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]

--- a/rust_drawline/src/lib.rs
+++ b/rust_drawline/src/lib.rs
@@ -1,0 +1,32 @@
+/// Utilities translated from the legacy `drawline.c` file.
+///
+/// Currently only a small helper is implemented which advances a
+/// pointer to the next color column to draw on the screen.
+
+/// Advance the color column pointer until it is at or beyond `vcol`.
+///
+/// The slice pointed to by `color_cols` is expected to be terminated by
+/// a negative value, matching the convention used in the original C code.
+/// Returns `true` if there are further columns to handle.
+pub fn advance_color_col(vcol: i32, color_cols: &mut &[i32]) -> bool {
+    while !color_cols.is_empty() && color_cols[0] >= 0 && vcol > color_cols[0] {
+        *color_cols = &color_cols[1..];
+    }
+    !color_cols.is_empty() && color_cols[0] >= 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance_across_columns() {
+        let cols = vec![10, 20, -1];
+        let mut slice: &[i32] = &cols;
+        assert!(advance_color_col(5, &mut slice));
+        assert_eq!(slice, &[10, 20, -1]);
+        assert!(advance_color_col(15, &mut slice));
+        assert_eq!(slice, &[20, -1]);
+        assert!(!advance_color_col(25, &mut slice));
+    }
+}

--- a/rust_gui_core/Cargo.toml
+++ b/rust_gui_core/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rust_drawline = { path = "../rust_drawline" }

--- a/rust_gui_core/src/lib.rs
+++ b/rust_gui_core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 
 pub use backend::{GuiBackend, GuiEvent};
+use rust_drawline::advance_color_col;
 
 /// Core GUI handling that delegates to a backend implementation.
 ///
@@ -35,6 +36,13 @@ impl<B: GuiBackend> GuiCore<B> {
         while let Some(event) = self.backend.poll_event() {
             handler(event);
         }
+    }
+
+    /// Wrapper around the `advance_color_col` helper from the screen
+    /// drawing logic.  Exposed here so GUI backends can easily reuse the
+    /// calculation without depending on the low level crate directly.
+    pub fn next_color_col(&self, vcol: i32, color_cols: &mut &[i32]) -> bool {
+        advance_color_col(vcol, color_cols)
     }
 }
 
@@ -102,5 +110,15 @@ mod tests {
                 GuiEvent::Expose,
             ]
         );
+    }
+
+    #[test]
+    fn color_column_helper() {
+        let backend = TestBackend::new();
+        let core = GuiCore::new(backend);
+        let cols = vec![2, -1];
+        let mut slice: &[i32] = &cols;
+        assert!(core.next_color_col(1, &mut slice));
+        assert!(!core.next_color_col(3, &mut slice));
     }
 }

--- a/rust_gui_gtk/Cargo.toml
+++ b/rust_gui_gtk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust_gui_core = { path = "../rust_gui_core" }
 rust_clipboard = { path = "../rust_clipboard" }
 gtk = { version = "0.18", optional = true }
+rust_drawline = { path = "../rust_drawline" }
 
 [features]
 default = []
-

--- a/rust_gui_gtk/src/lib.rs
+++ b/rust_gui_gtk/src/lib.rs
@@ -1,6 +1,7 @@
+use rust_clipboard;
+use rust_drawline::advance_color_col;
 use rust_gui_core::backend::{GuiBackend, GuiEvent};
 use std::collections::VecDeque;
-use rust_clipboard;
 
 #[cfg(feature = "gtk")]
 use gtk::prelude::*;
@@ -48,6 +49,11 @@ pub fn clipboard_get() -> Option<String> {
     rust_clipboard::get_string()
 }
 
+/// Compute the next color column using the shared helper.
+pub fn next_color_col(vcol: i32, color_cols: &mut &[i32]) -> bool {
+    advance_color_col(vcol, color_cols)
+}
+
 #[cfg(feature = "gtk")]
 pub fn gtk_available() -> bool {
     gtk::init().is_ok()
@@ -75,6 +81,14 @@ mod tests {
     fn clipboard_roundtrip() {
         clipboard_set("gtk clipboard").unwrap();
         assert_eq!(clipboard_get().as_deref(), Some("gtk clipboard"));
+    }
+
+    #[test]
+    fn color_column_helper() {
+        let cols = vec![3, -1];
+        let mut slice: &[i32] = &cols;
+        assert!(next_color_col(2, &mut slice));
+        assert!(!next_color_col(4, &mut slice));
     }
 
     #[test]

--- a/rust_gui_w32/Cargo.toml
+++ b/rust_gui_w32/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 rust_gui_core = { path = "../rust_gui_core" }
 rust_clipboard = { path = "../rust_clipboard" }
 
+rust_gui_xpm = { path = "../rust_gui_xpm" }

--- a/rust_gui_w32/src/lib.rs
+++ b/rust_gui_w32/src/lib.rs
@@ -1,6 +1,7 @@
-use rust_gui_core::backend::{GuiBackend, GuiEvent};
-use std::collections::VecDeque;
 use rust_clipboard;
+use rust_gui_core::backend::{GuiBackend, GuiEvent};
+use rust_gui_xpm;
+use std::collections::VecDeque;
 
 /// Minimal Windows backend.  Real drawing is delegated to the platform APIs
 /// but for now these methods record actions for testing purposes.
@@ -12,7 +13,10 @@ pub struct W32Backend {
 
 impl W32Backend {
     pub fn new() -> Self {
-        Self { drawn: Vec::new(), events: VecDeque::new() }
+        Self {
+            drawn: Vec::new(),
+            events: VecDeque::new(),
+        }
     }
 
     /// Queue an event so it can later be retrieved by `poll_event`.
@@ -41,6 +45,12 @@ pub fn clipboard_get() -> Option<String> {
     rust_clipboard::get_string()
 }
 
+/// Load an XPM image from raw data.  On non-Windows platforms this
+/// returns `None` as a stub implementation.
+pub fn load_xpm(data: &[u8]) -> Option<Vec<u8>> {
+    rust_gui_xpm::parse_xpm(data)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -58,5 +68,10 @@ mod tests {
     fn clipboard_roundtrip() {
         clipboard_set("w32 clipboard").unwrap();
         assert_eq!(clipboard_get().as_deref(), Some("w32 clipboard"));
+    }
+
+    #[test]
+    fn xpm_stub_returns_none() {
+        assert!(load_xpm(b"data").is_none());
     }
 }

--- a/rust_gui_xpm/Cargo.toml
+++ b/rust_gui_xpm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_gui_xpm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]

--- a/rust_gui_xpm/src/lib.rs
+++ b/rust_gui_xpm/src/lib.rs
@@ -1,0 +1,32 @@
+/// Minimal XPM image handling for Windows builds.
+///
+/// On non-Windows platforms this module provides stubs so the crate
+/// can be compiled but functions will return `None`.
+
+#[cfg(target_os = "windows")]
+pub fn parse_xpm(data: &[u8]) -> Option<Vec<u8>> {
+    Some(data.to_vec())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn parse_xpm(_data: &[u8]) -> Option<Vec<u8>> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn roundtrip() {
+        let data = b"abc";
+        assert_eq!(parse_xpm(data).unwrap(), data);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn not_supported() {
+        assert!(parse_xpm(b"abc").is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- port small drawline helper to new `rust_drawline` crate and expose through GUI core and GTK backend
- add Windows-only XPM parsing stub and wire into Win32 GUI backend
- gate clipboard implementation on `cfg(target_os)` for Windows

## Testing
- `cargo test -p rust_drawline`
- `cargo test -p rust_gui_xpm`
- `cargo test -p rust_gui_w32`
- `cargo test -p rust_gui_core`
- `cargo test -p rust_gui_gtk`
- `cargo test -p rust_clipboard`


------
https://chatgpt.com/codex/tasks/task_e_68b8d413edb08320919f0a0e5c16db9c