### PR TITLE
Add stub Rust ports for hardcopy, sound and Windows helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_exeval"
+version = "0.1.0"
+dependencies = [
+ "rust_excmds",
+]
+
+[[package]]
 name = "rust_ffi"
 version = "0.1.0"
 
@@ -2373,6 +2380,13 @@ name = "rust_gui_xim"
 version = "0.1.0"
 dependencies = [
  "rust_gui_core",
+]
+
+[[package]]
+name = "rust_hardcopy"
+version = "0.1.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2634,6 +2648,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_register"
+version = "0.1.0"
+dependencies = [
+ "rust_clipboard",
+]
+
+[[package]]
 name = "rust_screen"
 version = "0.1.0"
 dependencies = [
@@ -2666,6 +2687,14 @@ name = "rust_sign"
 version = "0.1.0"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "rust_sound"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2709,6 +2738,13 @@ name = "rust_term"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "libc",
+]
+
+[[package]]
+name = "rust_termlib"
+version = "0.1.0"
+dependencies = [
  "libc",
 ]
 
@@ -2824,10 +2860,25 @@ name = "rust_viminfo"
 version = "0.1.0"
 
 [[package]]
+name = "rust_vimrun"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "rust_wayland"
 version = "0.1.0"
 dependencies = [
  "wayland-client 0.30.2",
+]
+
+[[package]]
+name = "rust_winclip"
+version = "0.1.0"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2847,6 +2898,13 @@ version = "0.1.0"
 dependencies = [
  "diff",
  "similar",
+]
+
+[[package]]
+name = "rust_xpm_w32"
+version = "0.1.0"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3424,6 +3482,7 @@ dependencies = [
  "rust_fold",
  "rust_fuzzy",
  "rust_gc",
+ "rust_hardcopy",
  "rust_job",
  "rust_message",
  "rust_os_amiga",
@@ -3434,9 +3493,14 @@ dependencies = [
  "rust_pty",
  "rust_python",
  "rust_sha256",
+ "rust_sound",
  "rust_spell",
+ "rust_termlib",
  "rust_vim9class",
+ "rust_vimrun",
  "rust_wayland",
+ "rust_winclip",
+ "rust_xpm_w32",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ rust_evalwindow = { path = "rust_evalwindow" }
 rust_fuzzy = { path = "rust_fuzzy" }
 rust_gc = { path = "rust_gc" }
 rust_clipboard = { path = "rust_clipboard" }
+rust_hardcopy = { path = "rust_hardcopy" }
+rust_sound = { path = "rust_sound" }
+rust_termlib = { path = "rust_termlib" }
 regex = "1"
 blowfish = "0.8"
 pbkdf2 = "0.12"
@@ -54,6 +57,9 @@ default = []
 
 [target.'cfg(windows)'.dependencies]
 rust_os_win32 = { path = "rust_os_win32" }
+rust_winclip = { path = "rust_winclip" }
+rust_xpm_w32 = { path = "rust_xpm_w32" }
+rust_vimrun = { path = "rust_vimrun" }
 
 [target.'cfg(unix)'.dependencies]
 rust_os_unix = { path = "rust_os_unix" }

--- a/rust_hardcopy/Cargo.toml
+++ b/rust_hardcopy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_hardcopy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_hardcopy"
+crate-type = ["staticlib", "rlib"]

--- a/rust_hardcopy/src/lib.rs
+++ b/rust_hardcopy/src/lib.rs
@@ -1,0 +1,12 @@
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_hardcopy_print(text: *const c_char) -> c_int {
+    if text.is_null() {
+        return -1;
+    }
+    unsafe {
+        libc::puts(text);
+    }
+    0
+}

--- a/rust_sound/Cargo.toml
+++ b/rust_sound/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust_sound"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winuser"] }
+
+[lib]
+name = "rust_sound"
+crate-type = ["staticlib", "rlib"]

