### PR TITLE
Add rust_terminal crate with FFI hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_scriptfile"
+version = "0.1.0"
+dependencies = [
+ "rust_fileio",
+ "tempfile",
+]
+
+[[package]]
 name = "rust_search"
 version = "0.1.0"
 dependencies = [
@@ -2772,6 +2780,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_terminal"
+version = "0.1.0"
+dependencies = [
+ "rust_term",
+ "rust_termlib",
+]
+
+[[package]]
 name = "rust_termlib"
 version = "0.1.0"
 
@@ -2788,6 +2804,15 @@ name = "rust_text"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust_textformat"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rust_indent",
+ "rust_text",
 ]
 
 [[package]]

--- a/rust_terminal/Cargo.toml
+++ b/rust_terminal/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust_terminal"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust_term = { path = "../rust_term" }
+rust_termlib = { path = "../rust_termlib" }
+
+[lib]
+name = "rust_terminal"
+crate-type = ["staticlib", "rlib"]

--- a/rust_terminal/src/lib.rs
+++ b/rust_terminal/src/lib.rs
@@ -1,0 +1,72 @@
+pub use rust_term::*;
+pub use rust_termlib::*;
+
+use std::ffi::CString;
+use std::os::raw::{c_int, c_void};
+use std::ptr;
+
+/// Internal terminal state.
+pub struct TermState {
+    status: Option<CString>,
+}
+
+impl TermState {
+    fn new() -> Self {
+        Self { status: None }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rust_terminal_new() -> *mut TermState {
+    Box::into_raw(Box::new(TermState::new()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_terminal_free(term: *mut TermState) {
+    if term.is_null() {
+        return;
+    }
+    drop(Box::from_raw(term));
+}
+
+/// Free unused terminals - placeholder implementation.
+#[no_mangle]
+pub extern "C" fn rust_terminal_free_unused() {}
+
+/// Placeholder returning FAIL to indicate no terminal opened.
+#[no_mangle]
+pub unsafe extern "C" fn rust_terminal_none_open(_term: *mut c_void) -> c_int {
+    -1
+}
+
+/// Clear cached status text for the terminal.
+#[no_mangle]
+pub unsafe extern "C" fn rust_terminal_clear_status_text(term: *mut TermState) {
+    if let Some(ts) = term.as_mut() {
+        ts.status = None;
+    }
+}
+
+/// Return status text or NULL if none.
+#[no_mangle]
+pub unsafe extern "C" fn rust_terminal_get_status_text(term: *mut TermState) -> *const u8 {
+    term
+        .as_ref()
+        .and_then(|ts| ts.status.as_ref().map(|s| s.as_ptr() as *const u8))
+        .unwrap_or(ptr::null())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_roundtrip() {
+        let term = rust_terminal_new();
+        unsafe {
+            assert!(rust_terminal_get_status_text(term).is_null());
+            rust_terminal_clear_status_text(term);
+            rust_terminal_free(term);
+        }
+    }
+}

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -1,22 +1,26 @@
 #include "vim.h"
 
-// Stub implementations for terminal support in minimal builds.
+extern void rust_terminal_free_unused(void);
+extern int rust_terminal_none_open(void *term);
+extern void rust_terminal_clear_status_text(void *term);
+extern char_u *rust_terminal_get_status_text(void *term);
 
 void free_unused_terminals(void)
 {
-    // No terminals to free in this build.
+    rust_terminal_free_unused();
 }
 
 int term_none_open(void *term UNUSED)
 {
-    return FAIL;
+    return rust_terminal_none_open(term);
 }
 
-void term_clear_status_text(void *term UNUSED)
+void term_clear_status_text(void *term)
 {
+    rust_terminal_clear_status_text(term);
 }
 
-char_u *term_get_status_text(void *term UNUSED)
+char_u *term_get_status_text(void *term)
 {
-    return NULL;
+    return rust_terminal_get_status_text(term);
 }


### PR DESCRIPTION
## Summary
- Create new `rust_terminal` crate that reexports `rust_term` and `rust_termlib` and provides FFI helpers for terminal status management
- Replace C stubs in `src/terminal.c` with FFI calls into the Rust implementation

## Testing
- `cargo test -p rust_terminal`


------
https://chatgpt.com/codex/tasks/task_e_68b8e3ee83c8832093ee64aed6fbf55d