### PR TITLE
Remove unused parameters in UI and Vim9 compilation

### DIFF
--- a/src/proto/ui.pro
+++ b/src/proto/ui.pro
@@ -1,5 +1,5 @@
 /* ui.c */
-void ui_write(char_u *s, int len, int console);
+void ui_write(char_u *s, int len);
 void ui_inchar_undo(char_u *s, int len);
 int ui_inchar(char_u *buf, int maxlen, long wtime, int tb_change_cnt);
 int inchar_loop(char_u *buf, int maxlen, long wtime, int tb_change_cnt, int (*wait_func)(long wtime, int *interrupted, int ignore_input), int (*resize_func)(int check_only));
@@ -24,7 +24,7 @@ void add_to_input_buf(char_u *s, int len);
 void add_to_input_buf_csi(char_u *str, int len);
 void trash_input_buf(void);
 int read_from_input_buf(char_u *buf, long maxlen);
-void fill_input_buf(int exit_on_error);
+void fill_input_buf(void);
 void read_error_exit(void);
 void ui_cursor_shape_forced(int forced);
 void ui_cursor_shape(void);

--- a/src/ui.c
+++ b/src/ui.c
@@ -21,9 +21,8 @@
 extern void rs_ui_write(char *msg, int len);
 
     void
-ui_write(char_u *s, int len, int console UNUSED)
+ui_write(char_u *s, int len)
 {
-    (void)console;
     rs_ui_write((char *)s, len);
 }
 
@@ -866,7 +865,7 @@ trash_input_buf(void)
 read_from_input_buf(char_u *buf, long maxlen)
 {
     if (inbufcount == 0)	// if the buffer is empty, fill it
-	fill_input_buf(TRUE);
+	fill_input_buf();
     if (maxlen > inbufcount)
 	maxlen = inbufcount;
     mch_memmove(buf, inbuf, (size_t)maxlen);
@@ -878,7 +877,7 @@ read_from_input_buf(char_u *buf, long maxlen)
 }
 
     void
-fill_input_buf(int exit_on_error UNUSED)
+fill_input_buf(void)
 {
 #if defined(UNIX) || defined(VMS) || defined(MACOS_X)
     int		len;

--- a/src/vim9cmds.c
+++ b/src/vim9cmds.c
@@ -2130,7 +2130,7 @@ compile_defer(char_u *arg_start, cctx_T *cctx)
 compile_mult_expr(
 	char_u	*arg,
 	int	cmdidx,
-	long	cmd_count UNUSED,
+	long	cmd_count,
 	cctx_T	*cctx)
 {
     char_u	*p = arg;

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -4064,9 +4064,8 @@ exec_instructions(ectx_T *ectx)
 #endif
 			    else if (iptr->isn_type == ISN_ECHOCONSOLE)
 			    {
-				ui_write(ga.ga_data, (int)STRLEN(ga.ga_data),
-									 TRUE);
-				ui_write((char_u *)"\r\n", 2, TRUE);
+                                ui_write(ga.ga_data, (int)STRLEN(ga.ga_data));
+                                ui_write((char_u *)"\r\n", 2);
 			    }
 			    else
 			    {


### PR DESCRIPTION
## Summary
- drop unused console flag from `ui_write`
- remove unused exit_on_error argument from `fill_input_buf`
- mark `cmd_count` as used in `compile_mult_expr`

## Testing
- `cargo test`
- `make -C src` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de8faf1c832094236f1642e49134