### PR TITLE
Remove VMS-specific code from memfile and bufwrite

### DIFF
--- a/src/memfile.c
+++ b/src/memfile.c
@@ -600,13 +600,6 @@ mf_sync(memfile_T *mfp, int flags)
 	    fflush(NULL);
 # endif
 #endif
-#ifdef VMS
-	if (STRCMP(p_sws, "fsync") == 0)
-	{
-	    if (vim_fsync(mfp->mf_fd))
-		status = FAIL;
-	}
-#endif
 #ifdef MSWIN
 	if (_commit(mfp->mf_fd))
 	    status = FAIL;


### PR DESCRIPTION
## Summary
- drop VMS-only fsync handling in memfile
- remove VMS-specific file writing paths and `vms_remove_version` call in bufwrite
- simplify conditional compilation that referenced VMS

## Testing
- `make -C src memfile.o bufwrite.o` *(failed: Makefile:1626: *** missing separator. Stop.)*
- `cargo test` *(failed: failed to load manifest for workspace member `/workspace/vim_rust/rust_editor`)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d5f7a908320963f2280bf966091