### PR TITLE
Add Rust crates for Ex evaluation and option processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,11 +2248,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_ex_eval"
+version = "0.1.0"
+dependencies = [
+ "rust_exeval",
+ "rust_usercmd",
+]
+
+[[package]]
+name = "rust_ex_getln"
+version = "0.1.0"
+
+[[package]]
 name = "rust_excmds"
 version = "0.1.0"
 dependencies = [
  "once_cell",
  "rust_change",
+]
+
+[[package]]
+name = "rust_exeval"
+version = "0.1.0"
+dependencies = [
+ "rust_excmds",
 ]
 
 [[package]]
@@ -2511,6 +2530,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_optionstr"
+version = "0.1.0"
+dependencies = [
+ "rust_option",
+]
+
+[[package]]
 name = "rust_os_amiga"
 version = "0.1.0"
 dependencies = [
@@ -2634,10 +2660,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_register"
+version = "0.1.0"
+dependencies = [
+ "rust_clipboard",
+]
+
+[[package]]
 name = "rust_screen"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust_scriptfile"
+version = "0.1.0"
+dependencies = [
+ "rust_ex_eval",
+ "rust_ex_getln",
+ "tempfile",
 ]
 
 [[package]]
@@ -2777,6 +2819,10 @@ dependencies = [
  "libc",
  "rust_memline",
 ]
+
+[[package]]
+name = "rust_usercmd"
+version = "0.1.0"
 
 [[package]]
 name = "rust_userfunc"

--- a/rust_ex_eval/Cargo.toml
+++ b/rust_ex_eval/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_ex_eval"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_exeval = { path = "../rust_exeval" }
+rust_usercmd = { path = "../rust_usercmd" }
+
+[dev-dependencies]
+

--- a/rust_ex_eval/src/lib.rs
+++ b/rust_ex_eval/src/lib.rs
@@ -1,0 +1,41 @@
+use rust_exeval::{execute_command, ExEvalError};
+use rust_usercmd::expand_user_command;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+pub fn ex_eval(line: &str) -> Result<(), ExEvalError> {
+    let expanded = expand_user_command(line).unwrap_or_else(|| line.to_string());
+    execute_command(&expanded)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ex_eval(line: *const c_char) -> c_int {
+    if line.is_null() {
+        return 1;
+    }
+    let c_str = unsafe { CStr::from_ptr(line) };
+    match c_str.to_str() {
+        Ok(s) => match ex_eval(s) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        },
+        Err(_) => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eval_simple_command() {
+        assert!(ex_eval("cmd1").is_ok());
+    }
+
+    #[test]
+    fn eval_user_command() {
+        rust_usercmd::define_user_command("Foo", "cmd1");
+        assert!(ex_eval("Foo").is_ok());
+    }
+}
+

--- a/rust_ex_getln/Cargo.toml
+++ b/rust_ex_getln/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_ex_getln"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+

--- a/rust_ex_getln/src/lib.rs
+++ b/rust_ex_getln/src/lib.rs
@@ -1,0 +1,40 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+pub fn get_line(script: &str, line_no: usize) -> Option<String> {
+    script.lines().nth(line_no).map(|s| s.to_string())
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ex_getln(script: *const c_char, line_no: usize) -> *mut c_char {
+    if script.is_null() {
+        return std::ptr::null_mut();
+    }
+    let c_str = unsafe { CStr::from_ptr(script) };
+    let Ok(script) = c_str.to_str() else { return std::ptr::null_mut() };
+    match get_line(script, line_no) {
+        Some(line) => CString::new(line).unwrap().into_raw(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_ex_getln_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe { drop(CString::from_raw(s)); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lines_are_returned_in_order() {
+        let script = "cmd1\ncmd2";
+        assert_eq!(get_line(script, 0).unwrap(), "cmd1");
+        assert_eq!(get_line(script, 1).unwrap(), "cmd2");
+        assert!(get_line(script, 2).is_none());
+    }
+}
+

--- a/rust_option/Cargo.toml
+++ b/rust_option/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 

--- a/rust_optionstr/Cargo.toml
+++ b/rust_optionstr/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust_optionstr"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_option = { path = "../rust_option" }
+
+[dev-dependencies]
+

--- a/rust_optionstr/src/lib.rs
+++ b/rust_optionstr/src/lib.rs
@@ -1,0 +1,45 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use rust_option::rs_parse_option;
+
+pub fn apply_option_str(s: &str) -> bool {
+    for part in s.split_whitespace() {
+        let c = match CString::new(part) {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+        if !rs_parse_option(c.as_ptr()) {
+            return false;
+        }
+    }
+    true
+}
+
+#[no_mangle]
+pub extern "C" fn rs_apply_option_str(s: *const c_char) -> bool {
+    if s.is_null() {
+        return false;
+    }
+    let c_str = unsafe { CStr::from_ptr(s) };
+    let Ok(s) = c_str.to_str() else { return false };
+    apply_option_str(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_option::{rs_get_option, rs_options_init};
+    use std::ffi::CString;
+
+    #[test]
+    fn parse_multiple_options() {
+        rs_options_init();
+        assert!(apply_option_str("background=dark fileformat=dos"));
+        let name = CString::new("background").unwrap();
+        let val_ptr = rs_get_option(name.as_ptr());
+        assert!(!val_ptr.is_null());
+        let val = unsafe { CString::from_raw(val_ptr) };
+        assert_eq!(val.to_str().unwrap(), "dark");
+    }
+}
+

--- a/rust_scriptfile/Cargo.toml
+++ b/rust_scriptfile/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust_scriptfile"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_ex_eval = { path = "../rust_ex_eval" }
+rust_ex_getln = { path = "../rust_ex_getln" }
+
+[dev-dependencies]
+tempfile = "3"
+

--- a/rust_scriptfile/src/lib.rs
+++ b/rust_scriptfile/src/lib.rs
@@ -1,0 +1,50 @@
+use std::fs;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+use rust_ex_eval::ex_eval;
+use rust_ex_getln::get_line;
+
+#[derive(Debug)]
+pub enum ScriptError {
+    Io,
+    Eval,
+    InvalidEncoding,
+}
+
+pub fn exec_script(path: &str) -> Result<(), ScriptError> {
+    let content = fs::read_to_string(path).map_err(|_| ScriptError::Io)?;
+    let mut idx = 0;
+    while let Some(line) = get_line(&content, idx) {
+        ex_eval(&line).map_err(|_| ScriptError::Eval)?;
+        idx += 1;
+    }
+    Ok(())
+}
+
+#[no_mangle]
+pub extern "C" fn rs_exec_scriptfile(path: *const c_char) -> bool {
+    if path.is_null() {
+        return false;
+    }
+    let c_path = unsafe { CStr::from_ptr(path) };
+    match c_path.to_str() {
+        Ok(p) => exec_script(p).is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn execute_scriptfile() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(file, "cmd1").unwrap();
+        writeln!(file, "cmd2").unwrap();
+        assert!(exec_script(file.path().to_str().unwrap()).is_ok());
+    }
+}
+

--- a/rust_usercmd/Cargo.toml
+++ b/rust_usercmd/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust_usercmd"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[dev-dependencies]
+

--- a/rust_usercmd/src/lib.rs
+++ b/rust_usercmd/src/lib.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+fn registry() -> &'static Mutex<HashMap<String, String>> {
+    static REG: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    REG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn define_user_command(name: &str, expansion: &str) {
+    registry().lock().unwrap().insert(name.to_string(), expansion.to_string());
+}
+
+pub fn expand_user_command(name: &str) -> Option<String> {
+    registry().lock().unwrap().get(name).cloned()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_define_user_command(name: *const c_char, expansion: *const c_char) -> bool {
+    if name.is_null() || expansion.is_null() {
+        return false;
+    }
+    let name = unsafe { CStr::from_ptr(name) };
+    let expansion = unsafe { CStr::from_ptr(expansion) };
+    let (Ok(name), Ok(expansion)) = (name.to_str(), expansion.to_str()) else { return false };
+    define_user_command(name, expansion);
+    true
+}
+
+#[no_mangle]
+pub extern "C" fn rs_expand_user_command(name: *const c_char) -> *mut c_char {
+    if name.is_null() {
+        return std::ptr::null_mut();
+    }
+    let name = unsafe { CStr::from_ptr(name) };
+    let Ok(name) = name.to_str() else { return std::ptr::null_mut() };
+    match expand_user_command(name) {
+        Some(s) => CString::new(s).unwrap().into_raw(),
+        None => std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_usercmd_free(s: *mut c_char) {
+    if !s.is_null() {
+        unsafe { drop(CString::from_raw(s)); }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn define_and_expand() {
+        define_user_command("Foo", "cmd1");
+        assert_eq!(expand_user_command("Foo").unwrap(), "cmd1");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `rust_usercmd` crate for defining and expanding user commands
- add `rust_ex_getln` crate to read script lines
- add `rust_ex_eval` crate integrating user commands with Ex command execution
- add `rust_scriptfile` crate to run script files line by line
- add `rust_optionstr` crate for applying option assignments and enable `rust_option` rlib

## Testing
- `cargo test -p rust_usercmd -p rust_ex_getln -p rust_ex_eval -p rust_scriptfile -p rust_optionstr`

------
https://chatgpt.com/codex/tasks/task_e_68b8de2f82d083208c75def73292e065