--- a/rust_sound/src/lib.rs
+++ b/rust_sound/src/lib.rs
@@ -1,0 +1,15 @@
+use std::os::raw::c_int;
+
+#[no_mangle]
+pub extern "C" fn rs_sound_beep() -> c_int {
+    #[cfg(windows)]
+    unsafe {
+        winapi::um::winuser::MessageBeep(winapi::um::winuser::MB_OK);
+    }
+    #[cfg(not(windows))]
+    unsafe {
+        libc::putchar(0x07 as c_int);
+        libc::fflush(std::ptr::null_mut());
+    }
+    0
+}

--- a/rust_termlib/Cargo.toml
+++ b/rust_termlib/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_termlib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_termlib"
+crate-type = ["staticlib", "rlib"]

--- a/rust_termlib/src/lib.rs
+++ b/rust_termlib/src/lib.rs
@@ -1,0 +1,9 @@
+use std::os::raw::c_int;
+
+#[no_mangle]
+pub extern "C" fn rs_termlib_clear() -> c_int {
+    unsafe {
+        libc::printf(b"\x1B[2J\x1B[H\0".as_ptr() as *const _);
+    }
+    0
+}

--- a/rust_vimrun/Cargo.toml
+++ b/rust_vimrun/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust_vimrun"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["shellapi", "winuser"] }
+
+[lib]
+name = "rust_vimrun"
+crate-type = ["staticlib", "rlib"]

--- a/rust_vimrun/src/lib.rs
+++ b/rust_vimrun/src/lib.rs
@@ -1,0 +1,24 @@
+use std::os::raw::{c_char, c_int};
+
+#[no_mangle]
+pub extern "C" fn rs_vimrun(cmd: *const c_char) -> c_int {
+    if cmd.is_null() {
+        return -1;
+    }
+    #[cfg(windows)]
+    unsafe {
+        winapi::um::shellapi::ShellExecuteA(
+            std::ptr::null_mut(),
+            b"open\0".as_ptr() as *const i8,
+            cmd,
+            std::ptr::null(),
+            std::ptr::null(),
+            winapi::um::winuser::SW_SHOWNORMAL,
+        );
+    }
+    #[cfg(not(windows))]
+    unsafe {
+        libc::system(cmd);
+    }
+    0
+}

--- a/rust_winclip/Cargo.toml
+++ b/rust_winclip/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_winclip"
+version = "0.1.0"
+edition = "2021"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winuser"] }
+
+[lib]
+name = "rust_winclip"
+crate-type = ["staticlib", "rlib"]

--- a/rust_winclip/src/lib.rs
+++ b/rust_winclip/src/lib.rs
@@ -1,0 +1,10 @@
+use std::os::raw::c_int;
+
+#[no_mangle]
+pub extern "C" fn rs_winclip_beep() -> c_int {
+    #[cfg(windows)]
+    unsafe {
+        winapi::um::winuser::MessageBeep(0);
+    }
+    0
+}

--- a/rust_xpm_w32/Cargo.toml
+++ b/rust_xpm_w32/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_xpm_w32"
+version = "0.1.0"
+edition = "2021"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winuser"] }
+
+[lib]
+name = "rust_xpm_w32"
+crate-type = ["staticlib", "rlib"]

--- a/rust_xpm_w32/src/lib.rs
+++ b/rust_xpm_w32/src/lib.rs
@@ -1,0 +1,10 @@
+use std::os::raw::c_int;
+
+#[no_mangle]
+pub extern "C" fn rs_xpm_w32_beep() -> c_int {
+    #[cfg(windows)]
+    unsafe {
+        winapi::um::winuser::MessageBeep(0);
+    }
+    0
+}


### PR DESCRIPTION
## Summary
- add rust_hardcopy, rust_sound, rust_termlib, rust_winclip, rust_xpm_w32, rust_vimrun crates
- wrap basic OS calls via libc or winapi
- wire crates into workspace with conditional windows deps

## Testing
- `cargo test -p rust_hardcopy -p rust_sound -p rust_termlib -p rust_winclip -p rust_xpm_w32 -p rust_vimrun`

------
https://chatgpt.com/codex/tasks/task_e_68b8de33429883208acb732f1c5d2463