### PR TITLE
Add Rust crates for line matching, marks, and regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_exeval"
+version = "0.1.0"
+dependencies = [
+ "rust_excmds",
+]
+
+[[package]]
 name = "rust_ffi"
 version = "0.1.0"
 
@@ -2424,6 +2431,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_linematch"
+version = "0.1.0"
+
+[[package]]
 name = "rust_list"
 version = "0.1.0"
 dependencies = [
@@ -2446,6 +2457,17 @@ name = "rust_map"
 version = "0.1.0"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "rust_mark"
+version = "0.1.0"
+
+[[package]]
+name = "rust_match"
+version = "0.1.0"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -2631,6 +2653,13 @@ dependencies = [
  "criterion 0.5.1",
  "regex",
  "rust_fuzzy",
+]
+
+[[package]]
+name = "rust_register"
+version = "0.1.0"
+dependencies = [
+ "rust_clipboard",
 ]
 
 [[package]]

--- a/rust_linematch/Cargo.toml
+++ b/rust_linematch/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_linematch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_linematch"
+crate-type = ["staticlib", "rlib"]

--- a/rust_linematch/include/rust_linematch.h
+++ b/rust_linematch/include/rust_linematch.h
@@ -1,0 +1,11 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    const char *ptr;
+    size_t size;
+} MMFile;
+
+int matching_chars(const MMFile *m1, const MMFile *m2);
+int matching_chars_ignore_whitespace(const MMFile *m1, const MMFile *m2);

--- a/rust_linematch/src/lib.rs
+++ b/rust_linematch/src/lib.rs
@@ -1,0 +1,98 @@
+use std::cmp::min;
+use std::os::raw::{c_char, c_int};
+use std::slice;
+
+#[repr(C)]
+pub struct MMFile {
+    pub ptr: *const c_char,
+    pub size: usize,
+}
+
+fn line_len(m: &MMFile) -> usize {
+    if m.ptr.is_null() {
+        return 0;
+    }
+    let bytes = unsafe { slice::from_raw_parts(m.ptr as *const u8, m.size) };
+    match bytes.iter().position(|&b| b == b'\n') {
+        Some(idx) => idx,
+        None => bytes.len(),
+    }
+}
+
+fn lcs(a: &[u8], b: &[u8]) -> usize {
+    if a.is_empty() || b.is_empty() {
+        return 0;
+    }
+    let n = b.len();
+    let mut dp = vec![vec![0; n + 1]; 2];
+    for (i, &ai) in a.iter().enumerate() {
+        let cur = i % 2;
+        let prev = 1 - cur;
+        for (j, &bj) in b.iter().enumerate() {
+            if ai == bj {
+                dp[cur][j + 1] = dp[prev][j] + 1;
+            } else {
+                dp[cur][j + 1] = dp[cur][j].max(dp[prev][j + 1]);
+            }
+        }
+    }
+    dp[(a.len() - 1) % 2][n]
+}
+
+#[no_mangle]
+pub extern "C" fn matching_chars(m1: *const MMFile, m2: *const MMFile) -> c_int {
+    if m1.is_null() || m2.is_null() {
+        return 0;
+    }
+    let m1 = unsafe { &*m1 };
+    let m2 = unsafe { &*m2 };
+    let s1len = min(799, line_len(m1));
+    let s2len = min(799, line_len(m2));
+    let s1 = unsafe { slice::from_raw_parts(m1.ptr as *const u8, s1len) };
+    let s2 = unsafe { slice::from_raw_parts(m2.ptr as *const u8, s2len) };
+    lcs(s1, s2) as c_int
+}
+
+fn strip_ws(m: &MMFile) -> Vec<u8> {
+    let len = min(799, line_len(m));
+    let bytes = unsafe { slice::from_raw_parts(m.ptr as *const u8, len) };
+    bytes
+        .iter()
+        .cloned()
+        .filter(|&b| b != b' ' && b != b'\t')
+        .collect()
+}
+
+#[no_mangle]
+pub extern "C" fn matching_chars_ignore_whitespace(m1: *const MMFile, m2: *const MMFile) -> c_int {
+    if m1.is_null() || m2.is_null() {
+        return 0;
+    }
+    let s1 = strip_ws(unsafe { &*m1 });
+    let s2 = strip_ws(unsafe { &*m2 });
+    lcs(&s1, &s2) as c_int
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_matching_chars_basic() {
+        let s1 = CString::new("aabc").unwrap();
+        let s2 = CString::new("acba").unwrap();
+        let m1 = MMFile { ptr: s1.as_ptr(), size: s1.as_bytes().len() };
+        let m2 = MMFile { ptr: s2.as_ptr(), size: s2.as_bytes().len() };
+        assert_eq!(matching_chars(&m1, &m2), 2);
+    }
+
+    #[test]
+    fn test_ignore_whitespace() {
+        let s1 = CString::new("a b c").unwrap();
+        let s2 = CString::new("abc").unwrap();
+        let m1 = MMFile { ptr: s1.as_ptr(), size: s1.as_bytes().len() };
+        let m2 = MMFile { ptr: s2.as_ptr(), size: s2.as_bytes().len() };
+        assert_eq!(matching_chars_ignore_whitespace(&m1, &m2), 3);
+    }
+}

