### PR TITLE
refactor: remove FFI from eval crates

### DIFF
--- a/rust_evalbuffer/Cargo.toml
+++ b/rust_evalbuffer/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 name = "rust_evalbuffer"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 once_cell = "1"

--- a/rust_evalbuffer/src/lib.rs
+++ b/rust_evalbuffer/src/lib.rs
@@ -1,72 +1,58 @@
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::ffi::CStr;
 use std::fs;
-use std::os::raw::c_char;
 use std::sync::Mutex;
 
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub enum Vartype {
-    VAR_UNKNOWN = 0,
-    VAR_NUMBER,
-    VAR_STRING,
-}
-
-#[repr(C)]
-pub union ValUnion {
-    pub v_number: i64,
-    pub v_string: *mut c_char,
-}
-
-#[repr(C)]
-pub struct typval_T {
-    pub v_type: Vartype,
-    pub v_lock: c_char,
-    pub vval: ValUnion,
-}
-
-#[derive(Clone)]
-struct Buffer {
-    lines: Vec<String>,
+/// Representation of a buffer: a list of lines.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Buffer {
+    pub lines: Vec<String>,
 }
 
 struct BufferManager {
     bufs: HashMap<String, Buffer>,
 }
 
-#[repr(C)]
-pub struct buf_T {
-    _private: [u8; 0],
-}
-
 static BUFFER_MANAGER: Lazy<Mutex<BufferManager>> = Lazy::new(|| {
     Mutex::new(BufferManager { bufs: HashMap::new() })
 });
 
