### PR TITLE
Document Rust port status and add editor manifest

### DIFF
--- a/docs/rust_port_overview.md
+++ b/docs/rust_port_overview.md
@@ -1,0 +1,33 @@
+# Rust Port Overview
+
+This document outlines where legacy C implementations exist for several features
+and the corresponding Rust crates that provide replacements.
+
+## Diff
+
+- C source: `src/diff.c` – handles buffer diffing but delegates the diff engine to
+  the Rust implementation via `rust_diff`.
+- Rust crate: `rust_diff` – provides `xdl_diff`, unified/indices output, and
+  line matching utilities.
+
+## Spell Checking
+
+- C source: `src/spell.c` – legacy spell checking logic that now calls into
+  Rust for dictionary handling, word checking, and suggestions.
+- Rust crate: `rust_spell` – exposes dictionary loading, word validation, and
+  suggestion generation.
+
+## Profiler
+
+- C source: `src/profiler.c` – Vim script profiling still implemented in C.
+- Rust crate: `rust_profiler` – offers basic timers and formatting; further
+  integration is required to fully replace the C profiler.
+
+## Sound
+
+- C source: `src/sound.c` – thin wrappers around the Rust sound backend.
+- Rust crate: `rust_sound` – plays audio files and events using the `rodio`
+  library.
+
+Each crate contains its own tests. As functionality is migrated, these C
+sources can be reduced or removed.

--- a/rust_editor/Cargo.toml
+++ b/rust_editor/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust_editor"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+


### PR DESCRIPTION
## Summary
- document where C implementations map to Rust crates
- add minimal Cargo manifest for `rust_editor` to satisfy workspace tooling

## Testing
- `cargo test --manifest-path rust_diff/Cargo.toml` *(fails: `mmfile_t` not `Copy`)*
- `cargo test --manifest-path rust_spell/Cargo.toml` *(fails: uses unstable `Mutex::clear_poison`)*
- `cargo test --manifest-path rust_profiler/Cargo.toml`
- `cargo test --manifest-path rust_sound/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68b90d394f8c8320be3fb295a4dabc89