### PR TITLE
Add rudimentary rust_drawline crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_drawline"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rust_screen",
+]
+
+[[package]]
 name = "rust_drawscreen"
 version = "0.1.0"
 dependencies = [
@@ -2695,6 +2703,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_scriptfile"
+version = "0.1.0"
+dependencies = [
+ "rust_fileio",
+ "tempfile",
+]
+
+[[package]]
 name = "rust_search"
 version = "0.1.0"
 dependencies = [
@@ -2788,6 +2804,15 @@ name = "rust_text"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust_textformat"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rust_indent",
+ "rust_text",
 ]
 
 [[package]]

--- a/rust_drawline/Cargo.toml
+++ b/rust_drawline/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust_drawline"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+rust_screen = { path = "../rust_screen" }
+
+[lib]
+name = "rust_drawline"
+crate-type = ["staticlib", "rlib"]

--- a/rust_drawline/src/lib.rs
+++ b/rust_drawline/src/lib.rs
@@ -1,0 +1,31 @@
+use libc::{c_char, c_int};
+use rust_screen::ScreenBuffer;
+
+#[no_mangle]
+pub extern "C" fn rs_draw_line(
+    buf: *mut ScreenBuffer,
+    row: c_int,
+    text: *const c_char,
+    attr: u8,
+) {
+    if buf.is_null() || text.is_null() {
+        return;
+    }
+    // Clear the target line and draw new text starting at column 0.
+    rust_screen::rs_screen_clear_line(buf, row, attr);
+    rust_screen::rs_screen_draw_text(buf, row, 0, text, attr);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn draw_line_writes_text() {
+        let mut sb = ScreenBuffer::new(20, 2);
+        let txt = CString::new("hello").unwrap();
+        rs_draw_line(&mut sb as *mut ScreenBuffer, 1, txt.as_ptr(), 2);
+        assert_eq!(sb.line_as_string(1), "hello               ");
+    }
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1424,6 +1424,8 @@ RUST_UNDO_DIR = ../rust_undo
 RUST_UNDO_LIB = $(RUST_UNDO_DIR)/target/release/librust_undo.a
 RUST_DRAWSCREEN_DIR = ../rust_drawscreen
 RUST_DRAWSCREEN_LIB = $(RUST_DRAWSCREEN_DIR)/target/release/librust_drawscreen.a
+RUST_DRAWLINE_DIR = ../rust_drawline
+RUST_DRAWLINE_LIB = $(RUST_DRAWLINE_DIR)/target/release/librust_drawline.a
 RUST_OPTION_DIR = ../rust_option
 RUST_OPTION_LIB = $(RUST_OPTION_DIR)/target/release/librust_option.a
 RUST_EVALVARS_DIR = ../rust_evalvars
@@ -1489,6 +1491,7 @@ ALL_LIBS = \
            $(RUST_WINDOW_LIB) \
            $(RUST_UNDO_LIB) \
            $(RUST_DRAWSCREEN_LIB) \
+           $(RUST_DRAWLINE_LIB) \
            $(RUST_OPTION_LIB) \
            $(RUST_EVALVARS_LIB) \
            $(RUST_SCREEN_LIB) \
@@ -1623,10 +1626,13 @@ $(RUST_UNDO_LIB):
 	cd $(RUST_UNDO_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_DRAWSCREEN_LIB):
-	cd $(RUST_DRAWSCREEN_DIR) && CARGO_TARGET_DIR=target cargo build --release
+        cd $(RUST_DRAWSCREEN_DIR) && CARGO_TARGET_DIR=target cargo build --release
+
+$(RUST_DRAWLINE_LIB):
+        cd $(RUST_DRAWLINE_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_OPTION_LIB):
-	cd $(RUST_OPTION_DIR) && CARGO_TARGET_DIR=target cargo build --release
+        cd $(RUST_OPTION_DIR) && CARGO_TARGET_DIR=target cargo build --release
 
 $(RUST_EVALVARS_LIB):
 	cd $(RUST_EVALVARS_DIR) && CARGO_TARGET_DIR=target cargo build --release

--- a/src/rust_drawline.h
+++ b/src/rust_drawline.h
@@ -1,0 +1,17 @@
+#ifndef RUST_DRAWLINE_H
+#define RUST_DRAWLINE_H
+
+#include <stdint.h>
+#include "screen_rs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void rs_draw_line(ScreenBuffer *buf, int row, const char *text, uint8_t attr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RUST_DRAWLINE_H


### PR DESCRIPTION
## Summary
- add rust_drawline crate implementing simple line drawing via rust_screen
- expose rs_draw_line through new C header
- compile and link rust_drawline via src/Makefile

## Testing
- `cargo test -p rust_drawline`
- `cargo build -p rust_drawline --release`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3eae9748320851bcc99c39509e0