### PR TITLE
tui_vim: document minimal entry point

### DIFF
--- a/tui_vim/README.md
+++ b/tui_vim/README.md
@@ -1,0 +1,12 @@
+# tui_vim
+
+`tui_vim` provides a minimal binary wrapper around the editor's TUI.
+
+The `main` function simply gathers command-line arguments and forwards them to
+`rust_editor::tui::run`, which launches the terminal user interface.
+
+Run it with:
+
+```
+cargo run -p vim_tui -- [args]
+```

--- a/tui_vim/src/main.rs
+++ b/tui_vim/src/main.rs
@@ -1,5 +1,8 @@
+// Minimal entry point for the TUI version of the editor.
+//
+// This binary just collects command-line arguments and forwards them to
+// `rust_editor::tui::run`, where the real work happens.
 fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     rust_editor::tui::run(&args)
 }
-


### PR DESCRIPTION
## Summary
- explain that tui_vim main just forwards arguments to `rust_editor::tui::run`
- add README for tui_vim describing its minimal CLI entry

## Testing
- `cargo fmt -p vim_tui`
- `cargo test -p vim_tui`
- `cargo clippy -p vim_tui -- -D warnings` *(fails: clippy warnings in rust_editor)*

------
https://chatgpt.com/codex/tasks/task_e_68b959c4d8b483208ee1ed28e795cdd2