### PR TITLE
Port operator metadata logic to Rust

### DIFF
--- a/src/ops_rs.h
+++ b/src/ops_rs.h
@@ -16,6 +16,7 @@ int rs_op_change(oparg_T *oap);
 void rs_op_addsub(oparg_T *oap, long Prenum1, int g_cmd);
 void rs_op_colon(oparg_T *oap);
 void rs_op_function(oparg_T *oap);
+int rs_op_on_lines(int op);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- move operator lookup table and helper functions from `ops.c` into Rust
- expose operator line-check helper via FFI and update C call sites

## Testing
- `cargo test -p rust_ops`


------
https://chatgpt.com/codex/tasks/task_e_68b8e43b51908320946cfe9a96cce2cc