### PR TITLE
Add NetBeans protocol client and debugging utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_exeval"
+version = "0.1.0"
+dependencies = [
+ "rust_excmds",
+]
+
+[[package]]
 name = "rust_ffi"
 version = "0.1.0"
 
@@ -2495,6 +2502,22 @@ name = "rust_move"
 version = "0.1.0"
 
 [[package]]
+name = "rust_nbdebug"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "rust_netbeans"
+version = "0.1.0"
+dependencies = [
+ "rust_channel",
+ "rust_nbdebug",
+ "tokio",
+]
+
+[[package]]
 name = "rust_normal"
 version = "0.1.0"
 
@@ -2631,6 +2654,13 @@ dependencies = [
  "criterion 0.5.1",
  "regex",
  "rust_fuzzy",
+]
+
+[[package]]
+name = "rust_register"
+version = "0.1.0"
+dependencies = [
+ "rust_clipboard",
 ]
 
 [[package]]
@@ -3426,6 +3456,8 @@ dependencies = [
  "rust_gc",
  "rust_job",
  "rust_message",
+ "rust_nbdebug",
+ "rust_netbeans",
  "rust_os_amiga",
  "rust_os_qnx",
  "rust_os_unix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ rust_evalwindow = { path = "rust_evalwindow" }
 rust_fuzzy = { path = "rust_fuzzy" }
 rust_gc = { path = "rust_gc" }
 rust_clipboard = { path = "rust_clipboard" }
+rust_nbdebug = { path = "rust_nbdebug" }
+rust_netbeans = { path = "rust_netbeans" }
 regex = "1"
 blowfish = "0.8"
 pbkdf2 = "0.12"

--- a/rust_channel/Cargo.toml
+++ b/rust_channel/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "rust_channel"
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "io-util"] }

--- a/rust_nbdebug/Cargo.toml
+++ b/rust_nbdebug/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rust_nbdebug"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+once_cell = "1"

