### PR TITLE
Remove obsolete NetBeans commands

### DIFF
--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -376,8 +376,6 @@ pathname	String argument: file name with full path.
 
 6.3 Commands						*nb-commands*
 
-actionMenuItem	Not implemented.
-
 actionSensitivity
 		Not implemented.
 
@@ -617,8 +615,6 @@ unguard off len
 		Opposite of "guard", remove guarding for a text area.
 		Also sets the current buffer, if necessary.
 
-version		Not implemented.
-
 
 6.4 Functions and Replies				*nb-functions*
 
@@ -814,9 +810,6 @@ startupDone	The editor has finished its startup work and is ready for
 
 unmodified	The buffer is now unmodified.
 		Only fired when enabled, see "startDocumentListen".
-
-version vers	Report the version of the interface implementation.  Vim
-		reports "2.4" (including the quotes).
 
 
 6.6 Special messages					*nb-special*

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -219,8 +219,6 @@ netbeans_connect(char *params, int doabort)
 	    vim_snprintf(buf, sizeof(buf), "AUTH %s\n", password);
 	    nb_send(buf, "netbeans_connect");
 
-	    sprintf(buf, "0:version=0 \"%s\"\n", ExtEdProtocolVersion);
-	    nb_send(buf, "externaleditor_version");
 	}
     }
 
@@ -2193,19 +2191,10 @@ nb_do_cmd(
 	    special_keys(args);
 // =====================================================================
 	}
-	else if (streq((char *)cmd, "actionMenuItem"))
-	{
-	    // not used yet
-// =====================================================================
-	}
-	else if (streq((char *)cmd, "version"))
-	{
-	    // not used yet
-	}
-	else
-	{
-	    nbdebug(("Unrecognised command: %s\n", cmd));
-	}
+        else
+        {
+            nbdebug(("Unrecognised command: %s\n", cmd));
+        }
 	/*
 	 * Unrecognized command is ignored.
 	 */

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -47,12 +47,10 @@ func Nb_basic(port)
   " Establish the connection with the netbeans server
   exe 'nbstart :localhost:' .. a:port .. ':bunny'
   call assert_true(has("netbeans_enabled"))
-  call WaitFor('len(ReadXnetbeans()) > (g:last + 2)')
+  call WaitFor('len(ReadXnetbeans()) > (g:last + 1)')
   let l = ReadXnetbeans()
-  call assert_equal(['AUTH bunny',
-        \ '0:version=0 "2.5"',
-        \ '0:startupDone=0'], l[-3:])
-  let g:last += 3
+  call assert_equal(['AUTH bunny', '0:startupDone=0'], l[-2:])
+  let g:last += 2
 
   " Trying to connect again to netbeans server should fail
   call assert_fails("exe 'nbstart :localhost:' . a:port . ':bunny'", 'E511:')
@@ -856,12 +854,10 @@ func Nb_file_auth(port)
   exe 'nbstart =Xnbauth'
   call assert_true(has("netbeans_enabled"))
 
-  call WaitFor('len(ReadXnetbeans()) > 2')
+  call WaitFor('len(ReadXnetbeans()) > 1')
   nbclose
   let lines = ReadXnetbeans()
-  call assert_equal('AUTH bunny', lines[0])
-  call assert_equal('0:version=0 "2.5"', lines[1])
-  call assert_equal('0:startupDone=0', lines[2])
+  call assert_equal(['AUTH bunny', '0:startupDone=0'], lines)
 
   call delete("Xnbauth")
 endfunc
@@ -888,11 +884,9 @@ func Nb_quit_with_conn(port)
       " Establish the connection with the netbeans server
       exe 'nbstart :localhost:' .. g:port .. ':star'
       call assert_true(has("netbeans_enabled"))
-      call WaitFor('len(ReadXnetbeans()) >= 3')
+      call WaitFor('len(ReadXnetbeans()) >= 2')
       let l = ReadXnetbeans()
-      call assert_equal(['AUTH star',
-        \ '0:version=0 "2.5"',
-        \ '0:startupDone=0'], l[-3:])
+      call assert_equal(['AUTH star', '0:startupDone=0'], l[-2:])
 
       " Open the command buffer to communicate with the server
       split Xcmdbuf
@@ -939,10 +933,8 @@ func Nb_bwipe_buffer(port)
   exe 'nbstart :localhost:' .. a:port .. ':bunny'
   call WaitFor('len(ReadXnetbeans()) > (g:last + 2)')
   let l = ReadXnetbeans()
-  call assert_equal(['AUTH bunny',
-        \ '0:version=0 "2.5"',
-        \ '0:startupDone=0'], l[-3:])
-  let g:last += 3
+  call assert_equal(['AUTH bunny', '0:startupDone=0'], l[-2:])
+  let g:last += 2
 
   " Open the command buffer to communicate with the server
   split Xcmdbuf


### PR DESCRIPTION
## Summary
- drop unused `actionMenuItem` and `version` command handlers from NetBeans interface
- remove documentation and tests that referenced these obsolete commands
- stop sending NetBeans protocol version message on connect

## Testing
- `cargo build`
- `cargo test`
- ❌ `make -C src/testdir test_netbeans.res` (missing `../vim` target)


------
https://chatgpt.com/codex/tasks/task_e_68b8de98051483208a747d42c19685c4