### PR TITLE
screen: add highlight info struct and tests

### DIFF
--- a/tests/color_theme.rs
+++ b/tests/color_theme.rs
@@ -1,0 +1,34 @@
+use rust_screen::{
+    rs_screen_draw_text, rs_screen_flush, rs_screen_free, rs_screen_highlight_info, rs_screen_new,
+    HighlightInfo,
+};
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int};
+use std::sync::Mutex;
+
+static DATA: Mutex<Vec<(c_int, Vec<u8>)>> = Mutex::new(Vec::new());
+
+extern "C" fn collect(row: c_int, _text: *const c_char, attr: *const u8, len: c_int) {
+    let slice = unsafe { std::slice::from_raw_parts(attr, len as usize) };
+    DATA.lock().unwrap().push((row, slice.to_vec()));
+}
+
+#[test]
+fn highlight_struct_applies_theme() {
+    DATA.lock().unwrap().clear();
+    let sb = rs_screen_new(5, 1);
+    let txt = CString::new("hello").unwrap();
+    rs_screen_draw_text(sb, 0, 0, txt.as_ptr(), 1);
+    let info = HighlightInfo {
+        row: 0,
+        col: 1,
+        len: 3,
+        attr: 9,
+    };
+    rs_screen_highlight_info(sb, &info);
+    rs_screen_flush(sb, Some(collect));
+    rs_screen_free(sb);
+    let data = DATA.lock().unwrap();
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0].1[1..4], vec![9, 9, 9]);
+}

--- a/tests/fold.rs
+++ b/tests/fold.rs
@@ -1,4 +1,7 @@
-use rust_fold::{rs_fold_state_new, rs_fold_state_free, rs_fold_add, rs_fold_update, rs_fold_find, rs_fold_render};
+use rust_fold::{
+    rs_fold_add, rs_fold_find, rs_fold_render, rs_fold_state_free, rs_fold_state_new,
+    rs_fold_update,
+};
 use std::os::raw::c_long;
 
 #[test]
@@ -14,5 +17,18 @@ fn regression_add_and_update() {
     assert_eq!(rs_fold_find(state, 2, &mut first, &mut last), 1);
     assert_eq!(first, 1);
     assert_eq!(last, 4);
+    unsafe { rs_fold_state_free(state) };
+}
+
+#[test]
+fn nested_fold_lookup() {
+    let state = rs_fold_state_new();
+    rs_fold_add(state, 1, 10, 0, 0);
+    rs_fold_add(state, 3, 4, 0, 0);
+    let mut first: c_long = 0;
+    let mut last: c_long = 0;
+    assert_eq!(rs_fold_find(state, 4, &mut first, &mut last), 1);
+    assert_eq!(first, 3);
+    assert_eq!(last, 6);
     unsafe { rs_fold_state_free(state) };
 }


### PR DESCRIPTION
## Summary
- add `HighlightInfo` struct and `rs_screen_highlight_info` FFI
- test color theme propagation via screen buffer
- cover nested fold lookup via integration test

## Testing
- `cargo clippy --workspace -- -D warnings` *(fails: rust_clipboard result-unit-err)*
- `cargo test --workspace` *(fails: rust_linematch E0277, E0502)*

------
https://chatgpt.com/codex/tasks/task_e_68b91baccf2c8320988f3e263f78c0dc