### PR TITLE
refactor: drop unused decl_type in vim9type

### DIFF
--- a/src/vim9type.c
+++ b/src/vim9type.c
@@ -805,13 +805,10 @@ fp_typval2type(typval_T *tv, garray_T *type_gap)
 	int idx = find_internal_func(name);
 
 	if (idx >= 0)
-	{
-	    type_T *decl_type;  // unused
-
-	    internal_func_get_argcount(idx, &argcount, &min_argcount);
-	    member_type = internal_func_ret_type(idx, 0, NULL, &decl_type,
-		    type_gap);
-	}
+        {
+            internal_func_get_argcount(idx, &argcount, &min_argcount);
+            member_type = internal_func_ret_type(idx, 0, NULL, NULL, type_gap);
+        }
 	else
 	{
 	    // Check if name contains "<".  If it does, then replace "<" with


### PR DESCRIPTION
## Summary
- remove unused `decl_type` variable from `vim9type.c`
- call `internal_func_ret_type` with NULL decl type

## Testing
- `cargo build` *(fails: failed to load manifest for workspace member `rust_editor`)*
- `cargo test` *(fails: failed to load manifest for workspace member `rust_editor`)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d4f086483209e68c79663ea66d0