### PR TITLE
Remove unused JUMP_WHILE_FALSE case

### DIFF
--- a/src/vim9execute.c
+++ b/src/vim9execute.c
@@ -7615,9 +7615,6 @@ list_instructions(char *pfx, isn_T *instr, int instr_count, ufunc_T *ufunc)
 			case JUMP_IF_FALSE:
 			    when = "JUMP_IF_FALSE";
 			    break;
-			case JUMP_WHILE_FALSE:
-			    when = "JUMP_WHILE_FALSE";  // unused
-			    break;
 			case JUMP_IF_COND_FALSE:
 			    when = "JUMP_IF_COND_FALSE";
 			    break;


### PR DESCRIPTION
## Summary
- drop unused `JUMP_WHILE_FALSE` branch from `ISN_JUMP` debug switch

## Testing
- `make -C src` *(fails: missing separator in Makefile)*
- `gcc -fsyntax-only src/vim9execute.c` *(fails: missing types and headers)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d4e397883208081e10bbbb78f61