### PR TITLE
Use HashSet for visited paths and move ff_check_visited to Rust

### DIFF
--- a/rust_findfile/src/lib.rs
+++ b/rust_findfile/src/lib.rs
@@ -1,6 +1,10 @@
-use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
-use std::path::{PathBuf};
+use std::collections::HashSet;
+use std::ffi::{CStr, CString, OsStr};
+use std::os::raw::{c_char, c_int, c_void};
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 
 #[cfg(target_os = "windows")]
 const PATH_LIST_SEPARATOR: char = ';';
@@ -35,6 +39,71 @@ pub extern "C" fn rs_findfile(file: *const c_char, search: *const c_char) -> *mu
 pub extern "C" fn rs_findfile_free(s: *mut c_char) {
     if !s.is_null() {
         unsafe { let _ = CString::from_raw(s); }
+    }
+}
+
+/// Check if `fname` was already visited.  If not, add it to `visited`.
+/// Returns 1 when the file was seen before, 0 otherwise.
+#[no_mangle]
+pub extern "C" fn ff_check_visited(
+    visited: *mut *mut c_void,
+    fname: *const c_char,
+    fnamelen: usize,
+    _wc_path: *const c_char,
+    _wc_pathlen: usize,
+) -> c_int {
+    if visited.is_null() || fname.is_null() {
+        return 0;
+    }
+
+    // Convert the path bytes to a PathBuf.
+    let bytes = unsafe { std::slice::from_raw_parts(fname as *const u8, fnamelen) };
+    let path = {
+        #[cfg(unix)]
+        { PathBuf::from(OsStr::from_bytes(bytes)) }
+        #[cfg(not(unix))]
+        { PathBuf::from(String::from_utf8_lossy(bytes).to_string()) }
+    };
+
+    unsafe {
+        let set_ptr = *visited as *mut HashSet<PathBuf>;
+        if set_ptr.is_null() {
+            let mut set = match Box::try_new(HashSet::<PathBuf>::new()) {
+                Ok(b) => b,
+                Err(_) => {
+                    eprintln!("warning: findfile: out of memory");
+                    return 0;
+                }
+            };
+            if set.try_reserve(1).is_err() {
+                eprintln!("warning: findfile: out of memory");
+                return 0;
+            }
+            set.insert(path);
+            *visited = Box::into_raw(set) as *mut c_void;
+            0
+        } else {
+            let set = &mut *set_ptr;
+            if set.contains(&path) {
+                1
+            } else {
+                if set.try_reserve(1).is_err() {
+                    eprintln!("warning: findfile: out of memory");
+                    0
+                } else {
+                    set.insert(path);
+                    0
+                }
+            }
+        }
+    }
+}
+
+/// Free a visited list allocated in Rust.
+#[no_mangle]
+pub extern "C" fn ff_free_visited_list(list: *mut c_void) {
+    if !list.is_null() {
+        unsafe { drop(Box::from_raw(list as *mut HashSet<PathBuf>)); }
     }
 }
 


### PR DESCRIPTION
## Summary
- track visited paths with a `HashSet<PathBuf>` in rust_findfile
- warn and continue when out of memory while tracking visited paths
- replace C `ff_check_visited` with Rust implementation and tidy related comments

## Testing
- `cargo test --manifest-path rust_findfile/Cargo.toml` *(fails: failed to load manifest for workspace member `/workspace/vim_rust/rust_editor`)*
- `cargo fmt --manifest-path rust_findfile/Cargo.toml` *(fails: failed to load manifest for workspace member `/workspace/vim_rust/rust_editor`)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d240c2483209b2feab7fd14b1c8