### PR TITLE
tui_vim: drop ratatui and crossterm deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,8 +3749,6 @@ dependencies = [
 name = "vim_tui"
 version = "0.1.0"
 dependencies = [
- "crossterm",
- "ratatui",
  "rust_editor",
 ]
 

--- a/tui_vim/Cargo.toml
+++ b/tui_vim/Cargo.toml
@@ -5,6 +5,4 @@ edition = "2021"
 
 [dependencies]
 rust_editor = { path = "../rust_editor" }
-ratatui = { version = "0.26", default-features = false, features = ["crossterm"] }
-crossterm = "0.27"
 


### PR DESCRIPTION
## Summary
- remove ratatui and crossterm from vim_tui

## Testing
- `cargo fmt -p vim_tui`
- `cargo check -p vim_tui`


------
https://chatgpt.com/codex/tasks/task_e_68b959b9a2548320a7a179a20e8e3080