### PR TITLE
rust_os_api: add platform constants

### DIFF
--- a/rust_os_api/src/lib.rs
+++ b/rust_os_api/src/lib.rs
@@ -1,6 +1,8 @@
 use crossterm::{cursor, terminal, ExecutableCommand};
 
-use std::io::{stdout, Write, Result};
+use std::io::{stdout, Result, Write};
+
+pub mod os;
 
 /// Move the cursor to the given position.
 pub fn move_cursor_to(x: u16, y: u16) -> Result<()> {

--- a/rust_os_api/src/os/haiku.rs
+++ b/rust_os_api/src/os/haiku.rs
@@ -1,0 +1,6 @@
+pub const USE_TERM_CONSOLE: bool = true;
+
+pub const USR_VIM_DIR: &str = "$BE_USER_SETTINGS/vim";
+
+pub const DFLT_RUNTIMEPATH: &str = "$BE_USER_SETTINGS/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,$BE_USER_SETTINGS/vim/after";
+pub const CLEAN_RUNTIMEPATH: &str = "$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after";

--- a/rust_os_api/src/os/mac.rs
+++ b/rust_os_api/src/os/mac.rs
@@ -1,0 +1,8 @@
+pub const DFLT_ERRORFILE: &str = "errors.err";
+pub const DFLT_RUNTIMEPATH: &str =
+    "~/.vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,~/.vim/after";
+
+pub const CASE_INSENSITIVE_FILENAME: bool = true;
+pub const SPACE_IN_FILENAME: bool = true;
+
+pub const CMDBUFFSIZE: usize = 1024;

--- a/rust_os_api/src/os/mod.rs
+++ b/rust_os_api/src/os/mod.rs
@@ -1,0 +1,19 @@
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use windows::*;
+
+#[cfg(target_os = "macos")]
+mod mac;
+#[cfg(target_os = "macos")]
+pub use mac::*;
+
+#[cfg(target_os = "haiku")]
+mod haiku;
+#[cfg(target_os = "haiku")]
+pub use haiku::*;
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "haiku"))))]
+mod unix;
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "haiku"))))]
+pub use unix::*;

--- a/rust_os_api/src/os/unix.rs
+++ b/rust_os_api/src/os/unix.rs
@@ -1,0 +1,5 @@
+pub const DFLT_ERRORFILE: &str = "errors.err";
+pub const DFLT_RUNTIMEPATH: &str =
+    "~/.vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,~/.vim/after";
+
+pub const CMDBUFFSIZE: usize = 1024;

--- a/rust_os_api/src/os/windows.rs
+++ b/rust_os_api/src/os/windows.rs
@@ -1,0 +1,9 @@
+pub const DFLT_ERRORFILE: &str = "errors.err";
+pub const DFLT_RUNTIMEPATH: &str =
+    "$HOME/vimfiles,$VIM/vimfiles,$VIMRUNTIME,$HOME/vimfiles/after,$VIM/vimfiles/after";
+pub const CLEAN_RUNTIMEPATH: &str = "$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after";
+
+pub const CASE_INSENSITIVE_FILENAME: bool = true;
+pub const SPACE_IN_FILENAME: bool = true;
+pub const BACKSLASH_IN_FILENAME: bool = true;
+pub const USE_CRNL: bool = true;


### PR DESCRIPTION
## Summary
- reimplement `os_*.h` macros as Rust constants
- expose per-OS modules with `cfg(target_os)`

## Testing
- `cargo fmt -p rust_os_api`
- `cargo clippy --workspace -- -D warnings` *(fails: result-unit-err in rust_clipboard)*
- `cargo clippy -p rust_os_api -- -D warnings`
- `cargo test --workspace` *(fails to compile rust_linematch)*
- `cargo test -p rust_os_api`


------
https://chatgpt.com/codex/tasks/task_e_68b92758e7c88320a84433716b061cf1