### PR TITLE
Add stub free_unused_terminals

### DIFF
--- a/src/proto/terminal.pro
+++ b/src/proto/terminal.pro
@@ -1,4 +1,5 @@
 /* terminal stubs (minimal build) */
+void free_unused_terminals(void);
 int term_none_open(void *term);
 void term_clear_status_text(void *term);
 char_u *term_get_status_text(void *term);

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1,0 +1,22 @@
+#include "vim.h"
+
+// Stub implementations for terminal support in minimal builds.
+
+void free_unused_terminals(void)
+{
+    // No terminals to free in this build.
+}
+
+int term_none_open(void *term UNUSED)
+{
+    return FAIL;
+}
+
+void term_clear_status_text(void *term UNUSED)
+{
+}
+
+char_u *term_get_status_text(void *term UNUSED)
+{
+    return NULL;
+}


### PR DESCRIPTION
## Summary
- provide stub implementations for terminal-related helpers
- declare free_unused_terminals in terminal prototypes

## Testing
- `gcc -c src/terminal.c -I src` *(fails: Vim only works with 32 bit int or larger)*
- `make -C src objects/terminal.o` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68b8debf533c8320bac275a767f6d316