--- a/rust_nbdebug/src/lib.rs
+++ b/rust_nbdebug/src/lib.rs
@@ -1,0 +1,129 @@
+use once_cell::sync::Lazy;
+use std::ffi::CStr;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::os::raw::c_char;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
+use std::{env, thread, time::Duration};
+
+static NB_DEBUG_FILE: Lazy<Mutex<Option<std::fs::File>>> = Lazy::new(|| Mutex::new(None));
+static NB_DLEVEL: AtomicU32 = AtomicU32::new(0);
+
+const NB_TRACE: u32 = 0x00000001;
+const WT_ENV: u32 = 1;
+const WT_WAIT: u32 = 2;
+const WT_STOP: u32 = 3;
+
+/// Internal helper to log a message if debugging is enabled.
+pub fn nbdbg(msg: &str) {
+    if NB_DLEVEL.load(Ordering::Relaxed) & NB_TRACE != 0 {
+        if let Ok(mut guard) = NB_DEBUG_FILE.lock() {
+            if let Some(f) = guard.as_mut() {
+                let _ = writeln!(f, "{}", msg);
+            }
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_nbdbg(msg: *const c_char) {
+    if msg.is_null() {
+        return;
+    }
+    if let Ok(s) = CStr::from_ptr(msg).to_str() {
+        nbdbg(s);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_nbdebug_log_init(log_var: *const c_char, level_var: *const c_char) {
+    let log_path = if !log_var.is_null() {
+        let var = CStr::from_ptr(log_var).to_string_lossy().to_string();
+        env::var(var).ok()
+    } else {
+        None
+    };
+
+    if let Some(path) = log_path {
+        if let Ok(file) = OpenOptions::new().create(true).append(true).open(&path) {
+            if let Ok(mut guard) = NB_DEBUG_FILE.lock() {
+                *guard = Some(file);
+            }
+        }
+        let level = if !level_var.is_null() {
+            let var = CStr::from_ptr(level_var).to_string_lossy().to_string();
+            env::var(var).ok()
+        } else {
+            None
+        };
+        let lvl = level
+            .and_then(|s| u32::from_str_radix(&s, 0).ok())
+            .unwrap_or(NB_TRACE);
+        NB_DLEVEL.store(lvl, Ordering::Relaxed);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_nbdebug_wait(wait_flags: u32, wait_var: *const c_char, wait_secs: u32) {
+    // Determine the number of seconds to wait based on flags and environment.
+    if (wait_flags & WT_ENV) != 0 && !wait_var.is_null() {
+        if let Ok(var) = CStr::from_ptr(wait_var).to_str() {
+            if let Ok(val) = env::var(var) {
+                if let Ok(secs) = val.parse::<u64>() {
+                    thread::sleep(Duration::from_secs(secs));
+                    return;
+                }
+            }
+        }
+    }
+    if (wait_flags & WT_WAIT) != 0 {
+        if let Some(home) = env::var_os("HOME") {
+            let mut path = PathBuf::from(home);
+            path.push(".gvimwait");
+            if path.exists() {
+                let secs = wait_secs.min(120).max(1) as u64;
+                thread::sleep(Duration::from_secs(secs));
+                return;
+            }
+        }
+    }
+    if (wait_flags & WT_STOP) != 0 {
+        if let Some(home) = env::var_os("HOME") {
+            let mut path = PathBuf::from(home);
+            path.push(".gvimstop");
+            if path.exists() {
+                loop {
+                    thread::sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn log_messages() {
+        let dir = env::temp_dir();
+        let file_path = dir.join("nbdebug_test.log");
+        if let Ok(file) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file_path)
+        {
+            if let Ok(mut guard) = NB_DEBUG_FILE.lock() {
+                *guard = Some(file);
+            }
+        }
+        NB_DLEVEL.store(1, Ordering::Relaxed);
+        nbdbg("hello");
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert!(content.contains("hello"));
+        let _ = fs::remove_file(file_path);
+    }
+}

--- a/rust_netbeans/Cargo.toml
+++ b/rust_netbeans/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_netbeans"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["net", "io-util", "rt", "macros"] }
+rust_channel = { path = "../rust_channel" }
+rust_nbdebug = { path = "../rust_nbdebug" }

--- a/rust_netbeans/src/lib.rs
+++ b/rust_netbeans/src/lib.rs
@@ -1,0 +1,137 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::ptr;
+
+use rust_channel::{channel_close, channel_open, channel_receive, channel_send, Channel};
+use rust_nbdebug::nbdbg;
+
+/// Safe wrapper around the low-level `Channel` to communicate using the
+/// NetBeans protocol.
+pub struct NetBeansClient {
+    chan: *mut Channel,
+}
+
+impl NetBeansClient {
+    /// Connect to a NetBeans server at the given address (host:port).
+    pub fn connect(addr: &str) -> Option<Self> {
+        let caddr = CString::new(addr).ok()?;
+        let chan = channel_open(caddr.as_ptr());
+        if chan.is_null() {
+            None
+        } else {
+            Some(Self { chan })
+        }
+    }
+
+    /// Send a raw protocol command.
+    pub fn send(&self, cmd: &str) -> bool {
+        nbdbg(&format!("SEND: {}", cmd));
+        let c = CString::new(cmd).unwrap();
+        channel_send(self.chan, c.as_ptr(), c.as_bytes().len()) == 0
+    }
+
+    /// Receive a message from the server, if any.
+    pub fn receive(&self) -> Option<String> {
+        let mut buf = vec![0u8; 4096];
+        let n = channel_receive(self.chan, buf.as_mut_ptr() as *mut c_char, buf.len());
+        if n > 0 {
+            let msg = String::from_utf8_lossy(&buf[..n as usize]).into_owned();
+            nbdbg(&format!("RECV: {}", msg));
+            Some(msg)
+        } else {
+            None
+        }
+    }
+
+    /// Close the connection.
+    pub fn close(self) {
+        channel_close(self.chan)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_netbeans_connect(addr: *const c_char) -> *mut NetBeansClient {
+    if addr.is_null() {
+        return ptr::null_mut();
+    }
+    let addr_str = unsafe { CStr::from_ptr(addr).to_string_lossy().to_string() };
+    match NetBeansClient::connect(&addr_str) {
+        Some(c) => Box::into_raw(Box::new(c)),
+        None => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_netbeans_send(client: *mut NetBeansClient, msg: *const c_char) -> c_int {
+    if client.is_null() || msg.is_null() {
+        return -1;
+    }
+    let client = unsafe { &mut *client };
+    let msg_str = unsafe { CStr::from_ptr(msg).to_string_lossy().to_string() };
+    if client.send(&msg_str) {
+        0
+    } else {
+        -1
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_netbeans_receive(
+    client: *mut NetBeansClient,
+    buf: *mut c_char,
+    len: usize,
+) -> isize {
+    if client.is_null() || buf.is_null() {
+        return -1;
+    }
+    let client = unsafe { &mut *client };
+    if let Some(msg) = client.receive() {
+        let bytes = msg.as_bytes();
+        let n = len.min(bytes.len());
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf as *mut u8, n);
+        }
+        n as isize
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_netbeans_close(client: *mut NetBeansClient) {
+    if client.is_null() {
+        return;
+    }
+    unsafe {
+        Box::from_raw(client).close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    #[test]
+    fn basic_comm() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 1024];
+            let n = sock.read(&mut buf).unwrap();
+            sock.write_all(&buf[..n]).unwrap();
+        });
+        let caddr = CString::new(format!("{}", addr)).unwrap();
+        let client_ptr = rs_netbeans_connect(caddr.as_ptr());
+        assert!(!client_ptr.is_null());
+        let msg = CString::new("ping").unwrap();
+        assert_eq!(rs_netbeans_send(client_ptr, msg.as_ptr()), 0);
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let mut buf = [0i8; 1024];
+        let n = rs_netbeans_receive(client_ptr, buf.as_mut_ptr(), 1024);
+        assert!(n > 0);
+        rs_netbeans_close(client_ptr);
+    }
+}


### PR DESCRIPTION
## Summary
- add `rust_nbdebug` crate for NetBeans debugging support with logging and startup delay helpers
- implement `rust_netbeans` client using `rust_channel` for NetBeans protocol messaging
- expose `rust_channel` as an `rlib` and wire new crates into the workspace

## Testing
- `cargo test -p rust_nbdebug -p rust_netbeans`


------
https://chatgpt.com/codex/tasks/task_e_68b8de329d608320895c2effe36b7180