### PR TITLE
Handle popup menu redraw

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -381,10 +381,8 @@ ins_mousescroll(int dir)
     // window, need to redraw it.
     if (did_scroll && pum_visible())
     {
-	// TODO: Would be more efficient to only redraw the windows that are
-	// overlapped by the popup menu.
-	redraw_all_later(UPD_NOT_VALID);
-	ins_compl_show_pum();
+        rs_redraw_pum_overlap();
+        ins_compl_show_pum();
     }
 
     if (!EQUAL_POS(curwin->w_cursor, orig_cursor))

--- a/src/rust_mouse.h
+++ b/src/rust_mouse.h
@@ -4,5 +4,6 @@
 #include <stdint.h>
 
 int rs_handle_mouse_event(void *oap, int c, int dir, long count, int fixindent);
+void rs_redraw_pum_overlap(void);
 
 #endif // RUST_MOUSE_H


### PR DESCRIPTION
## Summary
- add Rust helper to redraw windows overlapping with popup menu
- replace `redraw_all_later` call in C mouse scroll with new helper
- expose helper through `rust_mouse.h`

## Testing
- `cargo test` *(fails: failed to load manifest for workspace member `rust_editor`)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d20814c8320b8f02c0953a38f38