### PR TITLE
rust_memline: expose typed buffer API

### DIFF
--- a/src/rust_memline.h
+++ b/src/rust_memline.h
@@ -8,13 +8,15 @@
 extern "C" {
 #endif
 
-void *rs_ml_buffer_new(void);
-void rs_ml_buffer_free(void *buf);
-bool rs_ml_append(void *buf, size_t lnum, const char *line);
-bool rs_ml_delete(void *buf, size_t lnum);
-bool rs_ml_replace(void *buf, size_t lnum, const char *line);
-unsigned char *rs_ml_get_line(void *buf, size_t lnum, int for_change, size_t *out_len);
-size_t rs_ml_line_count(void *buf);
+typedef struct MemBuffer MemBuffer;
+
+MemBuffer *ml_buffer_new(void);
+void ml_buffer_free(MemBuffer *buf);
+bool ml_append(MemBuffer *buf, size_t lnum, const char *line);
+bool ml_delete(MemBuffer *buf, size_t lnum);
+bool ml_replace(MemBuffer *buf, size_t lnum, const char *line);
+unsigned char *ml_get_line(MemBuffer *buf, size_t lnum, int for_change, size_t *out_len);
+size_t ml_line_count(MemBuffer *buf);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- expose `MemBuffer` type and rename memline FFI functions to `ml_*`
- update C memline bridge to use typed `MemBuffer` functions

## Testing
- `cargo build -p rust_memline`
- `cargo test -p rust_memline`
- `cargo clippy -p rust_memline -- -D warnings` *(fails: not_unsafe_ptr_arg_deref and manual_c_str_literals)*

------
https://chatgpt.com/codex/tasks/task_e_68b91bbd668c8320bb28ff0b6200a237