### PR TITLE
Move vim_time implementation to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ rust_gc = { path = "rust_gc" }
 rust_clipboard = { path = "rust_clipboard" }
 rust_hardcopy = { path = "rust_hardcopy" }
 rust_move = { path = "rust_move" }
+rust_time = { path = "rust_time" }
 regex = "1"
 blowfish = "0.8"
 pbkdf2 = "0.12"

--- a/rust_time/src/lib.rs
+++ b/rust_time/src/lib.rs
@@ -1,10 +1,11 @@
-use libc::{time_t, time};
+use libc::{time, time_t};
+use std::ptr;
 
 /// Return the current time in seconds.
 /// When Vim is built with testing support, a global `time_for_testing`
 /// value may be used instead of the system time.
 #[no_mangle]
-pub unsafe extern "C" fn rs_vim_time() -> time_t {
+pub unsafe extern "C" fn vim_time() -> time_t {
     #[cfg(feature = "feat_eval")]
     {
         extern "C" {
@@ -14,8 +15,9 @@ pub unsafe extern "C" fn rs_vim_time() -> time_t {
             return time_for_testing;
         }
     }
-    time(std::ptr::null_mut())
+    time(ptr::null_mut())
 }
+
 
 #[cfg(test)]
 mod tests {
@@ -24,7 +26,7 @@ mod tests {
     #[test]
     fn returns_time() {
         // Just ensure the function runs and returns a non-zero value.
-        let t = unsafe { rs_vim_time() };
+        let t = unsafe { vim_time() };
         assert!(t > 0);
     }
 }

--- a/src/time.c
+++ b/src/time.c
@@ -13,8 +13,6 @@
 
 #include "vim.h"
 
-// FFI: implemented in rust_time crate
-extern time_T rs_vim_time(void);
 /*
  * Cache of the current timezone name as retrieved from TZ, or an empty string
  * where unset, up to 64 octets long including trailing null byte.
@@ -60,15 +58,7 @@ vim_localtime(
 #endif	// HAVE_LOCALTIME_R
 }
 
-/*
- * Return the current time in seconds.  Implementation provided by the
- * Rust `rust_time` module.
- */
-    time_T
-vim_time(void)
-{
-    return rs_vim_time();
-}
+// `vim_time` is now implemented in the Rust `rust_time` crate.
 
 /*
  * Replacement for ctime(), which is not safe to use.


### PR DESCRIPTION
## Summary
- export vim_time directly from rust_time crate
- remove C shim around vim_time and depend on rust_time in workspace

## Testing
- `cargo test -p rust_time` *(fails: failed to load manifest for workspace member `rust_editor`)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d30152c8320b3387805a43ed6cd