### PR TITLE
Move numeric utilities to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_misc1"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rust_mouse"
 version = "0.1.0"
 dependencies = [
@@ -2695,6 +2702,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_scriptfile"
+version = "0.1.0"
+dependencies = [
+ "rust_fileio",
+ "tempfile",
+]
+
+[[package]]
 name = "rust_search"
 version = "0.1.0"
 dependencies = [
@@ -2788,6 +2803,15 @@ name = "rust_text"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust_textformat"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rust_indent",
+ "rust_text",
 ]
 
 [[package]]
@@ -3542,6 +3566,7 @@ dependencies = [
  "rust_hardcopy",
  "rust_job",
  "rust_message",
+ "rust_misc1",
  "rust_netbeans",
  "rust_os_amiga",
  "rust_os_qnx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rust_cmdhist = { path = "rust_cmdhist" }
 rust_usercmd = { path = "rust_usercmd" }
 rust_alloc = { path = "rust_alloc" }
 rust_message = { path = "rust_message" }
+rust_misc1 = { path = "rust_misc1" }
 rust_blob = { path = "rust_blob" }
 rust_sha256 = { path = "rust_sha256" }
 rust_bufwrite = { path = "rust_bufwrite" }

--- a/rust_misc1/Cargo.toml
+++ b/rust_misc1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_misc1"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[lib]
+name = "rust_misc1"
+crate-type = ["staticlib", "rlib"]

--- a/rust_misc1/src/lib.rs
+++ b/rust_misc1/src/lib.rs
@@ -1,0 +1,54 @@
+use libc::{c_int, c_long, c_longlong};
+
+/// For overflow detection, add a digit safely to a long value.
+#[no_mangle]
+pub unsafe extern "C" fn vim_append_digit_long(value: *mut c_long, digit: c_int) -> c_int {
+    if value.is_null() {
+        return 0; // FAIL
+    }
+    let x = *value;
+    if x > (c_long::MAX - digit as c_long) / 10 {
+        return 0; // FAIL
+    }
+    *value = x * 10 + digit as c_long;
+    1 // OK
+}
+
+/// Return something that fits into an int.
+#[no_mangle]
+pub extern "C" fn trim_to_int(x: c_longlong) -> c_int {
+    if x > c_int::MAX as c_longlong {
+        c_int::MAX
+    } else if x < c_int::MIN as c_longlong {
+        c_int::MIN
+    } else {
+        x as c_int
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vim_append_digit_long_ok() {
+        let mut v: c_long = 12;
+        let r = unsafe { vim_append_digit_long(&mut v as *mut c_long, 3) };
+        assert_eq!(r, 1);
+        assert_eq!(v, 123);
+    }
+
+    #[test]
+    fn test_vim_append_digit_long_overflow() {
+        let mut v: c_long = c_long::MAX / 10 + 1;
+        let r = unsafe { vim_append_digit_long(&mut v as *mut c_long, 5) };
+        assert_eq!(r, 0);
+    }
+
+    #[test]
+    fn test_trim_to_int() {
+        assert_eq!(trim_to_int(123), 123);
+        assert_eq!(trim_to_int(c_int::MAX as c_longlong + 1), c_int::MAX);
+        assert_eq!(trim_to_int(c_int::MIN as c_longlong - 1), c_int::MIN);
+    }
+}

--- a/src/misc1.c
+++ b/src/misc1.c
@@ -31,6 +31,10 @@ static garray_T	ga_users;
 // FFI: implemented in rust_strings crate
 extern char_u *skip_to_option_part(char_u *p);
 
+// FFI: implemented in rust_misc1 crate
+extern int vim_append_digit_long(long *value, int digit);
+extern int trim_to_int(vimlong_T x);
+
 /*
  * get_leader_len() returns the length in bytes of the prefix of the given
  * string which introduces a comment.  If this string is not a comment then
@@ -2859,23 +2863,5 @@ may_trigger_modechanged(void)
 
     restore_v_event(v_event, &save_v_event);
 #endif
-}
-
-// For overflow detection, add a digit safely to a long value.
-    int
-vim_append_digit_long(long *value, int digit)
-{
-    long x = *value;
-    if (x > ((LONG_MAX - (long)digit) / 10))
-	return FAIL;
-    *value = x * 10 + (long)digit;
-    return OK;
-}
-
-// Return something that fits into an int.
-    int
-trim_to_int(vimlong_T x)
-{
-    return x > INT_MAX ? INT_MAX : x < INT_MIN ? INT_MIN : x;
 }
 


### PR DESCRIPTION
## Summary
- port `vim_append_digit_long` and `trim_to_int` from C to a new `rust_misc1` crate
- expose these helpers via FFI and remove their C implementations
- include `rust_misc1` in the workspace

## Testing
- `cargo test -p rust_misc1`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3eb467c8320ae52b70b45e2f40f