### PR TITLE
Port misc helper functions to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ blowfish = "0.8"
 pbkdf2 = "0.12"
 ring = "0.17"
 rust_vim9class = { path = "rust_vim9class" }
+rust_misc1 = { path = "rust_misc1" }
+rust_misc2 = { path = "rust_misc2" }
 
 [features]
 default = []

--- a/rust_misc1/Cargo.toml
+++ b/rust_misc1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_misc1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_misc1"
+crate-type = ["staticlib", "rlib"]

--- a/rust_misc1/src/lib.rs
+++ b/rust_misc1/src/lib.rs
@@ -1,0 +1,30 @@
+use libc::{c_int, c_long, c_longlong};
+
+const OK: c_int = 1;
+const FAIL: c_int = 0;
+
+#[no_mangle]
+pub extern "C" fn vim_append_digit_long(value: *mut c_long, digit: c_int) -> c_int {
+    if value.is_null() {
+        return FAIL;
+    }
+    unsafe {
+        let x = *value;
+        if x > ((c_long::MAX - digit as c_long) / 10) {
+            return FAIL;
+        }
+        *value = x.wrapping_mul(10) + digit as c_long;
+    }
+    OK
+}
+
+#[no_mangle]
+pub extern "C" fn trim_to_int(x: c_longlong) -> c_int {
+    if x > c_int::MAX as c_longlong {
+        c_int::MAX
+    } else if x < c_int::MIN as c_longlong {
+        c_int::MIN
+    } else {
+        x as c_int
+    }
+}

--- a/rust_misc2/Cargo.toml
+++ b/rust_misc2/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_misc2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_misc2"
+crate-type = ["staticlib", "rlib"]

--- a/rust_misc2/src/lib.rs
+++ b/rust_misc2/src/lib.rs
@@ -1,0 +1,6 @@
+use libc::c_int;
+
+#[no_mangle]
+pub extern "C" fn vim_isspace(x: c_int) -> c_int {
+    ((x >= 9 && x <= 13) || x == 32) as c_int
+}

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -2861,21 +2861,7 @@ may_trigger_modechanged(void)
 #endif
 }
 
-// For overflow detection, add a digit safely to a long value.
-    int
-vim_append_digit_long(long *value, int digit)
-{
-    long x = *value;
-    if (x > ((LONG_MAX - (long)digit) / 10))
-	return FAIL;
-    *value = x * 10 + (long)digit;
-    return OK;
-}
-
-// Return something that fits into an int.
-    int
-trim_to_int(vimlong_T x)
-{
-    return x > INT_MAX ? INT_MAX : x < INT_MIN ? INT_MIN : x;
-}
+// FFI: implemented in rust_misc1 crate
+// vim_append_digit_long()
+// trim_to_int()
 

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -745,15 +745,8 @@ vim_memset(void *ptr, int c, size_t size)
 }
 #endif
 
-/*
- * Vim has its own isspace() function, because on some machines isspace()
- * can't handle characters above 128.
- */
-    int
-vim_isspace(int x)
-{
-    return ((x >= 9 && x <= 13) || x == ' ');
-}
+// FFI: implemented in rust_misc2 crate
+// vim_isspace()
 
 /************************************************************************
  * functions that use lookup tables for various things, generally to do with


### PR DESCRIPTION
## Summary
- Implement `vim_append_digit_long` and `trim_to_int` in new `rust_misc1` crate
- Provide `vim_isspace` via new `rust_misc2` crate
- Remove the C implementations and wire crates into workspace

## Testing
- `cargo test -p rust_misc1`
- `cargo test -p rust_misc2`
- `cargo build -p vim_channel`


------
https://chatgpt.com/codex/tasks/task_e_68b8de318e288320b4e2f0c107806c01