### PR TITLE
Remove unused parameters from UI functions

### DIFF
--- a/src/proto/ui.pro
+++ b/src/proto/ui.pro
@@ -1,5 +1,5 @@
 /* ui.c */
-void ui_write(char_u *s, int len, int console);
+void ui_write(char_u *s, int len);
 void ui_inchar_undo(char_u *s, int len);
 int ui_inchar(char_u *buf, int maxlen, long wtime, int tb_change_cnt);
 int inchar_loop(char_u *buf, int maxlen, long wtime, int tb_change_cnt, int (*wait_func)(long wtime, int *interrupted, int ignore_input), int (*resize_func)(int check_only));
@@ -24,7 +24,7 @@ void add_to_input_buf(char_u *s, int len);
 void add_to_input_buf_csi(char_u *str, int len);
 void trash_input_buf(void);
 int read_from_input_buf(char_u *buf, long maxlen);
-void fill_input_buf(int exit_on_error);
+void fill_input_buf(void);
 void read_error_exit(void);
 void ui_cursor_shape_forced(int forced);
 void ui_cursor_shape(void);

--- a/src/ui.c
+++ b/src/ui.c
@@ -21,9 +21,8 @@
 extern void rs_ui_write(char *msg, int len);
 
     void
-ui_write(char_u *s, int len, int console UNUSED)
+ui_write(char_u *s, int len)
 {
-    (void)console;
     rs_ui_write((char *)s, len);
 }
 
@@ -866,7 +865,7 @@ trash_input_buf(void)
 read_from_input_buf(char_u *buf, long maxlen)
 {
     if (inbufcount == 0)	// if the buffer is empty, fill it
-	fill_input_buf(TRUE);
+	fill_input_buf();
     if (maxlen > inbufcount)
 	maxlen = inbufcount;
     mch_memmove(buf, inbuf, (size_t)maxlen);
@@ -878,7 +877,7 @@ read_from_input_buf(char_u *buf, long maxlen)
 }
 
     void
-fill_input_buf(int exit_on_error UNUSED)
+fill_input_buf(void)
 {
 #if defined(UNIX) || defined(VMS) || defined(MACOS_X)
     int		len;
@@ -973,8 +972,6 @@ fill_input_buf(int exit_on_error UNUSED)
 #endif
 	    settmode(m);
 	}
-	if (!exit_on_error)
-	    return;
     }
     if (len <= 0 && !got_int)
 	read_error_exit();

--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -4064,9 +4064,8 @@ exec_instructions(ectx_T *ectx)
 #endif
 			    else if (iptr->isn_type == ISN_ECHOCONSOLE)
 			    {
-				ui_write(ga.ga_data, (int)STRLEN(ga.ga_data),
-									 TRUE);
-				ui_write((char_u *)"\r\n", 2, TRUE);
+                                ui_write(ga.ga_data, (int)STRLEN(ga.ga_data));
+                                ui_write((char_u *)"\r\n", 2);
 			    }
 			    else
 			    {


### PR DESCRIPTION
## Summary
- clean up `ui_write` and `fill_input_buf` by dropping unused parameters
- adjust callers and prototypes accordingly

## Testing
- `cargo build --workspace`
- `cargo test --workspace` *(fails: unresolved import `rust_change::Buffer` in `rust_excmds` integration test)*

------
https://chatgpt.com/codex/tasks/task_e_68b8de6ed5588320a075c8ef03781a9e