### PR TITLE
rust_typval: add safe TypVal and evaluation helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,6 +2251,7 @@ name = "rust_evalvars"
 version = "0.1.0"
 dependencies = [
  "once_cell",
+ "rust_typval",
 ]
 
 [[package]]
@@ -3593,6 +3594,7 @@ dependencies = [
  "rust_clipboard",
  "rust_cmdhist",
  "rust_debugger",
+ "rust_editor",
  "rust_evalfunc",
  "rust_evalwindow",
  "rust_excmds",
@@ -3617,6 +3619,7 @@ dependencies = [
  "rust_spell",
  "rust_time",
  "rust_usercmd",
+ "rust_version",
  "rust_vim9class",
  "rust_wayland",
  "rust_winclip",

--- a/rust_evalbuffer/src/lib.rs
+++ b/rust_evalbuffer/src/lib.rs
@@ -14,7 +14,9 @@ struct BufferManager {
 }
 
 static BUFFER_MANAGER: Lazy<Mutex<BufferManager>> = Lazy::new(|| {
-    Mutex::new(BufferManager { bufs: HashMap::new() })
+    Mutex::new(BufferManager {
+        bufs: HashMap::new(),
+    })
 });
 
 /// Locate a buffer by file name and load it if needed.
@@ -25,34 +27,20 @@ pub fn buflist_find_by_name(name: &str) -> Option<Buffer> {
     let mut manager = BUFFER_MANAGER.lock().unwrap();
     if !manager.bufs.contains_key(name) {
         let content = fs::read_to_string(name).ok()?;
-        let buf = Buffer { lines: content.lines().map(|l| l.to_string()).collect() };
+        let buf = Buffer {
+            lines: content.lines().map(|l| l.to_string()).collect(),
+        };
         manager.bufs.insert(name.to_string(), buf);
     }
     manager.bufs.get(name).cloned()
 }
 
-#[cfg(test)]
-mod tests {
-use super::*;
-    use std::env;
-    use std::fs::{self, File};
-    use std::io::Write;
-
-    #[test]
-    fn loads_and_caches_buffer() {
-        let mut path = env::temp_dir();
-        path.push("evalbuffer_test.txt");
-        let mut file = File::create(&path).unwrap();
-        write!(file, "foo\nbar\n").unwrap();
-
-        let path_str = path.to_str().unwrap();
-        let buf = buflist_find_by_name(path_str).expect("buffer");
-        assert_eq!(buf.lines, vec!["foo".to_string(), "bar".to_string()]);
-
-        // Second call should use cached buffer.
-        let cached = buflist_find_by_name(path_str).unwrap();
-        assert_eq!(cached.lines, buf.lines);
-
-        fs::remove_file(path).unwrap();
-    }
+/// Return the line `lnum` (1-based) from the buffer with the given `name`.
+///
+/// The buffer is loaded on demand through `buflist_find_by_name` and the
+/// requested line is cloned from the cached contents.  Returns `None` when the
+/// buffer or line cannot be found.
+pub fn buflist_get_line(name: &str, lnum: usize) -> Option<String> {
+    let buf = buflist_find_by_name(name)?;
+    buf.lines.get(lnum.checked_sub(1)?).cloned()
 }

--- a/rust_evalbuffer/tests/buflist.rs
+++ b/rust_evalbuffer/tests/buflist.rs
@@ -1,0 +1,26 @@
+use rust_evalbuffer::{buflist_find_by_name, buflist_get_line};
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+
+#[test]
+fn loads_and_caches_buffer_and_get_line() {
+    let mut path = env::temp_dir();
+    path.push("evalbuffer_test.txt");
+    let mut file = File::create(&path).unwrap();
+    write!(file, "foo\nbar\n").unwrap();
+
+    let path_str = path.to_str().unwrap();
+    let buf = buflist_find_by_name(path_str).expect("buffer");
+    assert_eq!(buf.lines, vec!["foo".to_string(), "bar".to_string()]);
+
+    // Second call should use cached buffer.
+    let cached = buflist_find_by_name(path_str).unwrap();
+    assert_eq!(cached.lines, buf.lines);
+
+    // Retrieve line via helper
+    let line2 = buflist_get_line(path_str, 2).unwrap();
+    assert_eq!(line2, "bar");
+
+    fs::remove_file(path).unwrap();
+}

--- a/rust_evalvars/Cargo.toml
+++ b/rust_evalvars/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 once_cell = "1"
+rust_typval = { path = "../rust_typval" }
 
 [lib]
 name = "rust_evalvars"

--- a/rust_evalvars/src/lib.rs
+++ b/rust_evalvars/src/lib.rs
@@ -1,37 +1,38 @@
 use once_cell::sync::Lazy;
+use rust_typval::TypVal;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-#[derive(Clone, Debug)]
-enum Value {
-    Number(i64),
-    String(String),
-}
-
-static VIM_VARS: Lazy<Mutex<HashMap<i32, Value>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+static VIM_VARS: Lazy<Mutex<HashMap<i32, TypVal>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 static WINDOWS: Lazy<Mutex<Vec<i32>>> = Lazy::new(|| Mutex::new(Vec::new()));
 
 /// Store a numeric Vim variable identified by `idx`.
 pub fn set_vim_var_nr(idx: i32, val: i64) {
     let mut vars = VIM_VARS.lock().unwrap();
-    vars.insert(idx, Value::Number(val));
+    vars.insert(idx, TypVal::Number(val));
 }
 
 /// Retrieve a previously stored numeric Vim variable.
 pub fn get_vim_var_nr(idx: i32) -> Option<i64> {
-    if let Some(Value::Number(n)) = VIM_VARS.lock().unwrap().get(&idx) {
-        Some(*n)
-    } else {
-        None
+    match VIM_VARS.lock().unwrap().get(&idx) {
+        Some(TypVal::Number(n)) => Some(*n),
+        _ => None,
     }
 }
 
 /// Store a string Vim variable identified by `idx`.
 pub fn set_vim_var_str(idx: i32, val: &str) {
     let mut vars = VIM_VARS.lock().unwrap();
-    vars.insert(idx, Value::String(val.to_string()));
+    vars.insert(idx, TypVal::String(val.to_string()));
+}
+
+/// Retrieve a previously stored string Vim variable.
+pub fn get_vim_var_str(idx: i32) -> Option<String> {
+    match VIM_VARS.lock().unwrap().get(&idx) {
+        Some(TypVal::String(s)) => Some(s.clone()),
+        _ => None,
+    }
 }
 
 /// Create a new window and return its id.  The first window gets id 1.
@@ -50,25 +51,4 @@ pub fn win_getid(winnr: i32) -> i32 {
         return *wins.first().unwrap_or(&0);
     }
     wins.get((winnr - 1) as usize).copied().unwrap_or(0)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn var_numbers_roundtrip() {
-        assert_eq!(get_vim_var_nr(1), None);
-        set_vim_var_nr(1, 42);
-        assert_eq!(get_vim_var_nr(1), Some(42));
-    }
-
-    #[test]
-    fn window_ids() {
-        let id1 = win_create();
-        let id2 = win_create();
-        assert_eq!(win_getid(0), id1);
-        assert_eq!(win_getid(2), id2);
-        assert_eq!(win_getid(3), 0);
-    }
 }

--- a/rust_evalvars/tests/vars.rs
+++ b/rust_evalvars/tests/vars.rs
@@ -1,0 +1,26 @@
+use rust_evalvars::{
+    get_vim_var_nr, get_vim_var_str, set_vim_var_nr, set_vim_var_str, win_create, win_getid,
+};
+
+#[test]
+fn var_numbers_roundtrip() {
+    assert_eq!(get_vim_var_nr(1), None);
+    set_vim_var_nr(1, 42);
+    assert_eq!(get_vim_var_nr(1), Some(42));
+}
+
+#[test]
+fn var_strings_roundtrip() {
+    assert_eq!(get_vim_var_str(1), None);
+    set_vim_var_str(1, "hello");
+    assert_eq!(get_vim_var_str(1), Some("hello".to_string()));
+}
+
+#[test]
+fn window_ids() {
+    let id1 = win_create();
+    let id2 = win_create();
+    assert_eq!(win_getid(0), id1);
+    assert_eq!(win_getid(2), id2);
+    assert_eq!(win_getid(3), 0);
+}

--- a/rust_evalwindow/src/lib.rs
+++ b/rust_evalwindow/src/lib.rs
@@ -1,4 +1,4 @@
-use rust_evalvars::{win_create, win_getid};
+use rust_evalvars::win_getid;
 
 /// Implementation of the `win_getid()` Vim function in pure Rust.
 ///
@@ -7,24 +7,4 @@ use rust_evalvars::{win_create, win_getid};
 pub fn f_win_getid(arg: Option<i64>) -> i64 {
     let winnr = arg.unwrap_or(0) as i32;
     win_getid(winnr) as i64
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn returns_window_id_for_number() {
-        win_create();
-        win_create();
-        let id = f_win_getid(Some(2));
-        assert_eq!(id, win_getid(2) as i64);
-    }
-
-    #[test]
-    fn defaults_to_current_window() {
-        win_create();
-        let id = f_win_getid(None);
-        assert_eq!(id, win_getid(0) as i64);
-    }
 }

--- a/rust_evalwindow/tests/win_getid.rs
+++ b/rust_evalwindow/tests/win_getid.rs
@@ -1,0 +1,17 @@
+use rust_evalvars::{win_create, win_getid};
+use rust_evalwindow::f_win_getid;
+
+#[test]
+fn returns_window_id_for_number() {
+    win_create();
+    win_create();
+    let id = f_win_getid(Some(2));
+    assert_eq!(id, win_getid(2) as i64);
+}
+
+#[test]
+fn defaults_to_current_window() {
+    win_create();
+    let id = f_win_getid(None);
+    assert_eq!(id, win_getid(0) as i64);
+}

--- a/rust_typval/src/lib.rs
+++ b/rust_typval/src/lib.rs
@@ -1,5 +1,7 @@
 use libc::{c_char, c_long, c_uchar};
+use std::ffi::{CStr, CString};
 
+#[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum vartype_T {
@@ -21,38 +23,82 @@ pub struct typval_T {
     pub vval: typval_vval,
 }
 
-/// Allocate a zeroed typval_T.
-#[no_mangle]
-pub unsafe extern "C" fn alloc_tv() -> *mut typval_T {
-    let tv: *mut typval_T = libc::calloc(1, std::mem::size_of::<typval_T>()) as *mut typval_T;
-    tv
+/// Safe Rust representation of a Vim typval.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TypVal {
+    Number(i64),
+    String(String),
 }
 
-/// Free a typval previously allocated with `alloc_tv`.
+impl From<&typval_T> for TypVal {
+    #[allow(clippy::unnecessary_cast)]
+    fn from(tv: &typval_T) -> Self {
+        unsafe {
+            match tv.v_type {
+                vartype_T::VAR_NUMBER => TypVal::Number(tv.vval.v_number as i64),
+                vartype_T::VAR_STRING => {
+                    let ptr = tv.vval.v_string;
+                    let s = if ptr.is_null() {
+                        String::new()
+                    } else {
+                        CStr::from_ptr(ptr as *const c_char)
+                            .to_string_lossy()
+                            .into_owned()
+                    };
+                    TypVal::String(s)
+                }
+                _ => TypVal::Number(0),
+            }
+        }
+    }
+}
+
+impl From<TypVal> for typval_T {
+    fn from(val: TypVal) -> Self {
+        match val {
+            TypVal::Number(n) => typval_T {
+                v_type: vartype_T::VAR_NUMBER,
+                v_lock: 0,
+                vval: typval_vval {
+                    v_number: n as c_long,
+                },
+            },
+            TypVal::String(s) => {
+                let c = CString::new(s).unwrap();
+                let ptr = c.into_raw() as *mut c_uchar;
+                typval_T {
+                    v_type: vartype_T::VAR_STRING,
+                    v_lock: 0,
+                    vval: typval_vval { v_string: ptr },
+                }
+            }
+        }
+    }
+}
+
+/// Allocate a zeroed `typval_T`.
+#[no_mangle]
+pub extern "C" fn alloc_tv() -> *mut typval_T {
+    Box::into_raw(Box::new(typval_T {
+        v_type: vartype_T::VAR_UNKNOWN,
+        v_lock: 0,
+        vval: typval_vval { v_number: 0 },
+    }))
+}
+
+/// Free a typval previously allocated with `alloc_tv` or converted from `TypVal`.
+///
+/// # Safety
+/// `tv` must point to a valid `typval_T` that was allocated by `alloc_tv` or
+/// created from a `TypVal`.  After calling this function the pointer must not
+/// be used again.
 #[no_mangle]
 pub unsafe extern "C" fn free_tv(tv: *mut typval_T) {
     if tv.is_null() {
         return;
     }
-    if (*tv).v_type == vartype_T::VAR_STRING {
-        libc::free((*tv).vval.v_string as *mut _);
+    if (*tv).v_type == vartype_T::VAR_STRING && !(*tv).vval.v_string.is_null() {
+        drop(CString::from_raw((*tv).vval.v_string as *mut c_char));
     }
-    libc::free(tv as *mut _);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ffi::CString;
-
-    #[test]
-    fn alloc_and_free_string_tv() {
-        unsafe {
-            let tv = alloc_tv();
-            (*tv).v_type = vartype_T::VAR_STRING;
-            let s = CString::new("hello").unwrap();
-            (*tv).vval.v_string = libc::strdup(s.as_ptr()) as *mut c_uchar;
-            free_tv(tv);
-        }
-    }
+    drop(Box::from_raw(tv));
 }

--- a/rust_typval/tests/typval.rs
+++ b/rust_typval/tests/typval.rs
@@ -1,0 +1,24 @@
+use rust_typval::{alloc_tv, free_tv, typval_T, vartype_T, TypVal};
+use std::ffi::CString;
+
+#[test]
+fn alloc_and_free_string_tv() {
+    unsafe {
+        let tv = alloc_tv();
+        (*tv).v_type = vartype_T::VAR_STRING;
+        let s = CString::new("hello").unwrap();
+        (*tv).vval.v_string = s.into_raw() as *mut u8;
+        free_tv(tv);
+    }
+}
+
+#[test]
+fn typval_enum_roundtrip() {
+    let val = TypVal::String("hello".to_string());
+    let raw = Box::into_raw(Box::new(typval_T::from(val.clone())));
+    unsafe {
+        let back = TypVal::from(&*raw);
+        assert_eq!(back, val);
+        free_tv(raw);
+    }
+}


### PR DESCRIPTION
## Summary
- redesign TypVal with safe Rust enum and ownership
- store Vim variables using TypVal and add string getter
- add buffer line lookup helper and integration tests
- move win_getid tests to integration suite

## Testing
- `cargo clippy -p rust_evalbuffer -p rust_evalvars -p rust_evalwindow -p rust_typval -- -D warnings`
- `cargo test -p rust_evalbuffer`
- `cargo test -p rust_evalvars`
- `cargo test -p rust_evalwindow`
- `cargo test -p rust_typval`


------
https://chatgpt.com/codex/tasks/task_e_68b91baa69448320bc034bef7c22b132