### PR TITLE
feat: add Rust-based vimrun helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,6 +2695,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_scriptfile"
+version = "0.1.0"
+dependencies = [
+ "rust_fileio",
+ "tempfile",
+]
+
+[[package]]
 name = "rust_search"
 version = "0.1.0"
 dependencies = [
@@ -2788,6 +2796,15 @@ name = "rust_text"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rust_textformat"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "rust_indent",
+ "rust_text",
 ]
 
 [[package]]
@@ -3560,6 +3577,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "vimrun"
+version = "0.1.0"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Filelist
+++ b/Filelist
@@ -480,8 +480,9 @@ SRC_DOS =	\
                 src/testdir/util/dos.vim \
                 src/vim.rc \
                 src/vim.manifest \
-                src/vimrun.c \
-		src/xpm_w32.h \
+                rust_vimrun/Cargo.toml \
+                rust_vimrun/src/main.rs \
+                src/xpm_w32.h \
 		src/tee/Make_ming.mak \
 		src/tee/Make_mvc.mak \
 		src/tee/Makefile \

--- a/rust_vimrun/Cargo.toml
+++ b/rust_vimrun/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "vimrun"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+windows-sys = { version = "0.48", features = ["Win32_System_Console", "Win32_System_Environment", "Win32_Foundation"] }
+

--- a/rust_vimrun/src/main.rs
+++ b/rust_vimrun/src/main.rs
@@ -1,0 +1,95 @@
+#![cfg(windows)]
+use std::{ffi::c_void, ptr};
+use std::vec::Vec;
+use windows_sys::Win32::System::Console::{GetStdHandle, WriteConsoleW, STD_OUTPUT_HANDLE};
+use windows_sys::Win32::System::Environment::GetCommandLineW;
+
+extern "C" {
+    fn _wsystem(cmd: *const u16) -> i32;
+    fn _kbhit() -> i32;
+    fn _getch() -> i32;
+}
+
+fn main() {
+    unsafe {
+        let mut p = GetCommandLineW();
+        let mut inquote = false;
+        while *p != 0 {
+            if *p == b'"' as u16 {
+                inquote = !inquote;
+            } else if !inquote && *p == b' ' as u16 {
+                p = p.add(1);
+                break;
+            }
+            p = p.add(1);
+        }
+        while *p == b' ' as u16 {
+            p = p.add(1);
+        }
+
+        let mut silent = false;
+        if *p == b'-' as u16 && *p.add(1) == b's' as u16 && *p.add(2) == b' ' as u16 {
+            silent = true;
+            p = p.add(3);
+            while *p == b' ' as u16 {
+                p = p.add(1);
+            }
+        }
+
+        let mut len = 0;
+        let mut t = p;
+        while *t != 0 {
+            len += 1;
+            t = t.add(1);
+        }
+        let slice = std::slice::from_raw_parts(p, len);
+
+        let mut written = 0u32;
+        let hstdout = GetStdHandle(STD_OUTPUT_HANDLE);
+        WriteConsoleW(
+            hstdout,
+            slice.as_ptr() as *const c_void,
+            slice.len() as u32,
+            &mut written,
+            ptr::null_mut(),
+        );
+        let newline: [u16; 2] = ['\r' as u16, '\n' as u16];
+        WriteConsoleW(
+            hstdout,
+            newline.as_ptr() as *const c_void,
+            2,
+            &mut written,
+            ptr::null_mut(),
+        );
+
+        let mut cmd_vec: Vec<u16>;
+        let cmd_ptr = if len >= 2 && slice[0] == b'"' as u16 && slice[len - 1] == b'"' as u16 {
+            cmd_vec = Vec::with_capacity(len + 3);
+            cmd_vec.push('(' as u16);
+            cmd_vec.extend_from_slice(slice);
+            cmd_vec.push(')' as u16);
+            cmd_vec.push(0);
+            cmd_vec.as_ptr()
+        } else {
+            cmd_vec = slice.to_vec();
+            cmd_vec.push(0);
+            cmd_vec.as_ptr()
+        };
+
+        let retval = _wsystem(cmd_ptr);
+        if retval == -1 {
+            eprintln!("vimrun _wsystem() failed");
+        } else if retval != 0 {
+            println!("shell returned {}", retval);
+        }
+
+        if !silent {
+            println!("Hit any key to close this window...");
+            while _kbhit() != 0 {
+                _getch();
+            }
+            _getch();
+        }
+        std::process::exit(retval);
+    }
+}

--- a/src/Make_cyg_ming.mak
+++ b/src/Make_cyg_ming.mak
@@ -1106,8 +1106,9 @@ endif
 
 all: $(MAIN_TARGET) vimrun.exe xxd/xxd.exe tee/tee.exe GvimExt/gvimext.dll
 
-vimrun.exe: vimrun.c
-	$(CC) $(CFLAGS) -o vimrun.exe vimrun.c $(LIB)
+vimrun.exe:
+	cargo build --release -p vimrun --target x86_64-pc-windows-gnu
+	cp target/x86_64-pc-windows-gnu/release/vimrun.exe .
 
 
 $(OBJ): | $(OUTDIR)

--- a/src/Make_mvc.mak
+++ b/src/Make_mvc.mak
@@ -1302,9 +1302,9 @@ CFLAGS_INST = /nologo /O2 -DNDEBUG -DWIN32 -DWINVER=$(WINVER) \
 
 CFLAGS_INST = $(CFLAGS_INST) -DVIM_VERSION_PATCHLEVEL=$(PATCHLEVEL)
 
-vimrun.exe: vimrun.c
-        $(CC) /nologo -DNDEBUG vimrun.c -link -subsystem:$(SUBSYSTEM_TOOLS)
-
+vimrun.exe:
+	cargo build --release -p vimrun --target x86_64-pc-windows-gnu
+	cp target/x86_64-pc-windows-gnu/release/vimrun.exe .
 xxd/xxd.exe:
 	cd xxd
 	$(MAKE) -lf Make_mvc.mak $(MAKEFLAGS_TOOLS)


### PR DESCRIPTION
## Summary
- reimplement Windows `vimrun` helper in Rust
- build `vimrun.exe` with Cargo and include in distribution
- update Windows makefiles to use the new Rust binary

## Testing
- `cargo build --target x86_64-pc-windows-gnu -p vimrun`  
- `cargo build --target x86_64-pc-windows-gnu -p vimrun --release`  
- `wine target/x86_64-pc-windows-gnu/release/vimrun.exe -s echo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e3ef61e88320aaaf779273bff6a1