### PR TITLE
rust_option: add typed option id

### DIFF
--- a/rust_option/build.rs
+++ b/rust_option/build.rs
@@ -4,6 +4,24 @@ use std::path::PathBuf;
 
 use regex::Regex;
 
+fn variant_name(name: &str) -> String {
+    let mut out = String::new();
+    let mut upper = true;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if upper {
+                out.push(ch.to_ascii_uppercase());
+                upper = false;
+            } else {
+                out.push(ch);
+            }
+        } else {
+            upper = true;
+        }
+    }
+    out
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=../src/option_rs.h");
     println!("cargo:rerun-if-changed=../src/optiondefs.h");
@@ -20,13 +38,14 @@ fn main() {
         .expect("Couldn't write bindings!");
 
     // Parse option names from optiondefs.h to build a Rust table.
-    let content = fs::read_to_string("../src/optiondefs.h")
-        .expect("failed to read optiondefs.h");
+    let content = fs::read_to_string("../src/optiondefs.h").expect("failed to read optiondefs.h");
 
     let re = Regex::new(r#"^\{"([^"]+)",\s*"([^"]*)",\s*([^,]+),"#).unwrap();
     let term_re = Regex::new(r#"^p_term\("([^"]+)""#).unwrap();
 
+    use std::collections::HashSet;
     let mut entries = Vec::new();
+    let mut seen = HashSet::new();
 
     for line in content.lines() {
         let t = line.trim();
@@ -37,24 +56,52 @@ fn main() {
             let (rs_kind, c_kind) = if flags.contains("P_BOOL") {
                 ("OptType::Bool", "crate::bindings::rs_opt_type_RS_OPT_BOOL")
             } else if flags.contains("P_NUM") {
-                ("OptType::Number", "crate::bindings::rs_opt_type_RS_OPT_NUMBER")
+                (
+                    "OptType::Number",
+                    "crate::bindings::rs_opt_type_RS_OPT_NUMBER",
+                )
             } else {
-                ("OptType::String", "crate::bindings::rs_opt_type_RS_OPT_STRING")
+                (
+                    "OptType::String",
+                    "crate::bindings::rs_opt_type_RS_OPT_STRING",
+                )
             };
-            entries.push((name, short, rs_kind.to_string(), c_kind.to_string()));
+            let var = variant_name(&name);
+            if seen.insert(var.clone()) {
+                entries.push((name, short, rs_kind.to_string(), c_kind.to_string()));
+            }
         } else if let Some(caps) = term_re.captures(t) {
             let name = caps.get(1).unwrap().as_str().to_string();
-            entries.push((name, String::new(), "OptType::String".to_string(), "crate::bindings::rs_opt_type_RS_OPT_STRING".to_string()));
+            let var = variant_name(&name);
+            if seen.insert(var.clone()) {
+                entries.push((
+                    name,
+                    String::new(),
+                    "OptType::String".to_string(),
+                    "crate::bindings::rs_opt_type_RS_OPT_STRING".to_string(),
+                ));
+            }
         }
     }
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut out = String::new();
+
+    out.push_str("#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n");
+    out.push_str("pub enum OptionId {\n");
+    for (name, _, _, _) in &entries {
+        out.push_str(&format!("    {},\n", variant_name(name)));
+    }
+    out.push_str("}\n\n");
+
     out.push_str("pub static OPTION_TABLE: &[OptionDef] = &[\n");
     for (name, short, rs_kind, _) in &entries {
         out.push_str(&format!(
-            "    OptionDef {{ name: \"{}\", short: \"{}\", opt_type: {} }},\n",
-            name, short, rs_kind
+            "    OptionDef {{ id: OptionId::{}, name: \"{}\", short: \"{}\", opt_type: {} }},\n",
+            variant_name(name),
+            name,
+            short,
+            rs_kind
         ));
     }
     out.push_str("];\n\n");


### PR DESCRIPTION
## Summary
- generate `OptionId` enum for all options
- record typed id in `OptionDef`

## Testing
- `cargo clippy -p rust_option -p rust_session -p rust_viminfo -- -D warnings` *(fails: not_unsafe_ptr_arg_deref in existing crates)*
- `cargo test -p rust_option`
- `cargo test -p rust_session`
- `cargo test -p rust_viminfo`


------
https://chatgpt.com/codex/tasks/task_e_68b91baf9b848320917d86e280264d29