--- a/rust_mark/Cargo.toml
+++ b/rust_mark/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_mark"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lib]
+name = "rust_mark"
+crate-type = ["staticlib", "rlib"]

--- a/rust_mark/include/rust_mark.h
+++ b/rust_mark/include/rust_mark.h
@@ -1,0 +1,11 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    int64_t line;
+    int64_t col;
+} Position;
+
+void mark_set(char name, int64_t line, int64_t col);
+bool mark_get(char name, Position *out);
+void mark_clear(char name);

--- a/rust_mark/src/lib.rs
+++ b/rust_mark/src/lib.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::os::raw::c_char;
+use std::sync::{Mutex, OnceLock};
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Position {
+    pub line: i64,
+    pub col: i64,
+}
+
+static MARKS: OnceLock<Mutex<HashMap<u8, Position>>> = OnceLock::new();
+
+fn marks() -> &'static Mutex<HashMap<u8, Position>> {
+    MARKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[no_mangle]
+pub extern "C" fn mark_set(name: c_char, line: i64, col: i64) {
+    let mut map = marks().lock().unwrap();
+    map.insert(name as u8, Position { line, col });
+}
+
+#[no_mangle]
+pub extern "C" fn mark_get(name: c_char, out: *mut Position) -> bool {
+    let map = marks().lock().unwrap();
+    if let Some(pos) = map.get(&(name as u8)) {
+        if !out.is_null() {
+            unsafe { *out = *pos; }
+        }
+        true
+    } else {
+        false
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn mark_clear(name: c_char) {
+    let mut map = marks().lock().unwrap();
+    map.remove(&(name as u8));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mark_lifecycle() {
+        mark_set('a' as c_char, 10, 20);
+        let mut pos = Position { line: 0, col: 0 };
+        assert!(mark_get('a' as c_char, &mut pos as *mut Position));
+        assert_eq!(pos.line, 10);
+        assert_eq!(pos.col, 20);
+        mark_clear('a' as c_char);
+        assert!(!mark_get('a' as c_char, &mut pos as *mut Position));
+    }
+}

--- a/rust_match/Cargo.toml
+++ b/rust_match/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_match"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+regex = "1"
+
+[lib]
+name = "rust_match"
+crate-type = ["staticlib", "rlib"]

--- a/rust_match/include/rust_match.h
+++ b/rust_match/include/rust_match.h
@@ -1,0 +1,9 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct Regex Regex;
+
+Regex *regex_new(const char *pattern);
+bool regex_is_match(const Regex *re, const char *text);
+void regex_free(Regex *re);

--- a/rust_match/src/lib.rs
+++ b/rust_match/src/lib.rs
@@ -1,0 +1,50 @@
+use regex::Regex;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::ptr;
+
+#[no_mangle]
+pub extern "C" fn regex_new(pattern: *const c_char) -> *mut Regex {
+    if pattern.is_null() {
+        return ptr::null_mut();
+    }
+    let cstr = unsafe { CStr::from_ptr(pattern) };
+    match Regex::new(cstr.to_str().unwrap_or("")) {
+        Ok(re) => Box::into_raw(Box::new(re)),
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn regex_is_match(re_ptr: *const Regex, text: *const c_char) -> bool {
+    if re_ptr.is_null() || text.is_null() {
+        return false;
+    }
+    let re = unsafe { &*re_ptr };
+    let cstr = unsafe { CStr::from_ptr(text) };
+    re.is_match(cstr.to_str().unwrap_or(""))
+}
+
+#[no_mangle]
+pub extern "C" fn regex_free(re_ptr: *mut Regex) {
+    if re_ptr.is_null() {
+        return;
+    }
+    unsafe { drop(Box::from_raw(re_ptr)) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn basic_match() {
+        let pat = CString::new("a+\\d").unwrap();
+        let re = regex_new(pat.as_ptr());
+        assert!(!re.is_null());
+        let text = CString::new("aa1").unwrap();
+        assert!(regex_is_match(re, text.as_ptr()));
+        regex_free(re);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `rust_linematch` crate providing line matching utilities with whitespace-insensitive options.
- Implement `rust_mark` crate storing and retrieving text marks via a thread-safe hash map.
- Implement `rust_match` crate exposing regex compilation and matching through an FFI-friendly API.

## Testing
- `cargo test -p rust_linematch`
- `cargo test -p rust_mark`
- `cargo test -p rust_match`


------
https://chatgpt.com/codex/tasks/task_e_68b8de30b9248320ba0b2e500795add1