-static DUMMY_BUF: buf_T = buf_T { _private: [] };
-
-#[no_mangle]
-pub extern "C" fn buflist_find_by_name_rs(name: *const c_char, _curtab_only: bool) -> *mut buf_T {
-    if name.is_null() {
-        return std::ptr::null_mut();
-    }
-    let c_str = unsafe { CStr::from_ptr(name) };
-    let name_str = match c_str.to_str() {
-        Ok(s) => s,
-        Err(_) => return std::ptr::null_mut(),
-    };
+/// Locate a buffer by file name and load it if needed.
+///
+/// Returns a copy of the buffer's contents if the file could be read,
+/// otherwise `None`.
+pub fn buflist_find_by_name(name: &str) -> Option<Buffer> {
     let mut manager = BUFFER_MANAGER.lock().unwrap();
-    if !manager.bufs.contains_key(name_str) {
-        let content = match fs::read_to_string(name_str) {
-            Ok(c) => c,
-            Err(_) => return std::ptr::null_mut(),
-        };
-        let buf = Buffer {
-            lines: content.lines().map(|l| l.to_string()).collect(),
-        };
-        manager.bufs.insert(name_str.to_string(), buf);
+    if !manager.bufs.contains_key(name) {
+        let content = fs::read_to_string(name).ok()?;
+        let buf = Buffer { lines: content.lines().map(|l| l.to_string()).collect() };
+        manager.bufs.insert(name.to_string(), buf);
     }
-    &DUMMY_BUF as *const buf_T as *mut buf_T
+    manager.bufs.get(name).cloned()
 }
 
+#[cfg(test)]
+mod tests {
+use super::*;
+    use std::env;
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    #[test]
+    fn loads_and_caches_buffer() {
+        let mut path = env::temp_dir();
+        path.push("evalbuffer_test.txt");
+        let mut file = File::create(&path).unwrap();
+        write!(file, "foo\nbar\n").unwrap();
+
+        let path_str = path.to_str().unwrap();
+        let buf = buflist_find_by_name(path_str).expect("buffer");
+        assert_eq!(buf.lines, vec!["foo".to_string(), "bar".to_string()]);
+
+        // Second call should use cached buffer.
+        let cached = buflist_find_by_name(path_str).unwrap();
+        assert_eq!(cached.lines, buf.lines);
+
+        fs::remove_file(path).unwrap();
+    }
+}

--- a/rust_evalvars/Cargo.toml
+++ b/rust_evalvars/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 once_cell = "1"
-libc = "0.2"
 
 [lib]
 name = "rust_evalvars"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["rlib"]

--- a/rust_evalwindow/Cargo.toml
+++ b/rust_evalwindow/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"
 rust_evalvars = { path = "../rust_evalvars" }
 
 [lib]
 name = "rust_evalwindow"
-crate-type = ["staticlib", "rlib"]
+crate-type = ["rlib"]

--- a/rust_evalwindow/src/lib.rs
+++ b/rust_evalwindow/src/lib.rs
@@ -1,101 +1,30 @@
-use libc::c_char;
-use rust_evalvars::rs_win_getid;
+use rust_evalvars::{win_create, win_getid};
 
-#[allow(non_camel_case_types)]
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub enum Vartype {
-    VAR_UNKNOWN = 0,
-    VAR_ANY,
-    VAR_VOID,
-    VAR_BOOL,
-    VAR_SPECIAL,
-    VAR_NUMBER,
-    VAR_FLOAT,
-    VAR_STRING,
-    VAR_BLOB,
-    VAR_FUNC,
-    VAR_PARTIAL,
-    VAR_LIST,
-    VAR_DICT,
-    VAR_JOB,
-    VAR_CHANNEL,
-    VAR_INSTR,
-    VAR_CLASS,
-    VAR_OBJECT,
-    VAR_TYPEALIAS,
-    VAR_TUPLE,
-}
-
-#[repr(C)]
-pub union ValUnion {
-    pub v_number: i64,
-    pub v_string: *mut c_char,
-}
-
-#[repr(C)]
-pub struct typval_T {
-    pub v_type: Vartype,
-    pub v_lock: c_char,
-    pub vval: ValUnion,
-}
-
-#[no_mangle]
-pub extern "C" fn f_win_getid(argvars: *mut typval_T, rettv: *mut typval_T) {
-    unsafe {
-        let winnr = if (*argvars).v_type as i32 == Vartype::VAR_UNKNOWN as i32 {
-            0
-        } else {
-            (*argvars).vval.v_number as i32
-        };
-        let id = rs_win_getid(winnr);
-        (*rettv).v_type = Vartype::VAR_NUMBER;
-        (*rettv).v_lock = 0;
-        (*rettv).vval.v_number = id as i64;
-    }
+/// Implementation of the `win_getid()` Vim function in pure Rust.
+///
+/// `arg` corresponds to the optional window number.  When `None` or `0`, the
+/// current window (the first one) is used.
+pub fn f_win_getid(arg: Option<i64>) -> i64 {
+    let winnr = arg.unwrap_or(0) as i32;
+    win_getid(winnr) as i64
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rust_evalvars::{rs_win_create, rs_win_getid};
 
     #[test]
     fn returns_window_id_for_number() {
-        unsafe {
-            rs_win_create();
-            rs_win_create();
-            let mut args = [typval_T {
-                v_type: Vartype::VAR_NUMBER,
-                v_lock: 0,
-                vval: ValUnion { v_number: 2 },
-            }];
-            let mut ret = typval_T {
-                v_type: Vartype::VAR_UNKNOWN,
-                v_lock: 0,
-                vval: ValUnion { v_number: 0 },
-            };
-            f_win_getid(args.as_mut_ptr(), &mut ret);
-            assert_eq!(ret.vval.v_number, rs_win_getid(2) as i64);
-        }
+        win_create();
+        win_create();
+        let id = f_win_getid(Some(2));
+        assert_eq!(id, win_getid(2) as i64);
     }
 
     #[test]
     fn defaults_to_current_window() {
-        unsafe {
-            rs_win_create();
-            let mut args = [typval_T {
-                v_type: Vartype::VAR_UNKNOWN,
-                v_lock: 0,
-                vval: ValUnion { v_number: 0 },
-            }];
-            let mut ret = typval_T {
-                v_type: Vartype::VAR_UNKNOWN,
-                v_lock: 0,
-                vval: ValUnion { v_number: 0 },
-            };
-            f_win_getid(args.as_mut_ptr(), &mut ret);
-            assert_eq!(ret.vval.v_number, rs_win_getid(0) as i64);
-        }
+        win_create();
+        let id = f_win_getid(None);
+        assert_eq!(id, win_getid(0) as i64);
     }
 }


### PR DESCRIPTION
## Summary
- implement variable and window helpers using pure Rust
- add Rust-only buffer manager and window eval function

## Testing
- `cargo test` (rust_evalvars)
- `cargo test` (rust_evalbuffer)
- `cargo test` (rust_evalwindow)


------
https://chatgpt.com/codex/tasks/task_e_68b90d35b15c8320a30a90da4dbf0c8d