### PR TITLE
Reimplement core containers in Rust

### DIFF
--- a/rust_dict/Cargo.toml
+++ b/rust_dict/Cargo.toml
@@ -3,9 +3,6 @@ name = "rust_dict"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-libc = "0.2"
-
 [lib]
 name = "rust_dict"
 crate-type = ["staticlib", "rlib"]

--- a/rust_dict/src/lib.rs
+++ b/rust_dict/src/lib.rs
@@ -1,33 +1,83 @@
-use std::os::raw::c_void;
-use std::ptr;
+#![allow(clippy::missing_safety_doc)]
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_void};
 
 #[repr(C)]
 pub struct VimDict {
-    _private: *mut c_void,
+    entries: HashMap<String, *mut c_void>,
 }
 
 #[no_mangle]
 pub extern "C" fn rust_dict_new() -> *mut VimDict {
-    Box::into_raw(Box::new(VimDict { _private: ptr::null_mut() }))
+    Box::into_raw(Box::new(VimDict {
+        entries: HashMap::new(),
+    }))
 }
 
 #[no_mangle]
-pub extern "C" fn rust_dict_free(d: *mut VimDict) {
+pub unsafe extern "C" fn rust_dict_free(d: *mut VimDict) {
     if !d.is_null() {
-        unsafe {
-            drop(Box::from_raw(d));
-        }
+        drop(Box::from_raw(d));
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn alloc_and_free() {
-        let d = rust_dict_new();
-        assert!(!d.is_null());
-        rust_dict_free(d);
+unsafe fn to_key(key: *const c_char) -> Option<String> {
+    if key.is_null() {
+        None
+    } else {
+        CStr::from_ptr(key).to_str().ok().map(|s| s.to_owned())
     }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_dict_set(
+    d: *mut VimDict,
+    key: *const c_char,
+    value: *mut c_void,
+) -> c_int {
+    let dict = match d.as_mut() {
+        Some(d) => d,
+        None => return 0,
+    };
+    let key = match to_key(key) {
+        Some(k) => k,
+        None => return 0,
+    };
+    dict.entries.insert(key, value);
+    1
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_dict_get(d: *mut VimDict, key: *const c_char) -> *mut c_void {
+    let dict = match d.as_ref() {
+        Some(d) => d,
+        None => return std::ptr::null_mut(),
+    };
+    let key = match to_key(key) {
+        Some(k) => k,
+        None => return std::ptr::null_mut(),
+    };
+    dict.entries
+        .get(&key)
+        .copied()
+        .unwrap_or(std::ptr::null_mut())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_dict_remove(d: *mut VimDict, key: *const c_char) -> c_int {
+    let dict = match d.as_mut() {
+        Some(d) => d,
+        None => return 0,
+    };
+    let key = match to_key(key) {
+        Some(k) => k,
+        None => return 0,
+    };
+    dict.entries.remove(&key).is_some() as c_int
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rust_dict_len(d: *const VimDict) -> usize {
+    d.as_ref().map(|d| d.entries.len()).unwrap_or(0)
 }

--- a/rust_dict/tests/dict.rs
+++ b/rust_dict/tests/dict.rs
@@ -1,0 +1,19 @@
+use rust_dict::*;
+use std::ffi::CString;
+use std::os::raw::c_void;
+
+#[test]
+fn dict_basic_operations() {
+    unsafe {
+        let d = rust_dict_new();
+        assert_eq!(rust_dict_len(d), 0);
+        let key = CString::new("key").unwrap();
+        let val = 0xdeadbeef as *mut c_void;
+        assert_eq!(rust_dict_set(d, key.as_ptr(), val), 1);
+        assert_eq!(rust_dict_len(d), 1);
+        assert_eq!(rust_dict_get(d, key.as_ptr()), val);
+        assert_eq!(rust_dict_remove(d, key.as_ptr()), 1);
+        assert_eq!(rust_dict_len(d), 0);
+        rust_dict_free(d);
+    }
+}

--- a/rust_hashtab/src/lib.rs
+++ b/rust_hashtab/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_safety_doc)]
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
@@ -12,23 +13,23 @@ pub extern "C" fn rust_hashtab_new() -> *mut c_void {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_hashtab_free(tab: *mut c_void) {
+pub unsafe extern "C" fn rust_hashtab_free(tab: *mut c_void) {
     if tab.is_null() {
         return;
     }
-    // Reconstruct the Box to drop the table and free its memory.
-    unsafe { drop(Box::from_raw(tab as *mut Table)); }
+    drop(Box::from_raw(tab as *mut Table));
 }
 
 unsafe fn to_key(key: *const c_char) -> Option<String> {
     if key.is_null() {
-        return None;
+        None
+    } else {
+        CStr::from_ptr(key).to_str().ok().map(|s| s.to_owned())
     }
-    CStr::from_ptr(key).to_str().ok().map(|s| s.to_owned())
 }
 
 #[no_mangle]
-pub extern "C" fn rust_hashtab_set(
+pub unsafe extern "C" fn rust_hashtab_set(
     tab: *mut c_void,
     key: *const c_char,
     value: *mut c_void,
@@ -36,63 +37,46 @@ pub extern "C" fn rust_hashtab_set(
     if tab.is_null() {
         return 0;
     }
-    let key = match unsafe { to_key(key) } {
+    let key = match to_key(key) {
         Some(k) => k,
         None => return 0,
     };
-    let table = unsafe { &mut *(tab as *mut Table) };
+    let table = &mut *(tab as *mut Table);
     table.insert(key, value);
     1
 }
 
 #[no_mangle]
-pub extern "C" fn rust_hashtab_get(
-    tab: *mut c_void,
-    key: *const c_char,
-) -> *mut c_void {
+pub unsafe extern "C" fn rust_hashtab_get(tab: *mut c_void, key: *const c_char) -> *mut c_void {
     if tab.is_null() {
         return std::ptr::null_mut();
     }
-    let key = match unsafe { to_key(key) } {
+    let key = match to_key(key) {
         Some(k) => k,
         None => return std::ptr::null_mut(),
     };
-    let table = unsafe { &*(tab as *mut Table) };
+    let table = &*(tab as *mut Table);
     table.get(&key).copied().unwrap_or(std::ptr::null_mut())
 }
 
 #[no_mangle]
-pub extern "C" fn rust_hashtab_remove(
-    tab: *mut c_void,
-    key: *const c_char,
-) -> c_int {
+pub unsafe extern "C" fn rust_hashtab_remove(tab: *mut c_void, key: *const c_char) -> c_int {
     if tab.is_null() {
         return 0;
     }
-    let key = match unsafe { to_key(key) } {
+    let key = match to_key(key) {
         Some(k) => k,
         None => return 0,
     };
-    let table = unsafe { &mut *(tab as *mut Table) };
+    let table = &mut *(tab as *mut Table);
     table.remove(&key).is_some() as c_int
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ffi::CString;
-
-    #[test]
-    fn basic_operations() {
-        let tab = rust_hashtab_new();
-        let key = CString::new("alpha").unwrap();
-        let value = 0xdeadbeef as *mut c_void;
-
-        assert_eq!(rust_hashtab_get(tab, key.as_ptr()), std::ptr::null_mut());
-        assert_eq!(rust_hashtab_set(tab, key.as_ptr(), value), 1);
-        assert_eq!(rust_hashtab_get(tab, key.as_ptr()), value);
-        assert_eq!(rust_hashtab_remove(tab, key.as_ptr()), 1);
-        assert_eq!(rust_hashtab_get(tab, key.as_ptr()), std::ptr::null_mut());
-        rust_hashtab_free(tab);
+#[no_mangle]
+pub unsafe extern "C" fn rust_hashtab_len(tab: *mut c_void) -> usize {
+    if tab.is_null() {
+        return 0;
     }
+    let table = &*(tab as *mut Table);
+    table.len()
 }

--- a/rust_hashtab/tests/hashtab.rs
+++ b/rust_hashtab/tests/hashtab.rs
@@ -1,0 +1,20 @@
+use rust_hashtab::*;
+use std::ffi::CString;
+use std::os::raw::c_void;
+
+#[test]
+fn hashtab_basic_operations() {
+    unsafe {
+        let tab = rust_hashtab_new();
+        let key = CString::new("alpha").unwrap();
+        let value = 0xdeadbeef as *mut c_void;
+        assert_eq!(rust_hashtab_len(tab), 0);
+        assert_eq!(rust_hashtab_get(tab, key.as_ptr()), std::ptr::null_mut());
+        assert_eq!(rust_hashtab_set(tab, key.as_ptr(), value), 1);
+        assert_eq!(rust_hashtab_len(tab), 1);
+        assert_eq!(rust_hashtab_get(tab, key.as_ptr()), value);
+        assert_eq!(rust_hashtab_remove(tab, key.as_ptr()), 1);
+        assert_eq!(rust_hashtab_len(tab), 0);
+        rust_hashtab_free(tab);
+    }
+}

--- a/rust_list/Cargo.toml
+++ b/rust_list/Cargo.toml
@@ -3,9 +3,6 @@ name = "rust_list"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
-libc = "0.2"
-
 [lib]
 name = "rust_list"
 crate-type = ["staticlib", "rlib"]

--- a/rust_list/tests/list.rs
+++ b/rust_list/tests/list.rs
@@ -1,0 +1,17 @@
+use rust_list::*;
+use std::os::raw::c_void;
+
+#[test]
+fn list_basic_operations() {
+    unsafe {
+        let list = rust_list_new();
+        assert_eq!(rust_list_len(list), 0);
+        rust_list_append(list, 1 as *mut c_void);
+        rust_list_append(list, 2 as *mut c_void);
+        assert_eq!(rust_list_len(list), 2);
+        assert_eq!(rust_list_get(list, 0), 1 as *mut c_void);
+        assert_eq!(rust_list_remove(list, 0), 1 as *mut c_void);
+        assert_eq!(rust_list_len(list), 1);
+        rust_list_free(list);
+    }
+}

--- a/rust_strings/tests/strings.rs
+++ b/rust_strings/tests/strings.rs
@@ -1,0 +1,52 @@
+use libc::{c_char, c_int, c_uchar};
+use rust_strings::*;
+use std::ffi::{CStr, CString};
+
+#[test]
+fn test_skip_and_copy_option() {
+    unsafe {
+        let s = CString::new(",  test").unwrap();
+        let p = skip_to_option_part(s.as_ptr() as *mut c_uchar);
+        let res = CStr::from_ptr(p as *const c_char).to_str().unwrap();
+        assert_eq!(res, "test");
+
+        let opt = CString::new("part1, part2").unwrap();
+        let p = opt.as_ptr() as *mut c_uchar;
+        let mut buf = [0u8; 20];
+        let mut option_ptr = p;
+        let len = copy_option_part(
+            &mut option_ptr,
+            buf.as_mut_ptr(),
+            buf.len() as c_int,
+            CString::new(",").unwrap().as_ptr(),
+        );
+        assert_eq!(len, 5);
+        let part = CStr::from_ptr(buf.as_ptr() as *const c_char)
+            .to_str()
+            .unwrap();
+        assert_eq!(part, "part1");
+    }
+}
+
+#[test]
+fn test_vim_isspace() {
+    assert_eq!(vim_isspace(b' ' as c_int), 1);
+    assert_eq!(vim_isspace(9), 1);
+    assert_eq!(vim_isspace(b'a' as c_int), 0);
+}
+
+#[test]
+fn test_vim_strsave_and_strnsave() {
+    unsafe {
+        let s = CString::new("hello").unwrap();
+        let p = vim_strsave(s.as_ptr() as *const c_uchar);
+        let res = CStr::from_ptr(p as *const c_char).to_str().unwrap();
+        assert_eq!(res, "hello");
+        libc::free(p as *mut libc::c_void);
+
+        let p2 = vim_strnsave(s.as_ptr() as *const c_uchar, 3);
+        let res2 = CStr::from_ptr(p2 as *const c_char).to_str().unwrap();
+        assert_eq!(res2, "hel");
+        libc::free(p2 as *mut libc::c_void);
+    }
+}


### PR DESCRIPTION
## Summary
- Rewrite list and dict as owned Rust structs with FFI bindings
- Provide unsafe hash table API with length retrieval
- Add vim_strsave/vim_strnsave and move container tests into dedicated crates

## Testing
- `cargo clippy -p rust_list -p rust_dict -p rust_hashtab -p rust_strings -- -D warnings`
- `cargo test -p rust_list -p rust_dict -p rust_hashtab -p rust_strings`


------
https://chatgpt.com/codex/tasks/task_e_68b91bb08ff88320a43d75e7a41d4fa3