### PR TITLE
Remove obsolete NetBeans style and highlight setup

### DIFF
--- a/runtime/doc/netbeans.txt
+++ b/runtime/doc/netbeans.txt
@@ -460,9 +460,11 @@ endAtomic	End an atomic operation.  The changes between "startAtomic"
 		implemented yet.  Redraw when necessary.
 
 guard off len
-		Mark an area in the buffer as guarded.  This means it cannot
-		be edited.  "off" and "len" are numbers and specify the text
-		to be guarded.
+                Mark an area in the buffer as guarded.  This means it cannot
+                be edited.  "off" and "len" are numbers and specify the text
+                to be guarded.  Vim no longer defines a highlight or sign for
+                guarded lines; the client must define its own if visual
+                indication is desired.
 
 initDone	Mark the buffer as ready for use.  Implicitly makes the buffer
 		the current buffer.  Fires the BufReadPost autocommand event.
@@ -568,7 +570,7 @@ setReadOnly readonly
 		buffer as readonly, when it is "F" for False, mark it as not
 		readonly.  Implemented in version 2.3.
 
-setStyle	Not implemented.
+setStyle	Removed.  Previously not implemented.
 
 setTitle name
 		Set the title for the buffer to "name", a string argument.

--- a/src/netbeans.c
+++ b/src/netbeans.c
@@ -53,7 +53,6 @@ static void special_keys(char_u *args);
 
 static int getConnInfo(char *file, char **host, char **port, char **password);
 
-static void nb_init_graphics(void);
 static void coloncmd(char *cmd, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 static void nb_set_curbuf(buf_T *buf);
 static void nb_parse_cmd(char_u *);
@@ -1892,13 +1891,8 @@ nb_do_cmd(
 	    do_update = 1;
 // =====================================================================
 	}
-	else if (streq((char *)cmd, "setStyle")) // obsolete...
-	{
-	    nbdebug(("    setStyle is obsolete!\n"));
-// =====================================================================
-	}
-	else if (streq((char *)cmd, "setExitDelay"))
-	{
+        else if (streq((char *)cmd, "setExitDelay"))
+        {
 	    // Only used in version 2.1.
 // =====================================================================
 	}
@@ -2056,9 +2050,7 @@ nb_do_cmd(
 		return OK;
 	    }
 
-	    nb_init_graphics();
-
-	    if (buf == NULL || buf->bufp == NULL)
+            if (buf == NULL || buf->bufp == NULL)
 	    {
 		nbdebug(("    invalid buffer identifier in %s command\n", cmd));
 		return FAIL;
@@ -2358,24 +2350,6 @@ ex_nbstart(
 # endif
 #endif
     netbeans_open((char *)eap->arg, FALSE);
-}
-
-/*
- * Initialize highlights and signs for use by netbeans  (mostly obsolete)
- */
-    static void
-nb_init_graphics(void)
-{
-    static int did_init = FALSE;
-
-    if (did_init)
-	return;
-
-    coloncmd(":highlight NBGuarded guibg=Cyan guifg=Black"
-	    " ctermbg=LightCyan ctermfg=Black");
-    coloncmd(":sign define %d linehl=NBGuarded", GUARDED);
-
-    did_init = TRUE;
 }
 
 /*

--- a/src/testdir/test_netbeans.vim
+++ b/src/testdir/test_netbeans.vim
@@ -563,12 +563,6 @@ func Nb_basic(port)
   call assert_fails('normal 2GIbaz', 'E463:')
   call assert_fails('normal 2GAbaz', 'E463:')
   call assert_fails('normal dd', 'E463:')
-  call assert_equal([{'name': '1', 'texthl': 'NB_s1', 'text': '=>'},
-        \ {'name': '10000', 'linehl': 'NBGuarded'}],
-        \ sign_getdefined())
-  let s = sign_getplaced()[0].signs[0]
-  call assert_equal(2, s.lnum)
-  call assert_equal('10000', s.name)
   let g:last += 3
 
   " setModified test


### PR DESCRIPTION
## Summary
- remove legacy `setStyle` handler and NetBeans highlight/sign initialization
- document removal and update guard command docs
- drop guard highlight expectations from NetBeans tests

## Testing
- `make -C src -j4` *(fails: missing separator)*
- `make -C src/testdir test_netbeans.res` *(fails: No rule to make target '../vim')*
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68b8de8e1d6883209c728032ce626f7c